### PR TITLE
[nrf fromlist] Added argument allowing to bypass caching DNS-SD.

### DIFF
--- a/examples/chip-tool/commands/discover/Commands.h
+++ b/examples/chip-tool/commands/discover/Commands.h
@@ -36,7 +36,7 @@ public:
         chip::Dnssd::Resolver::Instance().SetResolverDelegate(this);
         ChipLogProgress(chipTool, "Dnssd: Searching for NodeId: %" PRIx64 " FabricId: %" PRIx64 " ...", remoteId, fabricId);
         return chip::Dnssd::Resolver::Instance().ResolveNodeId(chip::PeerId().SetNodeId(remoteId).SetCompressedFabricId(fabricId),
-                                                               chip::Inet::IPAddressType::kAny);
+                                                               chip::Inet::IPAddressType::kAny, true);
     }
 
     void OnNodeIdResolved(const chip::Dnssd::ResolvedNodeData & nodeData) override

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -51,7 +51,7 @@ CHIP_ERROR OperationalDeviceProxy::Connect(Callback::Callback<OnDeviceConnected>
         break;
 
     case State::NeedsAddress:
-        err = Dnssd::Resolver::Instance().ResolveNodeId(mPeerId, chip::Inet::IPAddressType::kAny);
+        err = Dnssd::Resolver::Instance().ResolveNodeId(mPeerId, chip::Inet::IPAddressType::kAny, false);
         EnqueueConnectionCallbacks(onConnection, onFailure);
         break;
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -295,7 +295,7 @@ CHIP_ERROR DeviceController::UpdateDevice(NodeId deviceId)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
     return Dnssd::Resolver::Instance().ResolveNodeId(PeerId().SetCompressedFabricId(GetCompressedFabricId()).SetNodeId(deviceId),
-                                                     chip::Inet::IPAddressType::kAny);
+                                                     chip::Inet::IPAddressType::kAny, true);
 #else
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DNSSD
@@ -1900,7 +1900,7 @@ void DeviceCommissioner::AdvanceCommissioningStage(CHIP_ERROR err)
         RendezvousCleanup(CHIP_NO_ERROR);
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD
         ChipLogProgress(Controller, "Finding node on operational network");
-        Dnssd::Resolver::Instance().ResolveNodeId(peerId, Inet::IPAddressType::kAny);
+        Dnssd::Resolver::Instance().ResolveNodeId(peerId, Inet::IPAddressType::kAny, false);
 #endif
     }
     break;

--- a/src/controller/python/chip/discovery/NodeResolution.cpp
+++ b/src/controller/python/chip/discovery/NodeResolution.cpp
@@ -100,7 +100,7 @@ extern "C" ChipError::StorageType pychip_discovery_resolve(uint64_t fabricId, ui
         Resolver::Instance().SetResolverDelegate(&gPythonResolverDelegate);
 
         result = Resolver::Instance().ResolveNodeId(chip::PeerId().SetCompressedFabricId(fabricId).SetNodeId(nodeId),
-                                                    chip::Inet::IPAddressType::kAny);
+                                                    chip::Inet::IPAddressType::kAny, false);
     });
 
     return result.AsInteger();

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -34,7 +34,10 @@ public:
     CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer) override { return InitStatus; }
     void Shutdown() override {}
     void SetResolverDelegate(ResolverDelegate *) override {}
-    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override { return ResolveNodeIdStatus; }
+    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, bool dnssdCacheBypass) override
+    {
+        return ResolveNodeIdStatus;
+    }
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return FindCommissionersStatus; }
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -454,17 +454,20 @@ CHIP_ERROR DiscoveryImplPlatform::FinalizeServiceUpdate()
     return ChipDnssdFinalizeServiceUpdate();
 }
 
-CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type)
+CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, bool dnssdCacheBypass)
 {
     ReturnErrorOnFailure(InitImpl());
 
 #if CHIP_CONFIG_MDNS_CACHE_SIZE > 0
-    /* see if the entry is cached and use it.... */
-    ResolvedNodeData nodeData;
-    if (sDnssdCache.Lookup(peerId, nodeData) == CHIP_NO_ERROR)
+    if (!dnssdCacheBypass)
     {
-        mResolverDelegate->OnNodeIdResolved(nodeData);
-        return CHIP_NO_ERROR;
+        /* see if the entry is cached and use it.... */
+        ResolvedNodeData nodeData;
+        if (sDnssdCache.Lookup(peerId, nodeData) == CHIP_NO_ERROR)
+        {
+            mResolverDelegate->OnNodeIdResolved(nodeData);
+            return CHIP_NO_ERROR;
+        }
     }
 #endif
 

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -49,7 +49,7 @@ public:
 
     // Members that implement Resolver interface.
     void SetResolverDelegate(ResolverDelegate * delegate) override { mResolverDelegate = delegate; }
-    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
+    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, bool dnssdCacheBypass) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
 

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -286,11 +286,14 @@ public:
     /**
      * Requests resolution of the given operational node service.
      *
+     * If `dnssdCacheBypass` is set it forces resolution of the given node and bypass option
+     * of using DNS-SD cache.
+     *
      * When the operation succeeds or fails, and a resolver delegate has been registered,
      * the result of the operation is passed to the delegate's `OnNodeIdResolved` or
      * `OnNodeIdResolutionFailed` method, respectively.
      */
-    virtual CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) = 0;
+    virtual CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, bool dnssdCacheBypass) = 0;
 
     /**
      * Finds all commissionable nodes matching the given filter.

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -344,7 +344,7 @@ public:
     CHIP_ERROR Init(chip::Inet::InetLayer * inetLayer) override;
     void Shutdown() override;
     void SetResolverDelegate(ResolverDelegate * delegate) override { mDelegate = delegate; }
-    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
+    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, bool dnssdCacheBypass) override;
     CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
 
@@ -499,7 +499,7 @@ CHIP_ERROR MinMdnsResolver::BrowseNodes(DiscoveryType type, DiscoveryFilter filt
     return SendQuery(qname, mdns::Minimal::QType::ANY);
 }
 
-CHIP_ERROR MinMdnsResolver::ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type)
+CHIP_ERROR MinMdnsResolver::ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, bool dnssdCacheBypass)
 {
     mDiscoveryType = DiscoveryType::kOperational;
     mActiveResolves.MarkPending(peerId);

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -30,7 +30,7 @@ public:
     void Shutdown() override {}
     void SetResolverDelegate(ResolverDelegate *) override {}
 
-    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override
+    CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type, bool dnssdCacheBypass) override
     {
         ChipLogError(Discovery, "Failed to resolve node ID: dnssd resolving not available");
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -124,7 +124,7 @@ CHIP_ERROR ResolveHandler(int argc, char ** argv)
     peerId.SetCompressedFabricId(strtoull(argv[0], NULL, 10));
     peerId.SetNodeId(strtoull(argv[1], NULL, 10));
 
-    return Dnssd::Resolver::Instance().ResolveNodeId(peerId, Inet::IPAddressType::kAny);
+    return Dnssd::Resolver::Instance().ResolveNodeId(peerId, Inet::IPAddressType::kAny, true);
 }
 
 bool ParseSubType(int argc, char ** argv, Dnssd::DiscoveryFilter & filter)


### PR DESCRIPTION
DNS-SD records are cached, so in case of device IP address change
and trying to resolve address again the cached value is used
instead of the new one.

Added argument that allows to bypass reading DNS-SD services data
from cache.
