### PR TITLE
[nrf noup] Add a dependency on nrfxlib

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -10,4 +10,5 @@ build:
     cmake: config/nrfconnect/chip-module
     kconfig: config/nrfconnect/chip-module/Kconfig
     depends:
+    - nrfxlib
     - openthread


### PR DESCRIPTION
Matter module takes all compilatinon flags associated with
the zephyr_interface target and passes them to the external
GN-based project. For that reason we must ensure that the
Matter module is processed after other revelant modules
that modify the zephyr_interface target. nrfxlib is such
a module as it contains nrf_security which carries the
mbedtls configuration.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>
