### PR TITLE
[nrf toup] Close BLE connection in Android CHIPTool

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -26,6 +26,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
+import chip.devicecontroller.ChipDeviceController
 import chip.setuppayload.SetupPayloadParser.UnrecognizedQrCodeException
 import com.google.chip.chiptool.attestation.AttestationTestFragment
 import com.google.chip.chiptool.clusterclient.OnOffClientFragment
@@ -84,6 +85,8 @@ class CHIPToolActivity :
   }
 
   override fun onCommissioningComplete(code: Int) {
+    ChipClient.getDeviceController().close()
+
     if (code == 0) {
       showFragment(OnOffClientFragment.newInstance(), false)
     } else {

--- a/src/controller/java/src/chip/devicecontroller/AndroidChipStack.java
+++ b/src/controller/java/src/chip/devicecontroller/AndroidChipStack.java
@@ -239,12 +239,20 @@ public final class AndroidChipStack {
 
   public static void onNotifyChipConnectionClosed(int connId) {
     ChipDeviceController deviceController = AndroidChipStack.getInstance().getConnection(connId);
+    if (deviceController == null) {
+      return;
+    }
+
     deviceController.onNotifyChipConnectionClosed(connId);
   }
 
   public static boolean onSendCharacteristic(
       int connId, byte[] svcId, byte[] charId, byte[] characteristicData) {
     ChipDeviceController deviceController = AndroidChipStack.getInstance().getConnection(connId);
+    if (deviceController == null) {
+      return false;
+    }
+
     BluetoothGatt bluetoothGatt = deviceController.getBluetoothGatt();
     if (bluetoothGatt == null) {
       return false;
@@ -276,6 +284,10 @@ public final class AndroidChipStack {
 
   public static boolean onSubscribeCharacteristic(int connId, byte[] svcId, byte[] charId) {
     ChipDeviceController deviceController = AndroidChipStack.getInstance().getConnection(connId);
+    if (deviceController == null) {
+      return false;
+    }
+
     BluetoothGatt bluetoothGatt = deviceController.getBluetoothGatt();
     if (bluetoothGatt == null) {
       return false;
@@ -312,6 +324,10 @@ public final class AndroidChipStack {
 
   public static boolean onUnsubscribeCharacteristic(int connId, byte[] svcId, byte[] charId) {
     ChipDeviceController deviceController = AndroidChipStack.getInstance().getConnection(connId);
+    if (deviceController == null) {
+      return false;
+    }
+
     BluetoothGatt bluetoothGatt = deviceController.getBluetoothGatt();
     if (bluetoothGatt == null) {
       return false;
@@ -348,6 +364,9 @@ public final class AndroidChipStack {
 
   public static boolean onCloseConnection(int connId) {
     ChipDeviceController deviceController = AndroidChipStack.getInstance().getConnection(connId);
+    if (deviceController == null) {
+      return false;
+    }
     deviceController.onCloseBleComplete(connId);
     return true;
   }


### PR DESCRIPTION
After commissioning is done, the Bluetooth LE connection
can be closed, so that subsequent devices can be paired
using the Android CHIPTool.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>