### PR TITLE
[nrf noup] SafePointerCast.h: match upstream version

### DIFF
--- a/src/lib/support/SafePointerCast.h
+++ b/src/lib/support/SafePointerCast.h
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2020 Project CHIP Authors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
#### Problem

This file has a 2020 copyright upstream, but commit
00ac05f5fd880aad6acf332b198353696b9ddf9e
("[nrf fromup] Fix unaligned access or ARM") pulls it in with a
different date.

Reconcile the difference before taking a snapshot of the repository
for history rewrite.

This allows us to rebase cleanly.

#### Change overview

Change to a comment.

#### Testing

No testing is required because comments are semantically irrelevant.