### PR TITLE
[nrf fromlist][commissioner] Drop BLE connection before CASE

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -102,7 +102,7 @@ void ExchangeContext::UpdateSEDPollingMode()
     }
 
     VerifyOrReturn(address.GetTransportType() != Transport::Type::kBle);
-    UpdateSEDPollingMode(IsResponseExpected() || IsSendExpected() || IsMessageNotAcked() || IsAckPending());
+    UpdateSEDPollingMode(IsResponseExpected() || IsSendExpected() || IsMessageNotAcked());
 }
 
 void ExchangeContext::UpdateSEDPollingMode(bool fastPollingMode)

--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -767,7 +767,7 @@ bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQU
 
 void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId)
 {
-    // Intentionally empty.
+    CloseConnection(conId);
 }
 
 bool BLEManagerImpl::IsSubscribed(bt_conn * conn)


### PR DESCRIPTION
The commissioner starts operational node discovery and CASE
with the commissionee without dropping the BLE connection
and it's the reposibility of the commissionee to drop the
BLE connection upon reception of Sigma 1.

Exchanging quite big Sigma messages while still maintaining
the BLE connection may cause frame drops on a Thread Sleepy
End Device depending on the device BLE configuration.

Drop the BLE connection on the commissioner side as soon as
it's no longer needed.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>

#### Problem
What is being fixed?  Examples:
* Fix crash on startup
* Fixes #12345 Frobnozzle is leaky (exactly like that, so GitHub will auto-close the issue).

#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
