### PR TITLE
[nrf fromlist] Close BLE connection after commissioning.

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -86,6 +86,7 @@ class CHIPToolActivity :
   }
 
   override fun onCommissioningComplete(code: Int) {
+    ChipClient.getDeviceController(this).close()
     if (code == 0) {
       showFragment(OnOffClientFragment.newInstance(), false)
     } else {


### PR DESCRIPTION
This PR ensures that the BLE connection is closed after PASE session.

Signed-off-by: Lukasz Duda <lukasz.duda@nordicsemi.no>