### PR TITLE
[nrf noup] Add Zephyr module manifest in the CHIP root directory

### DIFF
--- a/config/nrfconnect/chip-module/zephyr/module.yml
+++ b/config/nrfconnect/chip-module/zephyr/module.yml
@@ -14,6 +14,8 @@
 #   limitations under the License.
 #
 
+name: connectedhomeip
+
 build:
     cmake: .
     kconfig: Kconfig

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2021 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+name: connectedhomeip
+
+build:
+    cmake: config/nrfconnect/chip-module
+    kconfig: config/nrfconnect/chip-module/Kconfig
+    depends:
+    - openthread


### PR DESCRIPTION
Add Zephyr module manifest in the CHIP root directory in order to automatically pull CHIP into a project when CHIP is one of the submodules specified in west manifest.