### PR TITLE
[nrf noup] Added to release workflow chip controller release build

### DIFF
--- a/.github/workflows/release_tools.yaml
+++ b/.github/workflows/release_tools.yaml
@@ -60,23 +60,45 @@ jobs:
                   apt install -y --no-install-recommends g++-aarch64-linux-gnu libgirepository1.0-dev
                   dpkg --add-architecture arm64
                   apt install -y --no-install-recommends libavahi-client-dev:arm64 libglib2.0-dev:arm64 libssl-dev:arm64
-            - name: Build x64 Python CHIP Controller
+            - name: Build x64 Python CHIP Controller with debug logs enabled
               timeout-minutes: 10
               run: |
-                  scripts/run_in_build_env.sh "gn gen out/python_x64 --args='chip_mdns=\"platform\"'"
-                  scripts/run_in_build_env.sh "ninja -C out/python_x64 python"
-                  cp out/python_x64/controller/python/chip-*.whl /tmp/output_binaries/
-            - name: Build arm64 Python CHIP Controller
+                  scripts/run_in_build_env.sh "gn gen out/python_x64_debug --args='chip_mdns=\"platform\"'"
+                  scripts/run_in_build_env.sh "ninja -C out/python_x64_debug python"
+                  mv out/python_x64_debug/controller/python/chip-*.whl out/python_x64_debug/controller/python/chip-controller-x86_64-debug.whl
+                  cp out/python_x64_debug/controller/python/chip-controller-x86_64-debug.whl /tmp/output_binaries/
+            - name: Build x64 Python CHIP Controller with debug logs disabled
               timeout-minutes: 10
               run: |
-                  scripts/run_in_build_env.sh "gn gen out/python_arm64 --args='chip_mdns=\"platform\"
+                  scripts/run_in_build_env.sh "gn gen out/python_x64_release --args='chip_mdns=\"platform\" chip_detail_logging=false'"
+                  scripts/run_in_build_env.sh "ninja -C out/python_x64_release python"
+                  mv out/python_x64_release/controller/python/chip-*.whl out/python_x64_release/controller/python/chip-controller-x86_64-release.whl
+                  cp out/python_x64_release/controller/python/chip-controller-x86_64-release.whl /tmp/output_binaries/
+            - name: Build arm64 Python CHIP Controller with debug logs enabled
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh "gn gen out/python_arm64_debug --args='chip_mdns=\"platform\"
                       custom_toolchain=\"//build/toolchain/custom\"
                       target_cc=\"aarch64-linux-gnu-gcc\"
                       target_cxx=\"aarch64-linux-gnu-g++\"
                       target_ar=\"aarch64-linux-gnu-ar\"
                       target_cpu=\"arm64\"'"
-                  scripts/run_in_build_env.sh "ninja -C out/python_arm64 python"
-                  cp out/python_arm64/controller/python/chip-*.whl /tmp/output_binaries/
+                  scripts/run_in_build_env.sh "ninja -C out/python_arm64_debug python"
+                  mv out/python_arm64_debug/controller/python/chip-*.whl out/python_arm64_debug/controller/python/chip-controller-aarch64-debug.whl
+                  cp out/python_arm64_debug/controller/python/chip-controller-aarch64-debug.whl /tmp/output_binaries/
+            - name: Build arm64 Python CHIP Controller with debug logs disabled
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh "gn gen out/python_arm64_release --args='chip_mdns=\"platform\"
+                      chip_detail_logging=false
+                      custom_toolchain=\"//build/toolchain/custom\"
+                      target_cc=\"aarch64-linux-gnu-gcc\"
+                      target_cxx=\"aarch64-linux-gnu-g++\"
+                      target_ar=\"aarch64-linux-gnu-ar\"
+                      target_cpu=\"arm64\"'"
+                  scripts/run_in_build_env.sh "ninja -C out/python_arm64_release python"
+                  mv out/python_arm64_release/controller/python/chip-*.whl out/python_arm64_release/controller/python/chip-controller-aarch64-release.whl
+                  cp out/python_arm64_release/controller/python/chip-controller-aarch64-release.whl /tmp/output_binaries/
             - name: Build arm CHIPTool
               timeout-minutes: 10
               env:


### PR DESCRIPTION
Added configuration that builds Python CHIP controller with
detail logs disabled in order to reduce number of output logs
and make writing commands easier.