### PR TITLE
[nrf noup] Bump release_tools workflow Docker image

### DIFF
--- a/.github/workflows/release_tools.yaml
+++ b/.github/workflows/release_tools.yaml
@@ -37,7 +37,7 @@ jobs:
             JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
 
         container:
-            image: connectedhomeip/chip-build-android:0.5.58
+            image: connectedhomeip/chip-build-android:0.5.73
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
                 - "/tmp/output_binaries:/tmp/output_binaries"
@@ -47,11 +47,12 @@ jobs:
               uses: actions/checkout@v2
               with:
                   ref: "${{ github.event.inputs.commit }}"
-                  submodules: true
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform android linux
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
-            - name: Install Python CHIP Tool dependencies
+            - name: Install CHIP Tool dependencies
               timeout-minutes: 10
               run: |
                   echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports $(lsb_release -sc) main restricted" > /etc/apt/sources.list.d/arm64.list
@@ -59,7 +60,7 @@ jobs:
                   apt update
                   apt install -y --no-install-recommends -o APT::Immediate-Configure=false g++-aarch64-linux-gnu libgirepository1.0-dev
                   dpkg --add-architecture arm64
-                  apt install -y --no-install-recommends -o APT::Immediate-Configure=false libavahi-client-dev:arm64 libglib2.0-dev:arm64 libssl-dev:arm64
+                  apt install -y --no-install-recommends -o APT::Immediate-Configure=false libavahi-client-dev:arm64 libglib2.0-dev:arm64 libssl-dev:arm64 libreadline-dev:arm64
             - name: Build x64 CHIP Tool with debug logs enabled
               timeout-minutes: 10
               run: |


### PR DESCRIPTION
Too old Docker image was used for release_tools workflow and chip-tool build would fail because of that.