### PR TITLE
matter: Update default for matter to enable nrf_oberon

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -202,9 +202,9 @@ choice OPENTHREAD_SECURITY
 	default OPENTHREAD_NRF_SECURITY_CHOICE
 endchoice
 
-config CC3XX_BACKEND
-    bool
-    default n
+config PSA_CRYPTO_DRIVER_CC3XX
+	bool
+	default n
 
 config OBERON_BACKEND
     bool

--- a/src/platform/nrfconnect/CHIPPlatformConfig.h
+++ b/src/platform/nrfconnect/CHIPPlatformConfig.h
@@ -37,7 +37,7 @@
 // Size of the statically allocated context for SHA256 operations in CryptoPAL
 // determined empirically.
 #ifdef CONFIG_CC3XX_BACKEND
-#define CHIP_CONFIG_SHA256_CONTEXT_SIZE 240
+#define CHIP_CONFIG_SHA256_CONTEXT_SIZE 244
 #else
 #define CHIP_CONFIG_SHA256_CONTEXT_SIZE 208
 #endif


### PR DESCRIPTION
-Fix hash size issue (grew from 240 to 244 bytes)
-Changing default to disable PSA Crypto driver for nrf_cc3xx
 as it is not in use yet
-Removed CC3XX_BACKEND configuration from defaults

ref: NCSDK-13857

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>