### PR TITLE
[nrf noup] Fix CI for sdk-connectedhomeip fork

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -30,7 +30,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-nrf-platform:latest
+            image: connectedhomeip/chip-build-nrf-platform:0.4.27
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
                 - "/tmp/output_binaries:/tmp/output_binaries"

--- a/config/nrfconnect/.nrfconnect-recommended-revision
+++ b/config/nrfconnect/.nrfconnect-recommended-revision
@@ -1,1 +1,1 @@
-910c9ce5ba8ea30155b50b9d12f03ece7123a0c2
+origin/master


### PR DESCRIPTION
* Verify build of nRF Connect examples against the current
  NCS master, instead of a specific revision supported by
  the upstream.
* Use a specific Docker image instead of "latest" so that
  sdk-connectedhomeip is not impacted by the changes made
  to the upstream.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>
