### PR TITLE
Fix issues with Android CHIPTool

### DIFF
--- a/.github/workflows/release_tools.yaml
+++ b/.github/workflows/release_tools.yaml
@@ -108,8 +108,9 @@ jobs:
               env:
                 TARGET_CPU: arm64
               run: |
+                  git clean -fdx src/android/CHIPTool
                   scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target android-arm64-chip-tool build"
-                  cp out/android-arm64-chip-tool/outputs/apk/debug/app-debug.apk /tmp/output_binaries/chip-tool-android_armv7l.apk
+                  cp out/android-arm64-chip-tool/outputs/apk/debug/app-debug.apk /tmp/output_binaries/chip-tool-android_aarch64.apk
             - name: Upload artifacts
               uses: actions/upload-artifact@v2
               with:

--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -176,8 +176,10 @@ void PairingCommand::OnOpenCommissioningWindowResponse(void * context, NodeId re
 
 CHIP_ERROR PairingCommand::OpenCommissioningWindow()
 {
-    return mController.OpenCommissioningWindowWithCallback(mNodeId, mTimeout, mIteration, mDiscriminator,
-                                                           mCommissioningWindowOption, &mOnOpenCommissioningWindowCallback);
+    SetupPayload payload;
+    payload.discriminator = mDiscriminator;
+    return mController.OpenCommissioningWindowWithCallback(mNodeId, mTimeout, mIteration, payload, mCommissioningWindowOption,
+                                                           &mOnOpenCommissioningWindowCallback);
 }
 
 void PairingCommand::OnStatusUpdate(DevicePairingDelegate::Status status)

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/SensorClientFragment.kt
@@ -19,19 +19,16 @@ import com.jjoe64.graphview.LabelFormatter
 import com.jjoe64.graphview.Viewport
 import com.jjoe64.graphview.series.DataPoint
 import com.jjoe64.graphview.series.LineGraphSeries
+import kotlinx.android.synthetic.main.sensor_client_fragment.*
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
-import kotlinx.android.synthetic.main.sensor_client_fragment.clusterNameSpinner
-import kotlinx.android.synthetic.main.sensor_client_fragment.deviceIdEd
-import kotlinx.android.synthetic.main.sensor_client_fragment.endpointIdEd
-import kotlinx.android.synthetic.main.sensor_client_fragment.lastValueTv
-import kotlinx.android.synthetic.main.sensor_client_fragment.sensorGraph
 import kotlinx.android.synthetic.main.sensor_client_fragment.view.clusterNameSpinner
-import kotlinx.android.synthetic.main.sensor_client_fragment.view.readSensorBtn
+import kotlinx.android.synthetic.main.sensor_client_fragment.view.deviceIdEd
+import kotlinx.android.synthetic.main.sensor_client_fragment.view.endpointIdEd
 import kotlinx.android.synthetic.main.sensor_client_fragment.view.sensorGraph
+import kotlinx.android.synthetic.main.sensor_client_fragment.view.readSensorBtn
 import kotlinx.android.synthetic.main.sensor_client_fragment.view.watchSensorBtn
-import kotlinx.android.synthetic.main.sensor_client_fragment.watchSensorBtn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -467,7 +467,7 @@ CHIP_ERROR DeviceController::ComputePASEVerifier(uint32_t iterations, uint32_t s
 }
 
 CHIP_ERROR DeviceController::OpenCommissioningWindowWithCallback(NodeId deviceId, uint16_t timeout, uint16_t iteration,
-                                                                 uint16_t discriminator, uint8_t option,
+                                                                 SetupPayload & payload, uint8_t option,
                                                                  Callback::Callback<OnOpenCommissioningWindow> * callback)
 {
     ChipLogProgress(Controller, "OpenCommissioningWindow for device ID %" PRIu64, deviceId);
@@ -478,11 +478,8 @@ CHIP_ERROR DeviceController::OpenCommissioningWindowWithCallback(NodeId deviceId
 
     std::string QRCode;
     std::string manualPairingCode;
-    SetupPayload payload;
     CommissioningWindowOption commissioningWindowOption;
     ByteSpan salt(reinterpret_cast<const uint8_t *>(kSpake2pKeyExchangeSalt), strlen(kSpake2pKeyExchangeSalt));
-
-    payload.discriminator = discriminator;
 
     switch (option)
     {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -298,7 +298,8 @@ public:
     CHIP_ERROR OpenCommissioningWindow(NodeId deviceId, uint16_t timeout, uint16_t iteration, uint16_t discriminator,
                                        uint8_t option, SetupPayload & payload)
     {
-        return OpenCommissioningWindowWithCallback(deviceId, timeout, iteration, discriminator, option, nullptr);
+        payload.discriminator = discriminator;
+        return OpenCommissioningWindowWithCallback(deviceId, timeout, iteration, payload, option, nullptr);
     }
 
     /**
@@ -318,7 +319,7 @@ public:
      *
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
-    CHIP_ERROR OpenCommissioningWindowWithCallback(NodeId deviceId, uint16_t timeout, uint16_t iteration, uint16_t discriminator,
+    CHIP_ERROR OpenCommissioningWindowWithCallback(NodeId deviceId, uint16_t timeout, uint16_t iteration, SetupPayload & payload,
                                                    uint8_t option, Callback::Callback<OnOpenCommissioningWindow> * callback);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_DNSSD

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -424,7 +424,7 @@ JNI_METHOD(jboolean, openPairingWindowWithPIN)
     }
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err = wrapper->Controller()->OpenCommissioningWindow(chipDevice->GetDeviceId(), duration, 1000, discriminator, 1, setupPayload);
+    err = wrapper->Controller()->OpenCommissioningWindow(chipDevice->GetDeviceId(), duration, 1000, discriminator, 2, setupPayload);
 
     if (err != CHIP_NO_ERROR)
     {


### PR DESCRIPTION
* The app crashes on entering the sensor cluster screen.
* The app incorrectly invokes the admin ECM command.
* The release_tools.yml workflow generates too big packages.
