### PR TITLE
[nrf toup] reduce command parameters length

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -47,30 +47,30 @@ list(APPEND CHIP_CFLAGS_CC)
 list(APPEND CHIP_LIBRARIES)
 
 # GN meta-build system arguments passed to the make_gn_args.py script
-list(APPEND CHIP_GN_ARGS)
+string(APPEND CHIP_GN_ARGS)
 
 # ==============================================================================
 # Helper macros
 # ==============================================================================
 
 macro(chip_gn_arg_import FILE)
-    list(APPEND CHIP_GN_ARGS --module "${FILE}")
+    string(APPEND CHIP_GN_ARGS "--module\n\"${FILE}\"\n")
 endmacro()
 
 macro(chip_gn_arg_string ARG STRING)
-    list(APPEND CHIP_GN_ARGS --arg-string "${ARG}" "${STRING}")
+    string(APPEND CHIP_GN_ARGS "--arg-string\n${ARG}\n${STRING}\n")
 endmacro()
 
 macro(chip_gn_arg_bool ARG BOOLEAN)
     if (${BOOLEAN})
-        list(APPEND CHIP_GN_ARGS --arg "${ARG}" "true")
+        string(APPEND CHIP_GN_ARGS "--arg\n${ARG}\ntrue\n")
     else()
-        list(APPEND CHIP_GN_ARGS --arg "${ARG}" "false")
+        string(APPEND CHIP_GN_ARGS "--arg\n${ARG}\nfalse\n")
     endif()
 endmacro()
 
 macro(chip_gn_arg_cflags ARG CFLAGS)
-    list(APPEND CHIP_GN_ARGS --arg-cflags "${ARG}" "${CFLAGS}")
+    string(APPEND CHIP_GN_ARGS "--arg-cflags\n${ARG}\n${CFLAGS}\n")
 endmacro()
 
 # ==============================================================================
@@ -235,6 +235,8 @@ elseif (BOARD STREQUAL "native_posix_64")
     chip_gn_arg_string("target_cpu" "x64")
 endif()
 
+file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/args.tmp" CONTENT ${CHIP_GN_ARGS})
+
 # ==============================================================================
 # Define 'chip-gn' target that builds CHIP library(ies) with GN build system
 # ==============================================================================
@@ -244,7 +246,7 @@ ExternalProject_Add(
     SOURCE_DIR              ${CHIP_ROOT}
     BINARY_DIR              ${CMAKE_CURRENT_BINARY_DIR}
     CONFIGURE_COMMAND       ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/make_gn_args.py
-                                ${CHIP_GN_ARGS} > ${CMAKE_CURRENT_BINARY_DIR}/args.gn &&
+                                @${CMAKE_CURRENT_BINARY_DIR}/args.tmp > ${CMAKE_CURRENT_BINARY_DIR}/args.gn &&
                             ${GN_EXECUTABLE}
                                 --root=${CHIP_ROOT}
                                 --root-target=${GN_ROOT_TARGET}

--- a/config/nrfconnect/chip-module/make_gn_args.py
+++ b/config/nrfconnect/chip-module/make_gn_args.py
@@ -53,7 +53,7 @@ def write_gn_args(args):
         sys.stdout.write('{} = filter_exclude(string_split("{}"), [{}])\n'.format(key, value, cflag_excludes))
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
     parser.add_argument('--module', action='store')
     parser.add_argument('--arg', action='append', nargs=2, default=[])
     parser.add_argument('--arg-string', action='append', nargs=2, default=[])


### PR DESCRIPTION
This commit fixes issue with maximum command length on Windows.

Signed-off-by: Lukasz Duda <lukasz.duda@nordicsemi.no>