### PR TITLE
[nrf noup] Fix issue with spawning multiple DNS-SD queries

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Toast
@@ -42,15 +43,11 @@ class SensorClientFragment : Fragment() {
       savedInstanceState: Bundle?
   ): View {
     return inflater.inflate(R.layout.sensor_client_fragment, container, false).apply {
-      deviceIdEd.addTextChangedListener(object : TextWatcher {
-        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
-          if (s.isNullOrEmpty())
-            return
-          updateAddress(s.toString())
-        }
-        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) = Unit
-        override fun afterTextChanged(s: Editable?) = Unit
-      })
+      deviceIdEd.setOnEditorActionListener { textView, actionId, event ->
+        if (actionId == EditorInfo.IME_ACTION_DONE)
+          updateAddress(textView.text.toString())
+        actionId == EditorInfo.IME_ACTION_DONE
+      }
       clusterNameSpinner.adapter = makeClusterNamesAdapter()
       clusterNameSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
         override fun onNothingSelected(parent: AdapterView<*>?) = Unit


### PR DESCRIPTION
In some Android SDK versions spawning a DNS-SD query when a previous one is still in progress results in an error.
Change the device address update condition so that two identical queries are not sent on entering the sensor
clusters screen, not to generate a failure.