### PR TITLE
Alignment to the new NFC library version

### DIFF
--- a/src/platform/Zephyr/NFCManagerImpl.cpp
+++ b/src/platform/Zephyr/NFCManagerImpl.cpp
@@ -31,7 +31,7 @@
 namespace chip {
 namespace DeviceLayer {
 namespace {
-void nfcCallback(void * /* context */, nfc_t2t_event, const uint8_t * /* data */, size_t /* data_length */) {}
+void nfcCallback(void * /* context */, nfc_t2t_event_t, const uint8_t * /* data */, size_t /* data_length */) {}
 } // namespace
 
 NFCManagerImpl NFCManagerImpl::sInstance;


### PR DESCRIPTION
The new version of the NFC library has a slightly
changed api. This commit alignes to use the new API.

#### Problem
* Fixes building of the Matter samples

#### Change overview
Alignment to the new NFC API

#### Testing
Testing isn't required because the functionality of the NFC library hasn't be changed
