### PR TITLE
[nrf_noup]: Fix nrf_security includes for matter

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -99,10 +99,20 @@ if (CONFIG_POSIX_API)
 endif()
 
 if (CONFIG_NORDIC_SECURITY_BACKEND)
+  # This is a temphack to ensure that Matter works with nRF Security refactored code
+  if(CONFIG_NORDIC_SECURITY_PROMPTLESS)
+    zephyr_include_directories($<TARGET_PROPERTY:mbedtls_external,INTERFACE_INCLUDE_DIRECTORIES>)
+    zephyr_include_directories($<TARGET_PROPERTY:mbedcrypto_includes,INTERFACE_INCLUDE_DIRECTORIES>)
+    if(TARGET platform_cc3xx)
+      zephyr_include_directories($<TARGET_PROPERTY:platform_cc3xx,INTERFACE_INCLUDE_DIRECTORIES>)
+    endif()
+    list(APPEND CHIP_CFLAGS -DMBEDTLS_CONFIG_FILE=<nrf-config.h>)
+  else()
     # TODO: Remove when the missing dependency is fixed in nRF Connect SDK
     zephyr_include_directories(${ZEPHYR_BASE}/../nrfxlib/crypto/nrf_cc310_platform/include)
 
     list(APPEND CHIP_CFLAGS -DMBEDTLS_CONFIG_FILE=<nrf-config.h>)
+  endif()
 endif()
 
 zephyr_get_compile_flags(CHIP_CFLAGS_C C)


### PR DESCRIPTION
-IF CONFIG_NRF_SECURITY_BACKEND - Add includes from mbedtls_external

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>
