### PR TITLE
[nrf noup] add workflow for building CHIP tools

### DIFF
--- a/.github/workflows/release_tools.yaml
+++ b/.github/workflows/release_tools.yaml
@@ -1,0 +1,113 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release CHIP Tools
+
+on:
+    workflow_dispatch:
+        inputs:
+            commit:
+                description: "Release tag name or commit SHA:"
+                required: true
+            publishRelease:
+                description: "Publish release packages (if true, 'commit' must contain a release tag name):"
+                required: true
+                default: "false"
+
+jobs:
+    tools:
+        name: Build CHIP Tools
+        timeout-minutes: 60
+
+        runs-on: ubuntu-latest
+
+        env:
+            DEBIAN_FRONTEND: noninteractive
+            JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
+
+        container:
+            image: connectedhomeip/chip-build-android:0.4.33
+            volumes:
+                - "/tmp/log_output:/tmp/test_logs"
+                - "/tmp/output_binaries:/tmp/output_binaries"
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  ref: "${{ github.event.inputs.commit }}"
+                  submodules: true
+            - name: Bootstrap
+              timeout-minutes: 10
+              run: scripts/build/gn_bootstrap.sh
+            - name: Install Python CHIP Controller dependencies
+              timeout-minutes: 10
+              run: |
+                  echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $(lsb_release -sc) main restricted" > /etc/apt/sources.list.d/arm64.list
+                  echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $(lsb_release -sc)-updates main restricted" >> /etc/apt/sources.list.d/arm64.list
+                  apt update
+                  apt install -y --no-install-recommends g++-aarch64-linux-gnu libgirepository1.0-dev
+                  dpkg --add-architecture arm64
+                  apt install -y --no-install-recommends libavahi-client-dev:arm64 libglib2.0-dev:arm64 libssl-dev:arm64
+            - name: Build x64 Python CHIP Controller
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh "gn gen out/python_x64 --args='chip_mdns=\"platform\"'"
+                  scripts/run_in_build_env.sh "ninja -C out/python_x64 python"
+                  cp out/python_x64/controller/python/chip-*.whl /tmp/output_binaries/
+            - name: Build arm64 Python CHIP Controller
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh "gn gen out/python_arm64 --args='chip_mdns=\"platform\"
+                      custom_toolchain=\"//build/toolchain/custom\"
+                      target_cc=\"aarch64-linux-gnu-gcc\"
+                      target_cxx=\"aarch64-linux-gnu-g++\"
+                      target_ar=\"aarch64-linux-gnu-ar\"
+                      target_cpu=\"arm64\"'"
+                  scripts/run_in_build_env.sh "ninja -C out/python_arm64 python"
+                  cp out/python_arm64/controller/python/chip-*.whl /tmp/output_binaries/
+            - name: Build arm CHIPTool
+              timeout-minutes: 10
+              env:
+                TARGET_CPU: arm
+              run: |
+                  scripts/examples/android_app.sh
+                  yes | "$ANDROID_HOME/tools/bin/sdkmanager" --licenses
+                  cd src/android/CHIPTool
+                  ./gradlew build
+                  cp app/build/outputs/apk/debug/app-debug.apk /tmp/output_binaries/chip-tool-android_armv7l.apk
+            - name: Build arm64 CHIPTool
+              timeout-minutes: 10
+              env:
+                TARGET_CPU: arm64
+              run: |
+                  scripts/examples/android_app.sh
+                  yes | "$ANDROID_HOME/tools/bin/sdkmanager" --licenses
+                  cd src/android/CHIPTool
+                  ./gradlew build
+                  cp app/build/outputs/apk/debug/app-debug.apk /tmp/output_binaries/chip-tool-android_aarch64.apk
+            - name: Upload artifacts
+              uses: actions/upload-artifact@v2
+              with:
+                  name: chip
+                  path: /tmp/output_binaries/*
+            - name: Upload release packages
+              uses: softprops/action-gh-release@v1
+              if: github.event.inputs.publishRelease == 'true'
+              with:
+                  files: /tmp/output_binaries/*
+                  fail_on_unmatched_files: true
+                  tag_name: "${{ github.event.inputs.commit }}"
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a manually triggered workflow for building Android
CHIPTool packages for arm and arm64 architectures, and
Python CHIP Controller for Linux x64 and arm64.
The packages are uploaded both as github artifacts and
release packages (as the latter require a release tag).
