### PR TITLE
[nrf noup] update the Zephyr include path.

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 if (CONFIG_POSIX_API)
     list(APPEND CHIP_CFLAGS
         -D_SYS__PTHREADTYPES_H_
-        -isystem${ZEPHYR_BASE}/include/posix
+        -isystem${ZEPHYR_BASE}/include/zephyr/posix
     )
 endif()
 


### PR DESCRIPTION
Recently the Zephyr include path was changed from
${ZEPHYR_BASE}/include/posix/ to ${ZEPHYR_BASE}/include/zephyr/posix.
We need to align this in Matter SDK to avoid build errors.