### PR TITLE
Fix Android crash and extend release_tools workflow

### DIFF
--- a/.github/workflows/release_tools.yaml
+++ b/.github/workflows/release_tools.yaml
@@ -64,13 +64,13 @@ jobs:
             - name: Build x64 CHIP Tool with debug logs enabled
               timeout-minutes: 10
               run: |
-                  scripts/run_in_build_env.sh "gn gen out/chiptool_x64_debug --args='chip_mdns=\"platform\"'"
+                  scripts/run_in_build_env.sh "gn gen out/chiptool_x64_debug --args='chip_mdns=\"platform\" symbol_level=0'"
                   scripts/run_in_build_env.sh "ninja -C out/chiptool_x64_debug chip-tool"
                   mv out/chiptool_x64_debug/chip-tool out/chiptool_x64_debug/chip-tool-debug
             - name: Build x64 CHIP Tool with debug logs disabled
               timeout-minutes: 10
               run: |
-                  scripts/run_in_build_env.sh "gn gen out/chiptool_x64_release --args='chip_mdns=\"platform\" chip_detail_logging=false'"
+                  scripts/run_in_build_env.sh "gn gen out/chiptool_x64_release --args='chip_mdns=\"platform\" chip_detail_logging=false symbol_level=0'"
                   scripts/run_in_build_env.sh "ninja -C out/chiptool_x64_release chip-tool"
                   mv out/chiptool_x64_release/chip-tool out/chiptool_x64_release/chip-tool-release
             - name: Build arm64 CHIP Tool with debug logs enabled
@@ -81,7 +81,8 @@ jobs:
                       target_cc=\"aarch64-linux-gnu-gcc\"
                       target_cxx=\"aarch64-linux-gnu-g++\"
                       target_ar=\"aarch64-linux-gnu-ar\"
-                      target_cpu=\"arm64\"'"
+                      target_cpu=\"arm64\"
+                      symbol_level=0'"
                   scripts/run_in_build_env.sh "ninja -C out/chiptool_arm64_debug chip-tool"
                   mv out/chiptool_arm64_debug/chip-tool out/chiptool_arm64_debug/chip-tool-debug
             - name: Build arm64 CHIP Tool with debug logs disabled
@@ -93,9 +94,16 @@ jobs:
                       target_cc=\"aarch64-linux-gnu-gcc\"
                       target_cxx=\"aarch64-linux-gnu-g++\"
                       target_ar=\"aarch64-linux-gnu-ar\"
-                      target_cpu=\"arm64\"'"
+                      target_cpu=\"arm64\"
+                      symbol_level=0'"
                   scripts/run_in_build_env.sh "ninja -C out/chiptool_arm64_release chip-tool"
                   mv out/chiptool_arm64_release/chip-tool out/chiptool_arm64_release/chip-tool-release
+            - name: Build x64 OTA Provider
+              timeout-minutes: 10
+              run: |
+                  scripts/run_in_build_env.sh "gn gen out/chipotaprovider_x64 --args='symbol_level=0' --root=examples/ota-provider-app/linux"
+                  scripts/run_in_build_env.sh "ninja -C out/chipotaprovider_x64 chip-ota-provider-app"
+                  mv out/chipotaprovider_x64/chip-ota-provider-app /tmp/output_binaries/chip-ota-provider-app-linux_x64
             - name: Create zip files for CHIP Tool debug and release packages
               timeout-minutes: 10
               run: |

--- a/scripts/idl/generators/java/ChipClustersCpp.jinja
+++ b/scripts/idl/generators/java/ChipClustersCpp.jinja
@@ -1,14 +1,16 @@
 {%- macro encode_optional(target, source, depth, encodable) -%}
-  if ({{source}} != nullptr) {
-    jobject optionalValue_{{depth}};
+  {
+    jobject optionalValue_{{depth}} = nullptr;
     chip::JniReferences::GetInstance().GetOptionalValue({{source}}, optionalValue_{{depth}});
-    auto & definedValue_{{depth}} = {{target}}.Emplace();
-    {{ encode_value(
-       "definedValue_{}".format(depth),
-       "optionalValue_{}".format(depth),
-       depth+1,
-       encodable.without_optional()
-    )}}
+    if (optionalValue_{{depth}}) {
+      auto & definedValue_{{depth}} = {{target}}.Emplace();
+      {{ encode_value(
+          "definedValue_{}".format(depth),
+          "optionalValue_{}".format(depth),
+          depth+1,
+          encodable.without_optional()
+      )}}
+    }
   }
 {%- endmacro %}
 

--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/clusterinteraction/ClusterDetailFragment.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/clusterinteraction/ClusterDetailFragment.kt
@@ -45,6 +45,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import java.util.*
+import kotlin.collections.HashMap
 
 /**
  * ClusterDetailFragment allows user to pick cluster, command, specify parameters and see
@@ -135,16 +137,16 @@ class ClusterDetailFragment : Fragment() {
       )
       parameterList.forEach {
         val parameterName = it.clusterParameterNameTv.text.toString()
-        val castType =
-          selectedInteractionInfo.commandParameters[parameterName]!!.type
-        val data = castStringToType(it.clusterParameterData.text.toString(), castType)!!
+        val parameterType = selectedInteractionInfo.commandParameters[parameterName]!!.type
+        val parameterUnderlyingType = selectedInteractionInfo.commandParameters[parameterName]!!.underlyingType
+        val data = castStringToType(it.clusterParameterData.text.toString(), parameterType, parameterUnderlyingType)!!
         commandArguments[it.clusterParameterNameTv.text.toString()] = data
         clusterInteractionHistoryList[0].parameterList.add(
-          HistoryParameterInfo(
-            parameterName,
-            data.toString(),
-            castType
-          )
+            HistoryParameterInfo(
+                parameterName,
+                data.toString(),
+                parameterUnderlyingType
+            )
         )
       }
       selectedInteractionInfo.getCommandFunction()
@@ -185,12 +187,13 @@ class ClusterDetailFragment : Fragment() {
     }
   }
 
-  private fun castStringToType(data: String, type: Class<*>): Any? {
+  private fun castStringToType(data: String, type: Class<*>, underlyingType: Class<*>): Any? {
     return when (type) {
       Int::class.java -> data.toInt()
       Boolean::class.java -> data.toBoolean()
       ByteArray::class.java -> data.encodeToByteArray()
       Long::class.java -> data.toLong()
+      Optional::class.java -> if (data.isEmpty()) Optional.empty() else Optional.of(castStringToType(data, underlyingType, underlyingType)!!)
       else -> data
     }
   }

--- a/src/android/CHIPTool/app/src/main/res/layout/select_action_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/select_action_fragment.xml
@@ -1,103 +1,109 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <Button
-        android:id="@+id/scanQrBtn"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/scan_qr_code_btn_text" />
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:orientation="vertical" android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <Button
-        android:id="@+id/provisionWiFiCredentialsBtn"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/provision_wifi_credentials_btn_text" />
+        <Button
+            android:id="@+id/scanQrBtn"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/scan_qr_code_btn_text" />
 
-    <Button
-        android:id="@+id/provisionThreadCredentialsBtn"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/provision_thread_credentials_btn_text" />
+        <Button
+            android:id="@+id/provisionWiFiCredentialsBtn"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/provision_wifi_credentials_btn_text" />
 
-    <Button
-        android:id="@+id/provisionCustomFlowBtn"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/provision_custom_flow_btn_text" />
+        <Button
+            android:id="@+id/provisionThreadCredentialsBtn"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/provision_thread_credentials_btn_text" />
 
-    <Button
-        android:id="@+id/onOffClusterBtn"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/on_off_level_btn_text" />
+        <Button
+            android:id="@+id/provisionCustomFlowBtn"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/provision_custom_flow_btn_text" />
 
-    <Button
-        android:id="@+id/sensorClustersBtn"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/sensor_client_btn_text" />
+        <Button
+            android:id="@+id/onOffClusterBtn"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/on_off_level_btn_text" />
 
-    <Button
-        android:id="@+id/multiAdminClusterBtn"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/multi_admin_client_btn_text" />
+        <Button
+            android:id="@+id/sensorClustersBtn"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/sensor_client_btn_text" />
 
-    <Button
-        android:id="@+id/opCredClustersBtn"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/op_cred_client_btn_text" />
+        <Button
+            android:id="@+id/multiAdminClusterBtn"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/multi_admin_client_btn_text" />
 
-    <Button
-        android:id="@+id/basicClusterBtn"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/basic_cluster_btn_text" />
+        <Button
+            android:id="@+id/opCredClustersBtn"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/op_cred_client_btn_text" />
 
-    <Button
-        android:id="@+id/attestationTestBtn"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:visibility="gone"
-        android:text="@string/attestation_test_btn_text" />
+        <Button
+            android:id="@+id/basicClusterBtn"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/basic_cluster_btn_text" />
 
-    <Button
-        android:id="@+id/wildcardBtn"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/wildcard_btn_text" />
+        <Button
+            android:id="@+id/attestationTestBtn"
+            android:layout_height="wrap_content"
+            android:layout_width="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:visibility="gone"
+            android:text="@string/attestation_test_btn_text" />
 
-    <Button
-        android:id="@+id/clusterInteractionBtn"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="@string/cluster_interaction_tool" />
+        <Button
+            android:id="@+id/wildcardBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/wildcard_btn_text" />
 
-</LinearLayout>
+        <Button
+            android:id="@+id/clusterInteractionBtn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:text="@string/cluster_interaction_tool" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/src/controller/java/src/chip/clusterinfo/CommandParameterInfo.java
+++ b/src/controller/java/src/chip/clusterinfo/CommandParameterInfo.java
@@ -4,11 +4,13 @@ package chip.clusterinfo;
 public class CommandParameterInfo {
   public CommandParameterInfo() {}
 
-  public CommandParameterInfo(String name, Class<?> type) {
+  public CommandParameterInfo(String name, Class<?> type, Class<?> underlyingType) {
     this.name = name;
     this.type = type;
+    this.underlyingType = underlyingType;
   }
 
   public String name;
   public Class<?> type;
+  public Class<?> underlyingType;
 }

--- a/src/controller/java/templates/ClusterInfo-java.zapt
+++ b/src/controller/java/templates/ClusterInfo-java.zapt
@@ -307,7 +307,7 @@ public class ClusterInfoMapping {
      {{#chip_cluster_command_arguments}}
      {{#if_is_struct type}}
      {{else}}
-       CommandParameterInfo {{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}{{asLowerCamelCase label}}CommandParameterInfo = new CommandParameterInfo("{{asLowerCamelCase label}}", {{asJavaType type null parent.parent.name removeGenericType=true}}.class);
+       CommandParameterInfo {{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}{{asLowerCamelCase label}}CommandParameterInfo = new CommandParameterInfo("{{asLowerCamelCase label}}", {{asJavaType type null parent.parent.name removeGenericType=true}}.class, {{asJavaType type null parent.parent.name underlyingType=true}}.class);
        {{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}CommandParams.put("{{asLowerCamelCase label}}",{{asLowerCamelCase ../../name}}{{asLowerCamelCase ../name}}{{asLowerCamelCase label}}CommandParameterInfo);
      {{#not_last}} {{/not_last}}
      {{/if_is_struct}}

--- a/src/controller/java/templates/ClusterInfo-write-interaction.zapt
+++ b/src/controller/java/templates/ClusterInfo-write-interaction.zapt
@@ -21,7 +21,7 @@ public class ClusterWriteMapping {
         {{#if isWritableAttribute}}
         {{#unless isArray}}
         Map<String, CommandParameterInfo> write{{asUpperCamelCase ../name}}{{asUpperCamelCase name}}CommandParams = new LinkedHashMap<String, CommandParameterInfo>();
-        CommandParameterInfo {{asLowerCamelCase ../name}}{{asLowerCamelCase name}}CommandParameterInfo = new CommandParameterInfo("value", {{asJavaType type null parent.parent.name removeGenericType=true}}.class);
+        CommandParameterInfo {{asLowerCamelCase ../name}}{{asLowerCamelCase name}}CommandParameterInfo = new CommandParameterInfo("value", {{asJavaType type null parent.parent.name removeGenericType=true}}.class, {{asJavaType type null parent.parent.name underlyingType=true}}.class);
         write{{asUpperCamelCase ../name}}{{asUpperCamelCase name}}CommandParams.put("value",{{asLowerCamelCase ../name}}{{asLowerCamelCase name}}CommandParameterInfo);
         InteractionInfo write{{asUpperCamelCase ../name}}{{asUpperCamelCase name}}AttributeInteractionInfo = new InteractionInfo(
           (cluster, callback, commandArguments) -> {

--- a/src/controller/java/templates/helper.js
+++ b/src/controller/java/templates/helper.js
@@ -217,24 +217,26 @@ async function asJavaType(type, zclType, cluster, options)
     classType += asJavaBoxedType(type, zclType);
   }
 
-  if (!options.hash.forceNotList && (this.isArray || this.entryType)) {
-    if (!options.hash.removeGenericType) {
-      classType = 'ArrayList<' + classType + '>';
-    } else {
-      classType = 'ArrayList';
+  if (!options.hash.underlyingType) {
+    if (!options.hash.forceNotList && (this.isArray || this.entryType)) {
+      if (!options.hash.removeGenericType) {
+        classType = 'ArrayList<' + classType + '>';
+      } else {
+        classType = 'ArrayList';
+      }
     }
-  }
 
-  if (this.isOptional) {
-    if (!options.hash.removeGenericType) {
-      classType = 'Optional<' + classType + '>';
-    } else {
-      classType = 'Optional';
+    if (this.isOptional) {
+      if (!options.hash.removeGenericType) {
+        classType = 'Optional<' + classType + '>';
+      } else {
+        classType = 'Optional';
+      }
     }
-  }
 
-  if (this.isNullable && options.hash.includeAnnotations) {
-    classType = '@Nullable ' + classType;
+    if (this.isNullable && options.hash.includeAnnotations) {
+      classType = '@Nullable ' + classType;
+    }
   }
 
   return classType;

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterInfoMapping.java
@@ -7626,7 +7626,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> accountLogingetSetupPINCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo accountLogingetSetupPINtempAccountIdentifierCommandParameterInfo =
-        new CommandParameterInfo("tempAccountIdentifier", String.class);
+        new CommandParameterInfo("tempAccountIdentifier", String.class, String.class);
     accountLogingetSetupPINCommandParams.put(
         "tempAccountIdentifier", accountLogingetSetupPINtempAccountIdentifierCommandParameterInfo);
 
@@ -7646,12 +7646,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> accountLoginloginCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo accountLoginlogintempAccountIdentifierCommandParameterInfo =
-        new CommandParameterInfo("tempAccountIdentifier", String.class);
+        new CommandParameterInfo("tempAccountIdentifier", String.class, String.class);
     accountLoginloginCommandParams.put(
         "tempAccountIdentifier", accountLoginlogintempAccountIdentifierCommandParameterInfo);
 
     CommandParameterInfo accountLoginloginsetupPINCommandParameterInfo =
-        new CommandParameterInfo("setupPIN", String.class);
+        new CommandParameterInfo("setupPIN", String.class, String.class);
     accountLoginloginCommandParams.put("setupPIN", accountLoginloginsetupPINCommandParameterInfo);
 
     InteractionInfo accountLoginloginInteractionInfo =
@@ -7686,7 +7686,7 @@ public class ClusterInfoMapping {
             new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         administratorCommissioningopenBasicCommissioningWindowcommissioningTimeoutCommandParameterInfo =
-            new CommandParameterInfo("commissioningTimeout", Integer.class);
+            new CommandParameterInfo("commissioningTimeout", Integer.class, Integer.class);
     administratorCommissioningopenBasicCommissioningWindowCommandParams.put(
         "commissioningTimeout",
         administratorCommissioningopenBasicCommissioningWindowcommissioningTimeoutCommandParameterInfo);
@@ -7710,34 +7710,34 @@ public class ClusterInfoMapping {
             new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         administratorCommissioningopenCommissioningWindowcommissioningTimeoutCommandParameterInfo =
-            new CommandParameterInfo("commissioningTimeout", Integer.class);
+            new CommandParameterInfo("commissioningTimeout", Integer.class, Integer.class);
     administratorCommissioningopenCommissioningWindowCommandParams.put(
         "commissioningTimeout",
         administratorCommissioningopenCommissioningWindowcommissioningTimeoutCommandParameterInfo);
 
     CommandParameterInfo
         administratorCommissioningopenCommissioningWindowPAKEVerifierCommandParameterInfo =
-            new CommandParameterInfo("PAKEVerifier", byte[].class);
+            new CommandParameterInfo("PAKEVerifier", byte[].class, byte[].class);
     administratorCommissioningopenCommissioningWindowCommandParams.put(
         "PAKEVerifier",
         administratorCommissioningopenCommissioningWindowPAKEVerifierCommandParameterInfo);
 
     CommandParameterInfo
         administratorCommissioningopenCommissioningWindowdiscriminatorCommandParameterInfo =
-            new CommandParameterInfo("discriminator", Integer.class);
+            new CommandParameterInfo("discriminator", Integer.class, Integer.class);
     administratorCommissioningopenCommissioningWindowCommandParams.put(
         "discriminator",
         administratorCommissioningopenCommissioningWindowdiscriminatorCommandParameterInfo);
 
     CommandParameterInfo
         administratorCommissioningopenCommissioningWindowiterationsCommandParameterInfo =
-            new CommandParameterInfo("iterations", Long.class);
+            new CommandParameterInfo("iterations", Long.class, Long.class);
     administratorCommissioningopenCommissioningWindowCommandParams.put(
         "iterations",
         administratorCommissioningopenCommissioningWindowiterationsCommandParameterInfo);
 
     CommandParameterInfo administratorCommissioningopenCommissioningWindowsaltCommandParameterInfo =
-        new CommandParameterInfo("salt", byte[].class);
+        new CommandParameterInfo("salt", byte[].class, byte[].class);
     administratorCommissioningopenCommissioningWindowCommandParams.put(
         "salt", administratorCommissioningopenCommissioningWindowsaltCommandParameterInfo);
 
@@ -7795,7 +7795,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> applicationLauncherlaunchAppCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo applicationLauncherlaunchAppdataCommandParameterInfo =
-        new CommandParameterInfo("data", Optional.class);
+        new CommandParameterInfo("data", Optional.class, byte[].class);
     applicationLauncherlaunchAppCommandParams.put(
         "data", applicationLauncherlaunchAppdataCommandParameterInfo);
 
@@ -7833,12 +7833,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> audioOutputrenameOutputCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo audioOutputrenameOutputindexCommandParameterInfo =
-        new CommandParameterInfo("index", Integer.class);
+        new CommandParameterInfo("index", Integer.class, Integer.class);
     audioOutputrenameOutputCommandParams.put(
         "index", audioOutputrenameOutputindexCommandParameterInfo);
 
     CommandParameterInfo audioOutputrenameOutputnameCommandParameterInfo =
-        new CommandParameterInfo("name", String.class);
+        new CommandParameterInfo("name", String.class, String.class);
     audioOutputrenameOutputCommandParams.put(
         "name", audioOutputrenameOutputnameCommandParameterInfo);
 
@@ -7858,7 +7858,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> audioOutputselectOutputCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo audioOutputselectOutputindexCommandParameterInfo =
-        new CommandParameterInfo("index", Integer.class);
+        new CommandParameterInfo("index", Integer.class, Integer.class);
     audioOutputselectOutputCommandParams.put(
         "index", audioOutputselectOutputindexCommandParameterInfo);
 
@@ -7878,7 +7878,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> barrierControlbarrierControlGoToPercentCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo barrierControlbarrierControlGoToPercentpercentOpenCommandParameterInfo =
-        new CommandParameterInfo("percentOpen", Integer.class);
+        new CommandParameterInfo("percentOpen", Integer.class, Integer.class);
     barrierControlbarrierControlGoToPercentCommandParams.put(
         "percentOpen", barrierControlbarrierControlGoToPercentpercentOpenCommandParameterInfo);
 
@@ -7919,12 +7919,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionsdisableActionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionsdisableActionactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionsdisableActionCommandParams.put(
         "actionID", bridgedActionsdisableActionactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsdisableActioninvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionsdisableActionCommandParams.put(
         "invokeID", bridgedActionsdisableActioninvokeIDCommandParameterInfo);
 
@@ -7944,17 +7944,17 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionsdisableActionWithDurationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionsdisableActionWithDurationactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionsdisableActionWithDurationCommandParams.put(
         "actionID", bridgedActionsdisableActionWithDurationactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsdisableActionWithDurationinvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionsdisableActionWithDurationCommandParams.put(
         "invokeID", bridgedActionsdisableActionWithDurationinvokeIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsdisableActionWithDurationdurationCommandParameterInfo =
-        new CommandParameterInfo("duration", Long.class);
+        new CommandParameterInfo("duration", Long.class, Long.class);
     bridgedActionsdisableActionWithDurationCommandParams.put(
         "duration", bridgedActionsdisableActionWithDurationdurationCommandParameterInfo);
 
@@ -7975,12 +7975,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionsenableActionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionsenableActionactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionsenableActionCommandParams.put(
         "actionID", bridgedActionsenableActionactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsenableActioninvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionsenableActionCommandParams.put(
         "invokeID", bridgedActionsenableActioninvokeIDCommandParameterInfo);
 
@@ -8000,17 +8000,17 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionsenableActionWithDurationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionsenableActionWithDurationactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionsenableActionWithDurationCommandParams.put(
         "actionID", bridgedActionsenableActionWithDurationactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsenableActionWithDurationinvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionsenableActionWithDurationCommandParams.put(
         "invokeID", bridgedActionsenableActionWithDurationinvokeIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsenableActionWithDurationdurationCommandParameterInfo =
-        new CommandParameterInfo("duration", Long.class);
+        new CommandParameterInfo("duration", Long.class, Long.class);
     bridgedActionsenableActionWithDurationCommandParams.put(
         "duration", bridgedActionsenableActionWithDurationdurationCommandParameterInfo);
 
@@ -8031,12 +8031,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionsinstantActionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionsinstantActionactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionsinstantActionCommandParams.put(
         "actionID", bridgedActionsinstantActionactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsinstantActioninvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionsinstantActionCommandParams.put(
         "invokeID", bridgedActionsinstantActioninvokeIDCommandParameterInfo);
 
@@ -8056,18 +8056,18 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionsinstantActionWithTransitionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionsinstantActionWithTransitionactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionsinstantActionWithTransitionCommandParams.put(
         "actionID", bridgedActionsinstantActionWithTransitionactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsinstantActionWithTransitioninvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionsinstantActionWithTransitionCommandParams.put(
         "invokeID", bridgedActionsinstantActionWithTransitioninvokeIDCommandParameterInfo);
 
     CommandParameterInfo
         bridgedActionsinstantActionWithTransitiontransitionTimeCommandParameterInfo =
-            new CommandParameterInfo("transitionTime", Integer.class);
+            new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     bridgedActionsinstantActionWithTransitionCommandParams.put(
         "transitionTime",
         bridgedActionsinstantActionWithTransitiontransitionTimeCommandParameterInfo);
@@ -8089,12 +8089,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionspauseActionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionspauseActionactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionspauseActionCommandParams.put(
         "actionID", bridgedActionspauseActionactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionspauseActioninvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionspauseActionCommandParams.put(
         "invokeID", bridgedActionspauseActioninvokeIDCommandParameterInfo);
 
@@ -8114,17 +8114,17 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionspauseActionWithDurationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionspauseActionWithDurationactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionspauseActionWithDurationCommandParams.put(
         "actionID", bridgedActionspauseActionWithDurationactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionspauseActionWithDurationinvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionspauseActionWithDurationCommandParams.put(
         "invokeID", bridgedActionspauseActionWithDurationinvokeIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionspauseActionWithDurationdurationCommandParameterInfo =
-        new CommandParameterInfo("duration", Long.class);
+        new CommandParameterInfo("duration", Long.class, Long.class);
     bridgedActionspauseActionWithDurationCommandParams.put(
         "duration", bridgedActionspauseActionWithDurationdurationCommandParameterInfo);
 
@@ -8145,12 +8145,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionsresumeActionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionsresumeActionactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionsresumeActionCommandParams.put(
         "actionID", bridgedActionsresumeActionactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsresumeActioninvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionsresumeActionCommandParams.put(
         "invokeID", bridgedActionsresumeActioninvokeIDCommandParameterInfo);
 
@@ -8170,12 +8170,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionsstartActionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionsstartActionactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionsstartActionCommandParams.put(
         "actionID", bridgedActionsstartActionactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsstartActioninvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionsstartActionCommandParams.put(
         "invokeID", bridgedActionsstartActioninvokeIDCommandParameterInfo);
 
@@ -8195,17 +8195,17 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionsstartActionWithDurationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionsstartActionWithDurationactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionsstartActionWithDurationCommandParams.put(
         "actionID", bridgedActionsstartActionWithDurationactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsstartActionWithDurationinvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionsstartActionWithDurationCommandParams.put(
         "invokeID", bridgedActionsstartActionWithDurationinvokeIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsstartActionWithDurationdurationCommandParameterInfo =
-        new CommandParameterInfo("duration", Long.class);
+        new CommandParameterInfo("duration", Long.class, Long.class);
     bridgedActionsstartActionWithDurationCommandParams.put(
         "duration", bridgedActionsstartActionWithDurationdurationCommandParameterInfo);
 
@@ -8226,12 +8226,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> bridgedActionsstopActionCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedActionsstopActionactionIDCommandParameterInfo =
-        new CommandParameterInfo("actionID", Integer.class);
+        new CommandParameterInfo("actionID", Integer.class, Integer.class);
     bridgedActionsstopActionCommandParams.put(
         "actionID", bridgedActionsstopActionactionIDCommandParameterInfo);
 
     CommandParameterInfo bridgedActionsstopActioninvokeIDCommandParameterInfo =
-        new CommandParameterInfo("invokeID", Optional.class);
+        new CommandParameterInfo("invokeID", Optional.class, Long.class);
     bridgedActionsstopActionCommandParams.put(
         "invokeID", bridgedActionsstopActioninvokeIDCommandParameterInfo);
 
@@ -8256,7 +8256,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> channelchangeChannelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo channelchangeChannelmatchCommandParameterInfo =
-        new CommandParameterInfo("match", String.class);
+        new CommandParameterInfo("match", String.class, String.class);
     channelchangeChannelCommandParams.put("match", channelchangeChannelmatchCommandParameterInfo);
 
     InteractionInfo channelchangeChannelInteractionInfo =
@@ -8273,12 +8273,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> channelchangeChannelByNumberCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo channelchangeChannelByNumbermajorNumberCommandParameterInfo =
-        new CommandParameterInfo("majorNumber", Integer.class);
+        new CommandParameterInfo("majorNumber", Integer.class, Integer.class);
     channelchangeChannelByNumberCommandParams.put(
         "majorNumber", channelchangeChannelByNumbermajorNumberCommandParameterInfo);
 
     CommandParameterInfo channelchangeChannelByNumberminorNumberCommandParameterInfo =
-        new CommandParameterInfo("minorNumber", Integer.class);
+        new CommandParameterInfo("minorNumber", Integer.class, Integer.class);
     channelchangeChannelByNumberCommandParams.put(
         "minorNumber", channelchangeChannelByNumberminorNumberCommandParameterInfo);
 
@@ -8298,7 +8298,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> channelskipChannelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo channelskipChannelcountCommandParameterInfo =
-        new CommandParameterInfo("count", Integer.class);
+        new CommandParameterInfo("count", Integer.class, Integer.class);
     channelskipChannelCommandParams.put("count", channelskipChannelcountCommandParameterInfo);
 
     InteractionInfo channelskipChannelInteractionInfo =
@@ -8316,37 +8316,37 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlcolorLoopSetCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorLoopSetupdateFlagsCommandParameterInfo =
-        new CommandParameterInfo("updateFlags", Integer.class);
+        new CommandParameterInfo("updateFlags", Integer.class, Integer.class);
     colorControlcolorLoopSetCommandParams.put(
         "updateFlags", colorControlcolorLoopSetupdateFlagsCommandParameterInfo);
 
     CommandParameterInfo colorControlcolorLoopSetactionCommandParameterInfo =
-        new CommandParameterInfo("action", Integer.class);
+        new CommandParameterInfo("action", Integer.class, Integer.class);
     colorControlcolorLoopSetCommandParams.put(
         "action", colorControlcolorLoopSetactionCommandParameterInfo);
 
     CommandParameterInfo colorControlcolorLoopSetdirectionCommandParameterInfo =
-        new CommandParameterInfo("direction", Integer.class);
+        new CommandParameterInfo("direction", Integer.class, Integer.class);
     colorControlcolorLoopSetCommandParams.put(
         "direction", colorControlcolorLoopSetdirectionCommandParameterInfo);
 
     CommandParameterInfo colorControlcolorLoopSettimeCommandParameterInfo =
-        new CommandParameterInfo("time", Integer.class);
+        new CommandParameterInfo("time", Integer.class, Integer.class);
     colorControlcolorLoopSetCommandParams.put(
         "time", colorControlcolorLoopSettimeCommandParameterInfo);
 
     CommandParameterInfo colorControlcolorLoopSetstartHueCommandParameterInfo =
-        new CommandParameterInfo("startHue", Integer.class);
+        new CommandParameterInfo("startHue", Integer.class, Integer.class);
     colorControlcolorLoopSetCommandParams.put(
         "startHue", colorControlcolorLoopSetstartHueCommandParameterInfo);
 
     CommandParameterInfo colorControlcolorLoopSetoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlcolorLoopSetCommandParams.put(
         "optionsMask", colorControlcolorLoopSetoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlcolorLoopSetoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlcolorLoopSetCommandParams.put(
         "optionsOverride", colorControlcolorLoopSetoptionsOverrideCommandParameterInfo);
 
@@ -8371,22 +8371,22 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlenhancedMoveHueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlenhancedMoveHuemoveModeCommandParameterInfo =
-        new CommandParameterInfo("moveMode", Integer.class);
+        new CommandParameterInfo("moveMode", Integer.class, Integer.class);
     colorControlenhancedMoveHueCommandParams.put(
         "moveMode", colorControlenhancedMoveHuemoveModeCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedMoveHuerateCommandParameterInfo =
-        new CommandParameterInfo("rate", Integer.class);
+        new CommandParameterInfo("rate", Integer.class, Integer.class);
     colorControlenhancedMoveHueCommandParams.put(
         "rate", colorControlenhancedMoveHuerateCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedMoveHueoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlenhancedMoveHueCommandParams.put(
         "optionsMask", colorControlenhancedMoveHueoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedMoveHueoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlenhancedMoveHueCommandParams.put(
         "optionsOverride", colorControlenhancedMoveHueoptionsOverrideCommandParameterInfo);
 
@@ -8408,27 +8408,27 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlenhancedMoveToHueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlenhancedMoveToHueenhancedHueCommandParameterInfo =
-        new CommandParameterInfo("enhancedHue", Integer.class);
+        new CommandParameterInfo("enhancedHue", Integer.class, Integer.class);
     colorControlenhancedMoveToHueCommandParams.put(
         "enhancedHue", colorControlenhancedMoveToHueenhancedHueCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedMoveToHuedirectionCommandParameterInfo =
-        new CommandParameterInfo("direction", Integer.class);
+        new CommandParameterInfo("direction", Integer.class, Integer.class);
     colorControlenhancedMoveToHueCommandParams.put(
         "direction", colorControlenhancedMoveToHuedirectionCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedMoveToHuetransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlenhancedMoveToHueCommandParams.put(
         "transitionTime", colorControlenhancedMoveToHuetransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedMoveToHueoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlenhancedMoveToHueCommandParams.put(
         "optionsMask", colorControlenhancedMoveToHueoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedMoveToHueoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlenhancedMoveToHueCommandParams.put(
         "optionsOverride", colorControlenhancedMoveToHueoptionsOverrideCommandParameterInfo);
 
@@ -8451,30 +8451,30 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlenhancedMoveToHueAndSaturationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlenhancedMoveToHueAndSaturationenhancedHueCommandParameterInfo =
-        new CommandParameterInfo("enhancedHue", Integer.class);
+        new CommandParameterInfo("enhancedHue", Integer.class, Integer.class);
     colorControlenhancedMoveToHueAndSaturationCommandParams.put(
         "enhancedHue", colorControlenhancedMoveToHueAndSaturationenhancedHueCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedMoveToHueAndSaturationsaturationCommandParameterInfo =
-        new CommandParameterInfo("saturation", Integer.class);
+        new CommandParameterInfo("saturation", Integer.class, Integer.class);
     colorControlenhancedMoveToHueAndSaturationCommandParams.put(
         "saturation", colorControlenhancedMoveToHueAndSaturationsaturationCommandParameterInfo);
 
     CommandParameterInfo
         colorControlenhancedMoveToHueAndSaturationtransitionTimeCommandParameterInfo =
-            new CommandParameterInfo("transitionTime", Integer.class);
+            new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlenhancedMoveToHueAndSaturationCommandParams.put(
         "transitionTime",
         colorControlenhancedMoveToHueAndSaturationtransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedMoveToHueAndSaturationoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlenhancedMoveToHueAndSaturationCommandParams.put(
         "optionsMask", colorControlenhancedMoveToHueAndSaturationoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo
         colorControlenhancedMoveToHueAndSaturationoptionsOverrideCommandParameterInfo =
-            new CommandParameterInfo("optionsOverride", Integer.class);
+            new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlenhancedMoveToHueAndSaturationCommandParams.put(
         "optionsOverride",
         colorControlenhancedMoveToHueAndSaturationoptionsOverrideCommandParameterInfo);
@@ -8499,27 +8499,27 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlenhancedStepHueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlenhancedStepHuestepModeCommandParameterInfo =
-        new CommandParameterInfo("stepMode", Integer.class);
+        new CommandParameterInfo("stepMode", Integer.class, Integer.class);
     colorControlenhancedStepHueCommandParams.put(
         "stepMode", colorControlenhancedStepHuestepModeCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedStepHuestepSizeCommandParameterInfo =
-        new CommandParameterInfo("stepSize", Integer.class);
+        new CommandParameterInfo("stepSize", Integer.class, Integer.class);
     colorControlenhancedStepHueCommandParams.put(
         "stepSize", colorControlenhancedStepHuestepSizeCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedStepHuetransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlenhancedStepHueCommandParams.put(
         "transitionTime", colorControlenhancedStepHuetransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedStepHueoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlenhancedStepHueCommandParams.put(
         "optionsMask", colorControlenhancedStepHueoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlenhancedStepHueoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlenhancedStepHueCommandParams.put(
         "optionsOverride", colorControlenhancedStepHueoptionsOverrideCommandParameterInfo);
 
@@ -8542,20 +8542,20 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlmoveColorCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlmoveColorrateXCommandParameterInfo =
-        new CommandParameterInfo("rateX", Integer.class);
+        new CommandParameterInfo("rateX", Integer.class, Integer.class);
     colorControlmoveColorCommandParams.put("rateX", colorControlmoveColorrateXCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveColorrateYCommandParameterInfo =
-        new CommandParameterInfo("rateY", Integer.class);
+        new CommandParameterInfo("rateY", Integer.class, Integer.class);
     colorControlmoveColorCommandParams.put("rateY", colorControlmoveColorrateYCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveColoroptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlmoveColorCommandParams.put(
         "optionsMask", colorControlmoveColoroptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveColoroptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlmoveColorCommandParams.put(
         "optionsOverride", colorControlmoveColoroptionsOverrideCommandParameterInfo);
 
@@ -8576,36 +8576,36 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlmoveColorTemperatureCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlmoveColorTemperaturemoveModeCommandParameterInfo =
-        new CommandParameterInfo("moveMode", Integer.class);
+        new CommandParameterInfo("moveMode", Integer.class, Integer.class);
     colorControlmoveColorTemperatureCommandParams.put(
         "moveMode", colorControlmoveColorTemperaturemoveModeCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveColorTemperaturerateCommandParameterInfo =
-        new CommandParameterInfo("rate", Integer.class);
+        new CommandParameterInfo("rate", Integer.class, Integer.class);
     colorControlmoveColorTemperatureCommandParams.put(
         "rate", colorControlmoveColorTemperaturerateCommandParameterInfo);
 
     CommandParameterInfo
         colorControlmoveColorTemperaturecolorTemperatureMinimumCommandParameterInfo =
-            new CommandParameterInfo("colorTemperatureMinimum", Integer.class);
+            new CommandParameterInfo("colorTemperatureMinimum", Integer.class, Integer.class);
     colorControlmoveColorTemperatureCommandParams.put(
         "colorTemperatureMinimum",
         colorControlmoveColorTemperaturecolorTemperatureMinimumCommandParameterInfo);
 
     CommandParameterInfo
         colorControlmoveColorTemperaturecolorTemperatureMaximumCommandParameterInfo =
-            new CommandParameterInfo("colorTemperatureMaximum", Integer.class);
+            new CommandParameterInfo("colorTemperatureMaximum", Integer.class, Integer.class);
     colorControlmoveColorTemperatureCommandParams.put(
         "colorTemperatureMaximum",
         colorControlmoveColorTemperaturecolorTemperatureMaximumCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveColorTemperatureoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlmoveColorTemperatureCommandParams.put(
         "optionsMask", colorControlmoveColorTemperatureoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveColorTemperatureoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlmoveColorTemperatureCommandParams.put(
         "optionsOverride", colorControlmoveColorTemperatureoptionsOverrideCommandParameterInfo);
 
@@ -8629,21 +8629,21 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlmoveHueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlmoveHuemoveModeCommandParameterInfo =
-        new CommandParameterInfo("moveMode", Integer.class);
+        new CommandParameterInfo("moveMode", Integer.class, Integer.class);
     colorControlmoveHueCommandParams.put(
         "moveMode", colorControlmoveHuemoveModeCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveHuerateCommandParameterInfo =
-        new CommandParameterInfo("rate", Integer.class);
+        new CommandParameterInfo("rate", Integer.class, Integer.class);
     colorControlmoveHueCommandParams.put("rate", colorControlmoveHuerateCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveHueoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlmoveHueCommandParams.put(
         "optionsMask", colorControlmoveHueoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveHueoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlmoveHueCommandParams.put(
         "optionsOverride", colorControlmoveHueoptionsOverrideCommandParameterInfo);
 
@@ -8664,22 +8664,22 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlmoveSaturationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlmoveSaturationmoveModeCommandParameterInfo =
-        new CommandParameterInfo("moveMode", Integer.class);
+        new CommandParameterInfo("moveMode", Integer.class, Integer.class);
     colorControlmoveSaturationCommandParams.put(
         "moveMode", colorControlmoveSaturationmoveModeCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveSaturationrateCommandParameterInfo =
-        new CommandParameterInfo("rate", Integer.class);
+        new CommandParameterInfo("rate", Integer.class, Integer.class);
     colorControlmoveSaturationCommandParams.put(
         "rate", colorControlmoveSaturationrateCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveSaturationoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlmoveSaturationCommandParams.put(
         "optionsMask", colorControlmoveSaturationoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveSaturationoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlmoveSaturationCommandParams.put(
         "optionsOverride", colorControlmoveSaturationoptionsOverrideCommandParameterInfo);
 
@@ -8701,27 +8701,27 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlmoveToColorCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlmoveToColorcolorXCommandParameterInfo =
-        new CommandParameterInfo("colorX", Integer.class);
+        new CommandParameterInfo("colorX", Integer.class, Integer.class);
     colorControlmoveToColorCommandParams.put(
         "colorX", colorControlmoveToColorcolorXCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToColorcolorYCommandParameterInfo =
-        new CommandParameterInfo("colorY", Integer.class);
+        new CommandParameterInfo("colorY", Integer.class, Integer.class);
     colorControlmoveToColorCommandParams.put(
         "colorY", colorControlmoveToColorcolorYCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToColortransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlmoveToColorCommandParams.put(
         "transitionTime", colorControlmoveToColortransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToColoroptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlmoveToColorCommandParams.put(
         "optionsMask", colorControlmoveToColoroptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToColoroptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlmoveToColorCommandParams.put(
         "optionsOverride", colorControlmoveToColoroptionsOverrideCommandParameterInfo);
 
@@ -8744,22 +8744,22 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlmoveToColorTemperatureCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlmoveToColorTemperaturecolorTemperatureCommandParameterInfo =
-        new CommandParameterInfo("colorTemperature", Integer.class);
+        new CommandParameterInfo("colorTemperature", Integer.class, Integer.class);
     colorControlmoveToColorTemperatureCommandParams.put(
         "colorTemperature", colorControlmoveToColorTemperaturecolorTemperatureCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToColorTemperaturetransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlmoveToColorTemperatureCommandParams.put(
         "transitionTime", colorControlmoveToColorTemperaturetransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToColorTemperatureoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlmoveToColorTemperatureCommandParams.put(
         "optionsMask", colorControlmoveToColorTemperatureoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToColorTemperatureoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlmoveToColorTemperatureCommandParams.put(
         "optionsOverride", colorControlmoveToColorTemperatureoptionsOverrideCommandParameterInfo);
 
@@ -8781,26 +8781,26 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlmoveToHueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlmoveToHuehueCommandParameterInfo =
-        new CommandParameterInfo("hue", Integer.class);
+        new CommandParameterInfo("hue", Integer.class, Integer.class);
     colorControlmoveToHueCommandParams.put("hue", colorControlmoveToHuehueCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToHuedirectionCommandParameterInfo =
-        new CommandParameterInfo("direction", Integer.class);
+        new CommandParameterInfo("direction", Integer.class, Integer.class);
     colorControlmoveToHueCommandParams.put(
         "direction", colorControlmoveToHuedirectionCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToHuetransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlmoveToHueCommandParams.put(
         "transitionTime", colorControlmoveToHuetransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToHueoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlmoveToHueCommandParams.put(
         "optionsMask", colorControlmoveToHueoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToHueoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlmoveToHueCommandParams.put(
         "optionsOverride", colorControlmoveToHueoptionsOverrideCommandParameterInfo);
 
@@ -8822,27 +8822,27 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlmoveToHueAndSaturationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlmoveToHueAndSaturationhueCommandParameterInfo =
-        new CommandParameterInfo("hue", Integer.class);
+        new CommandParameterInfo("hue", Integer.class, Integer.class);
     colorControlmoveToHueAndSaturationCommandParams.put(
         "hue", colorControlmoveToHueAndSaturationhueCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToHueAndSaturationsaturationCommandParameterInfo =
-        new CommandParameterInfo("saturation", Integer.class);
+        new CommandParameterInfo("saturation", Integer.class, Integer.class);
     colorControlmoveToHueAndSaturationCommandParams.put(
         "saturation", colorControlmoveToHueAndSaturationsaturationCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToHueAndSaturationtransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlmoveToHueAndSaturationCommandParams.put(
         "transitionTime", colorControlmoveToHueAndSaturationtransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToHueAndSaturationoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlmoveToHueAndSaturationCommandParams.put(
         "optionsMask", colorControlmoveToHueAndSaturationoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToHueAndSaturationoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlmoveToHueAndSaturationCommandParams.put(
         "optionsOverride", colorControlmoveToHueAndSaturationoptionsOverrideCommandParameterInfo);
 
@@ -8865,22 +8865,22 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlmoveToSaturationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlmoveToSaturationsaturationCommandParameterInfo =
-        new CommandParameterInfo("saturation", Integer.class);
+        new CommandParameterInfo("saturation", Integer.class, Integer.class);
     colorControlmoveToSaturationCommandParams.put(
         "saturation", colorControlmoveToSaturationsaturationCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToSaturationtransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlmoveToSaturationCommandParams.put(
         "transitionTime", colorControlmoveToSaturationtransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToSaturationoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlmoveToSaturationCommandParams.put(
         "optionsMask", colorControlmoveToSaturationoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlmoveToSaturationoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlmoveToSaturationCommandParams.put(
         "optionsOverride", colorControlmoveToSaturationoptionsOverrideCommandParameterInfo);
 
@@ -8902,25 +8902,25 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlstepColorCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlstepColorstepXCommandParameterInfo =
-        new CommandParameterInfo("stepX", Integer.class);
+        new CommandParameterInfo("stepX", Integer.class, Integer.class);
     colorControlstepColorCommandParams.put("stepX", colorControlstepColorstepXCommandParameterInfo);
 
     CommandParameterInfo colorControlstepColorstepYCommandParameterInfo =
-        new CommandParameterInfo("stepY", Integer.class);
+        new CommandParameterInfo("stepY", Integer.class, Integer.class);
     colorControlstepColorCommandParams.put("stepY", colorControlstepColorstepYCommandParameterInfo);
 
     CommandParameterInfo colorControlstepColortransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlstepColorCommandParams.put(
         "transitionTime", colorControlstepColortransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlstepColoroptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlstepColorCommandParams.put(
         "optionsMask", colorControlstepColoroptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlstepColoroptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlstepColorCommandParams.put(
         "optionsOverride", colorControlstepColoroptionsOverrideCommandParameterInfo);
 
@@ -8942,41 +8942,41 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlstepColorTemperatureCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlstepColorTemperaturestepModeCommandParameterInfo =
-        new CommandParameterInfo("stepMode", Integer.class);
+        new CommandParameterInfo("stepMode", Integer.class, Integer.class);
     colorControlstepColorTemperatureCommandParams.put(
         "stepMode", colorControlstepColorTemperaturestepModeCommandParameterInfo);
 
     CommandParameterInfo colorControlstepColorTemperaturestepSizeCommandParameterInfo =
-        new CommandParameterInfo("stepSize", Integer.class);
+        new CommandParameterInfo("stepSize", Integer.class, Integer.class);
     colorControlstepColorTemperatureCommandParams.put(
         "stepSize", colorControlstepColorTemperaturestepSizeCommandParameterInfo);
 
     CommandParameterInfo colorControlstepColorTemperaturetransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlstepColorTemperatureCommandParams.put(
         "transitionTime", colorControlstepColorTemperaturetransitionTimeCommandParameterInfo);
 
     CommandParameterInfo
         colorControlstepColorTemperaturecolorTemperatureMinimumCommandParameterInfo =
-            new CommandParameterInfo("colorTemperatureMinimum", Integer.class);
+            new CommandParameterInfo("colorTemperatureMinimum", Integer.class, Integer.class);
     colorControlstepColorTemperatureCommandParams.put(
         "colorTemperatureMinimum",
         colorControlstepColorTemperaturecolorTemperatureMinimumCommandParameterInfo);
 
     CommandParameterInfo
         colorControlstepColorTemperaturecolorTemperatureMaximumCommandParameterInfo =
-            new CommandParameterInfo("colorTemperatureMaximum", Integer.class);
+            new CommandParameterInfo("colorTemperatureMaximum", Integer.class, Integer.class);
     colorControlstepColorTemperatureCommandParams.put(
         "colorTemperatureMaximum",
         colorControlstepColorTemperaturecolorTemperatureMaximumCommandParameterInfo);
 
     CommandParameterInfo colorControlstepColorTemperatureoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlstepColorTemperatureCommandParams.put(
         "optionsMask", colorControlstepColorTemperatureoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlstepColorTemperatureoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlstepColorTemperatureCommandParams.put(
         "optionsOverride", colorControlstepColorTemperatureoptionsOverrideCommandParameterInfo);
 
@@ -9001,27 +9001,27 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlstepHueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlstepHuestepModeCommandParameterInfo =
-        new CommandParameterInfo("stepMode", Integer.class);
+        new CommandParameterInfo("stepMode", Integer.class, Integer.class);
     colorControlstepHueCommandParams.put(
         "stepMode", colorControlstepHuestepModeCommandParameterInfo);
 
     CommandParameterInfo colorControlstepHuestepSizeCommandParameterInfo =
-        new CommandParameterInfo("stepSize", Integer.class);
+        new CommandParameterInfo("stepSize", Integer.class, Integer.class);
     colorControlstepHueCommandParams.put(
         "stepSize", colorControlstepHuestepSizeCommandParameterInfo);
 
     CommandParameterInfo colorControlstepHuetransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlstepHueCommandParams.put(
         "transitionTime", colorControlstepHuetransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlstepHueoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlstepHueCommandParams.put(
         "optionsMask", colorControlstepHueoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlstepHueoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlstepHueCommandParams.put(
         "optionsOverride", colorControlstepHueoptionsOverrideCommandParameterInfo);
 
@@ -9043,27 +9043,27 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlstepSaturationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlstepSaturationstepModeCommandParameterInfo =
-        new CommandParameterInfo("stepMode", Integer.class);
+        new CommandParameterInfo("stepMode", Integer.class, Integer.class);
     colorControlstepSaturationCommandParams.put(
         "stepMode", colorControlstepSaturationstepModeCommandParameterInfo);
 
     CommandParameterInfo colorControlstepSaturationstepSizeCommandParameterInfo =
-        new CommandParameterInfo("stepSize", Integer.class);
+        new CommandParameterInfo("stepSize", Integer.class, Integer.class);
     colorControlstepSaturationCommandParams.put(
         "stepSize", colorControlstepSaturationstepSizeCommandParameterInfo);
 
     CommandParameterInfo colorControlstepSaturationtransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     colorControlstepSaturationCommandParams.put(
         "transitionTime", colorControlstepSaturationtransitionTimeCommandParameterInfo);
 
     CommandParameterInfo colorControlstepSaturationoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlstepSaturationCommandParams.put(
         "optionsMask", colorControlstepSaturationoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlstepSaturationoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlstepSaturationCommandParams.put(
         "optionsOverride", colorControlstepSaturationoptionsOverrideCommandParameterInfo);
 
@@ -9086,12 +9086,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> colorControlstopMoveStepCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlstopMoveStepoptionsMaskCommandParameterInfo =
-        new CommandParameterInfo("optionsMask", Integer.class);
+        new CommandParameterInfo("optionsMask", Integer.class, Integer.class);
     colorControlstopMoveStepCommandParams.put(
         "optionsMask", colorControlstopMoveStepoptionsMaskCommandParameterInfo);
 
     CommandParameterInfo colorControlstopMoveStepoptionsOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionsOverride", Integer.class);
+        new CommandParameterInfo("optionsOverride", Integer.class, Integer.class);
     colorControlstopMoveStepCommandParams.put(
         "optionsOverride", colorControlstopMoveStepoptionsOverrideCommandParameterInfo);
 
@@ -9113,12 +9113,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> contentLauncherlaunchContentCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo contentLauncherlaunchContentautoPlayCommandParameterInfo =
-        new CommandParameterInfo("autoPlay", Boolean.class);
+        new CommandParameterInfo("autoPlay", Boolean.class, Boolean.class);
     contentLauncherlaunchContentCommandParams.put(
         "autoPlay", contentLauncherlaunchContentautoPlayCommandParameterInfo);
 
     CommandParameterInfo contentLauncherlaunchContentdataCommandParameterInfo =
-        new CommandParameterInfo("data", Optional.class);
+        new CommandParameterInfo("data", Optional.class, String.class);
     contentLauncherlaunchContentCommandParams.put(
         "data", contentLauncherlaunchContentdataCommandParameterInfo);
 
@@ -9140,12 +9140,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> contentLauncherlaunchURLCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo contentLauncherlaunchURLcontentURLCommandParameterInfo =
-        new CommandParameterInfo("contentURL", String.class);
+        new CommandParameterInfo("contentURL", String.class, String.class);
     contentLauncherlaunchURLCommandParams.put(
         "contentURL", contentLauncherlaunchURLcontentURLCommandParameterInfo);
 
     CommandParameterInfo contentLauncherlaunchURLdisplayStringCommandParameterInfo =
-        new CommandParameterInfo("displayString", Optional.class);
+        new CommandParameterInfo("displayString", Optional.class, String.class);
     contentLauncherlaunchURLCommandParams.put(
         "displayString", contentLauncherlaunchURLdisplayStringCommandParameterInfo);
 
@@ -9171,19 +9171,19 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> diagnosticLogsretrieveLogsRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo diagnosticLogsretrieveLogsRequestintentCommandParameterInfo =
-        new CommandParameterInfo("intent", Integer.class);
+        new CommandParameterInfo("intent", Integer.class, Integer.class);
     diagnosticLogsretrieveLogsRequestCommandParams.put(
         "intent", diagnosticLogsretrieveLogsRequestintentCommandParameterInfo);
 
     CommandParameterInfo diagnosticLogsretrieveLogsRequestrequestedProtocolCommandParameterInfo =
-        new CommandParameterInfo("requestedProtocol", Integer.class);
+        new CommandParameterInfo("requestedProtocol", Integer.class, Integer.class);
     diagnosticLogsretrieveLogsRequestCommandParams.put(
         "requestedProtocol",
         diagnosticLogsretrieveLogsRequestrequestedProtocolCommandParameterInfo);
 
     CommandParameterInfo
         diagnosticLogsretrieveLogsRequesttransferFileDesignatorCommandParameterInfo =
-            new CommandParameterInfo("transferFileDesignator", byte[].class);
+            new CommandParameterInfo("transferFileDesignator", byte[].class, byte[].class);
     diagnosticLogsretrieveLogsRequestCommandParams.put(
         "transferFileDesignator",
         diagnosticLogsretrieveLogsRequesttransferFileDesignatorCommandParameterInfo);
@@ -9222,7 +9222,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLockclearHolidayScheduleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockclearHolidayScheduleholidayIndexCommandParameterInfo =
-        new CommandParameterInfo("holidayIndex", Integer.class);
+        new CommandParameterInfo("holidayIndex", Integer.class, Integer.class);
     doorLockclearHolidayScheduleCommandParams.put(
         "holidayIndex", doorLockclearHolidayScheduleholidayIndexCommandParameterInfo);
 
@@ -9241,7 +9241,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLockclearUserCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockclearUseruserIndexCommandParameterInfo =
-        new CommandParameterInfo("userIndex", Integer.class);
+        new CommandParameterInfo("userIndex", Integer.class, Integer.class);
     doorLockclearUserCommandParams.put("userIndex", doorLockclearUseruserIndexCommandParameterInfo);
 
     InteractionInfo doorLockclearUserInteractionInfo =
@@ -9259,12 +9259,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLockclearWeekDayScheduleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockclearWeekDayScheduleweekDayIndexCommandParameterInfo =
-        new CommandParameterInfo("weekDayIndex", Integer.class);
+        new CommandParameterInfo("weekDayIndex", Integer.class, Integer.class);
     doorLockclearWeekDayScheduleCommandParams.put(
         "weekDayIndex", doorLockclearWeekDayScheduleweekDayIndexCommandParameterInfo);
 
     CommandParameterInfo doorLockclearWeekDayScheduleuserIndexCommandParameterInfo =
-        new CommandParameterInfo("userIndex", Integer.class);
+        new CommandParameterInfo("userIndex", Integer.class, Integer.class);
     doorLockclearWeekDayScheduleCommandParams.put(
         "userIndex", doorLockclearWeekDayScheduleuserIndexCommandParameterInfo);
 
@@ -9284,12 +9284,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLockclearYearDayScheduleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockclearYearDayScheduleyearDayIndexCommandParameterInfo =
-        new CommandParameterInfo("yearDayIndex", Integer.class);
+        new CommandParameterInfo("yearDayIndex", Integer.class, Integer.class);
     doorLockclearYearDayScheduleCommandParams.put(
         "yearDayIndex", doorLockclearYearDayScheduleyearDayIndexCommandParameterInfo);
 
     CommandParameterInfo doorLockclearYearDayScheduleuserIndexCommandParameterInfo =
-        new CommandParameterInfo("userIndex", Integer.class);
+        new CommandParameterInfo("userIndex", Integer.class, Integer.class);
     doorLockclearYearDayScheduleCommandParams.put(
         "userIndex", doorLockclearYearDayScheduleuserIndexCommandParameterInfo);
 
@@ -9323,7 +9323,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLockgetHolidayScheduleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockgetHolidayScheduleholidayIndexCommandParameterInfo =
-        new CommandParameterInfo("holidayIndex", Integer.class);
+        new CommandParameterInfo("holidayIndex", Integer.class, Integer.class);
     doorLockgetHolidayScheduleCommandParams.put(
         "holidayIndex", doorLockgetHolidayScheduleholidayIndexCommandParameterInfo);
 
@@ -9342,7 +9342,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLockgetUserCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockgetUseruserIndexCommandParameterInfo =
-        new CommandParameterInfo("userIndex", Integer.class);
+        new CommandParameterInfo("userIndex", Integer.class, Integer.class);
     doorLockgetUserCommandParams.put("userIndex", doorLockgetUseruserIndexCommandParameterInfo);
 
     InteractionInfo doorLockgetUserInteractionInfo =
@@ -9359,12 +9359,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLockgetWeekDayScheduleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockgetWeekDayScheduleweekDayIndexCommandParameterInfo =
-        new CommandParameterInfo("weekDayIndex", Integer.class);
+        new CommandParameterInfo("weekDayIndex", Integer.class, Integer.class);
     doorLockgetWeekDayScheduleCommandParams.put(
         "weekDayIndex", doorLockgetWeekDayScheduleweekDayIndexCommandParameterInfo);
 
     CommandParameterInfo doorLockgetWeekDayScheduleuserIndexCommandParameterInfo =
-        new CommandParameterInfo("userIndex", Integer.class);
+        new CommandParameterInfo("userIndex", Integer.class, Integer.class);
     doorLockgetWeekDayScheduleCommandParams.put(
         "userIndex", doorLockgetWeekDayScheduleuserIndexCommandParameterInfo);
 
@@ -9384,12 +9384,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLockgetYearDayScheduleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockgetYearDayScheduleyearDayIndexCommandParameterInfo =
-        new CommandParameterInfo("yearDayIndex", Integer.class);
+        new CommandParameterInfo("yearDayIndex", Integer.class, Integer.class);
     doorLockgetYearDayScheduleCommandParams.put(
         "yearDayIndex", doorLockgetYearDayScheduleyearDayIndexCommandParameterInfo);
 
     CommandParameterInfo doorLockgetYearDayScheduleuserIndexCommandParameterInfo =
-        new CommandParameterInfo("userIndex", Integer.class);
+        new CommandParameterInfo("userIndex", Integer.class, Integer.class);
     doorLockgetYearDayScheduleCommandParams.put(
         "userIndex", doorLockgetYearDayScheduleuserIndexCommandParameterInfo);
 
@@ -9409,7 +9409,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLocklockDoorCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLocklockDoorpinCodeCommandParameterInfo =
-        new CommandParameterInfo("pinCode", Optional.class);
+        new CommandParameterInfo("pinCode", Optional.class, byte[].class);
     doorLocklockDoorCommandParams.put("pinCode", doorLocklockDoorpinCodeCommandParameterInfo);
 
     InteractionInfo doorLocklockDoorInteractionInfo =
@@ -9427,27 +9427,27 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLocksetCredentialCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLocksetCredentialoperationTypeCommandParameterInfo =
-        new CommandParameterInfo("operationType", Integer.class);
+        new CommandParameterInfo("operationType", Integer.class, Integer.class);
     doorLocksetCredentialCommandParams.put(
         "operationType", doorLocksetCredentialoperationTypeCommandParameterInfo);
 
     CommandParameterInfo doorLocksetCredentialcredentialDataCommandParameterInfo =
-        new CommandParameterInfo("credentialData", byte[].class);
+        new CommandParameterInfo("credentialData", byte[].class, byte[].class);
     doorLocksetCredentialCommandParams.put(
         "credentialData", doorLocksetCredentialcredentialDataCommandParameterInfo);
 
     CommandParameterInfo doorLocksetCredentialuserIndexCommandParameterInfo =
-        new CommandParameterInfo("userIndex", Integer.class);
+        new CommandParameterInfo("userIndex", Integer.class, Integer.class);
     doorLocksetCredentialCommandParams.put(
         "userIndex", doorLocksetCredentialuserIndexCommandParameterInfo);
 
     CommandParameterInfo doorLocksetCredentialuserStatusCommandParameterInfo =
-        new CommandParameterInfo("userStatus", Integer.class);
+        new CommandParameterInfo("userStatus", Integer.class, Integer.class);
     doorLocksetCredentialCommandParams.put(
         "userStatus", doorLocksetCredentialuserStatusCommandParameterInfo);
 
     CommandParameterInfo doorLocksetCredentialuserTypeCommandParameterInfo =
-        new CommandParameterInfo("userType", Integer.class);
+        new CommandParameterInfo("userType", Integer.class, Integer.class);
     doorLocksetCredentialCommandParams.put(
         "userType", doorLocksetCredentialuserTypeCommandParameterInfo);
 
@@ -9471,22 +9471,22 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLocksetHolidayScheduleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLocksetHolidayScheduleholidayIndexCommandParameterInfo =
-        new CommandParameterInfo("holidayIndex", Integer.class);
+        new CommandParameterInfo("holidayIndex", Integer.class, Integer.class);
     doorLocksetHolidayScheduleCommandParams.put(
         "holidayIndex", doorLocksetHolidayScheduleholidayIndexCommandParameterInfo);
 
     CommandParameterInfo doorLocksetHolidaySchedulelocalStartTimeCommandParameterInfo =
-        new CommandParameterInfo("localStartTime", Long.class);
+        new CommandParameterInfo("localStartTime", Long.class, Long.class);
     doorLocksetHolidayScheduleCommandParams.put(
         "localStartTime", doorLocksetHolidaySchedulelocalStartTimeCommandParameterInfo);
 
     CommandParameterInfo doorLocksetHolidaySchedulelocalEndTimeCommandParameterInfo =
-        new CommandParameterInfo("localEndTime", Long.class);
+        new CommandParameterInfo("localEndTime", Long.class, Long.class);
     doorLocksetHolidayScheduleCommandParams.put(
         "localEndTime", doorLocksetHolidaySchedulelocalEndTimeCommandParameterInfo);
 
     CommandParameterInfo doorLocksetHolidayScheduleoperatingModeCommandParameterInfo =
-        new CommandParameterInfo("operatingMode", Integer.class);
+        new CommandParameterInfo("operatingMode", Integer.class, Integer.class);
     doorLocksetHolidayScheduleCommandParams.put(
         "operatingMode", doorLocksetHolidayScheduleoperatingModeCommandParameterInfo);
 
@@ -9508,33 +9508,33 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLocksetUserCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLocksetUseroperationTypeCommandParameterInfo =
-        new CommandParameterInfo("operationType", Integer.class);
+        new CommandParameterInfo("operationType", Integer.class, Integer.class);
     doorLocksetUserCommandParams.put(
         "operationType", doorLocksetUseroperationTypeCommandParameterInfo);
 
     CommandParameterInfo doorLocksetUseruserIndexCommandParameterInfo =
-        new CommandParameterInfo("userIndex", Integer.class);
+        new CommandParameterInfo("userIndex", Integer.class, Integer.class);
     doorLocksetUserCommandParams.put("userIndex", doorLocksetUseruserIndexCommandParameterInfo);
 
     CommandParameterInfo doorLocksetUseruserNameCommandParameterInfo =
-        new CommandParameterInfo("userName", String.class);
+        new CommandParameterInfo("userName", String.class, String.class);
     doorLocksetUserCommandParams.put("userName", doorLocksetUseruserNameCommandParameterInfo);
 
     CommandParameterInfo doorLocksetUseruserUniqueIdCommandParameterInfo =
-        new CommandParameterInfo("userUniqueId", Long.class);
+        new CommandParameterInfo("userUniqueId", Long.class, Long.class);
     doorLocksetUserCommandParams.put(
         "userUniqueId", doorLocksetUseruserUniqueIdCommandParameterInfo);
 
     CommandParameterInfo doorLocksetUseruserStatusCommandParameterInfo =
-        new CommandParameterInfo("userStatus", Integer.class);
+        new CommandParameterInfo("userStatus", Integer.class, Integer.class);
     doorLocksetUserCommandParams.put("userStatus", doorLocksetUseruserStatusCommandParameterInfo);
 
     CommandParameterInfo doorLocksetUseruserTypeCommandParameterInfo =
-        new CommandParameterInfo("userType", Integer.class);
+        new CommandParameterInfo("userType", Integer.class, Integer.class);
     doorLocksetUserCommandParams.put("userType", doorLocksetUseruserTypeCommandParameterInfo);
 
     CommandParameterInfo doorLocksetUsercredentialRuleCommandParameterInfo =
-        new CommandParameterInfo("credentialRule", Integer.class);
+        new CommandParameterInfo("credentialRule", Integer.class, Integer.class);
     doorLocksetUserCommandParams.put(
         "credentialRule", doorLocksetUsercredentialRuleCommandParameterInfo);
 
@@ -9559,37 +9559,37 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLocksetWeekDayScheduleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLocksetWeekDayScheduleweekDayIndexCommandParameterInfo =
-        new CommandParameterInfo("weekDayIndex", Integer.class);
+        new CommandParameterInfo("weekDayIndex", Integer.class, Integer.class);
     doorLocksetWeekDayScheduleCommandParams.put(
         "weekDayIndex", doorLocksetWeekDayScheduleweekDayIndexCommandParameterInfo);
 
     CommandParameterInfo doorLocksetWeekDayScheduleuserIndexCommandParameterInfo =
-        new CommandParameterInfo("userIndex", Integer.class);
+        new CommandParameterInfo("userIndex", Integer.class, Integer.class);
     doorLocksetWeekDayScheduleCommandParams.put(
         "userIndex", doorLocksetWeekDayScheduleuserIndexCommandParameterInfo);
 
     CommandParameterInfo doorLocksetWeekDayScheduledaysMaskCommandParameterInfo =
-        new CommandParameterInfo("daysMask", Integer.class);
+        new CommandParameterInfo("daysMask", Integer.class, Integer.class);
     doorLocksetWeekDayScheduleCommandParams.put(
         "daysMask", doorLocksetWeekDayScheduledaysMaskCommandParameterInfo);
 
     CommandParameterInfo doorLocksetWeekDaySchedulestartHourCommandParameterInfo =
-        new CommandParameterInfo("startHour", Integer.class);
+        new CommandParameterInfo("startHour", Integer.class, Integer.class);
     doorLocksetWeekDayScheduleCommandParams.put(
         "startHour", doorLocksetWeekDaySchedulestartHourCommandParameterInfo);
 
     CommandParameterInfo doorLocksetWeekDaySchedulestartMinuteCommandParameterInfo =
-        new CommandParameterInfo("startMinute", Integer.class);
+        new CommandParameterInfo("startMinute", Integer.class, Integer.class);
     doorLocksetWeekDayScheduleCommandParams.put(
         "startMinute", doorLocksetWeekDaySchedulestartMinuteCommandParameterInfo);
 
     CommandParameterInfo doorLocksetWeekDayScheduleendHourCommandParameterInfo =
-        new CommandParameterInfo("endHour", Integer.class);
+        new CommandParameterInfo("endHour", Integer.class, Integer.class);
     doorLocksetWeekDayScheduleCommandParams.put(
         "endHour", doorLocksetWeekDayScheduleendHourCommandParameterInfo);
 
     CommandParameterInfo doorLocksetWeekDayScheduleendMinuteCommandParameterInfo =
-        new CommandParameterInfo("endMinute", Integer.class);
+        new CommandParameterInfo("endMinute", Integer.class, Integer.class);
     doorLocksetWeekDayScheduleCommandParams.put(
         "endMinute", doorLocksetWeekDayScheduleendMinuteCommandParameterInfo);
 
@@ -9614,22 +9614,22 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLocksetYearDayScheduleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLocksetYearDayScheduleyearDayIndexCommandParameterInfo =
-        new CommandParameterInfo("yearDayIndex", Integer.class);
+        new CommandParameterInfo("yearDayIndex", Integer.class, Integer.class);
     doorLocksetYearDayScheduleCommandParams.put(
         "yearDayIndex", doorLocksetYearDayScheduleyearDayIndexCommandParameterInfo);
 
     CommandParameterInfo doorLocksetYearDayScheduleuserIndexCommandParameterInfo =
-        new CommandParameterInfo("userIndex", Integer.class);
+        new CommandParameterInfo("userIndex", Integer.class, Integer.class);
     doorLocksetYearDayScheduleCommandParams.put(
         "userIndex", doorLocksetYearDayScheduleuserIndexCommandParameterInfo);
 
     CommandParameterInfo doorLocksetYearDaySchedulelocalStartTimeCommandParameterInfo =
-        new CommandParameterInfo("localStartTime", Long.class);
+        new CommandParameterInfo("localStartTime", Long.class, Long.class);
     doorLocksetYearDayScheduleCommandParams.put(
         "localStartTime", doorLocksetYearDaySchedulelocalStartTimeCommandParameterInfo);
 
     CommandParameterInfo doorLocksetYearDaySchedulelocalEndTimeCommandParameterInfo =
-        new CommandParameterInfo("localEndTime", Long.class);
+        new CommandParameterInfo("localEndTime", Long.class, Long.class);
     doorLocksetYearDayScheduleCommandParams.put(
         "localEndTime", doorLocksetYearDaySchedulelocalEndTimeCommandParameterInfo);
 
@@ -9651,7 +9651,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLockunlockDoorCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockunlockDoorpinCodeCommandParameterInfo =
-        new CommandParameterInfo("pinCode", Optional.class);
+        new CommandParameterInfo("pinCode", Optional.class, byte[].class);
     doorLockunlockDoorCommandParams.put("pinCode", doorLockunlockDoorpinCodeCommandParameterInfo);
 
     InteractionInfo doorLockunlockDoorInteractionInfo =
@@ -9669,12 +9669,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> doorLockunlockWithTimeoutCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockunlockWithTimeouttimeoutCommandParameterInfo =
-        new CommandParameterInfo("timeout", Integer.class);
+        new CommandParameterInfo("timeout", Integer.class, Integer.class);
     doorLockunlockWithTimeoutCommandParams.put(
         "timeout", doorLockunlockWithTimeouttimeoutCommandParameterInfo);
 
     CommandParameterInfo doorLockunlockWithTimeoutpinCodeCommandParameterInfo =
-        new CommandParameterInfo("pinCode", Optional.class);
+        new CommandParameterInfo("pinCode", Optional.class, byte[].class);
     doorLockunlockWithTimeoutCommandParams.put(
         "pinCode", doorLockunlockWithTimeoutpinCodeCommandParameterInfo);
 
@@ -9723,13 +9723,13 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> generalCommissioningarmFailSafeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo generalCommissioningarmFailSafeexpiryLengthSecondsCommandParameterInfo =
-        new CommandParameterInfo("expiryLengthSeconds", Integer.class);
+        new CommandParameterInfo("expiryLengthSeconds", Integer.class, Integer.class);
     generalCommissioningarmFailSafeCommandParams.put(
         "expiryLengthSeconds",
         generalCommissioningarmFailSafeexpiryLengthSecondsCommandParameterInfo);
 
     CommandParameterInfo generalCommissioningarmFailSafebreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Long.class);
+        new CommandParameterInfo("breadcrumb", Long.class, Long.class);
     generalCommissioningarmFailSafeCommandParams.put(
         "breadcrumb", generalCommissioningarmFailSafebreadcrumbCommandParameterInfo);
 
@@ -9766,18 +9766,18 @@ public class ClusterInfoMapping {
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         generalCommissioningsetRegulatoryConfignewRegulatoryConfigCommandParameterInfo =
-            new CommandParameterInfo("newRegulatoryConfig", Integer.class);
+            new CommandParameterInfo("newRegulatoryConfig", Integer.class, Integer.class);
     generalCommissioningsetRegulatoryConfigCommandParams.put(
         "newRegulatoryConfig",
         generalCommissioningsetRegulatoryConfignewRegulatoryConfigCommandParameterInfo);
 
     CommandParameterInfo generalCommissioningsetRegulatoryConfigcountryCodeCommandParameterInfo =
-        new CommandParameterInfo("countryCode", String.class);
+        new CommandParameterInfo("countryCode", String.class, String.class);
     generalCommissioningsetRegulatoryConfigCommandParams.put(
         "countryCode", generalCommissioningsetRegulatoryConfigcountryCodeCommandParameterInfo);
 
     CommandParameterInfo generalCommissioningsetRegulatoryConfigbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Long.class);
+        new CommandParameterInfo("breadcrumb", Long.class, Long.class);
     generalCommissioningsetRegulatoryConfigCommandParams.put(
         "breadcrumb", generalCommissioningsetRegulatoryConfigbreadcrumbCommandParameterInfo);
 
@@ -9805,7 +9805,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> groupKeyManagementkeySetReadCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo groupKeyManagementkeySetReadgroupKeySetIDCommandParameterInfo =
-        new CommandParameterInfo("groupKeySetID", Integer.class);
+        new CommandParameterInfo("groupKeySetID", Integer.class, Integer.class);
     groupKeyManagementkeySetReadCommandParams.put(
         "groupKeySetID", groupKeyManagementkeySetReadgroupKeySetIDCommandParameterInfo);
 
@@ -9824,7 +9824,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> groupKeyManagementkeySetReadAllIndicesCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo groupKeyManagementkeySetReadAllIndicesgroupKeySetIDsCommandParameterInfo =
-        new CommandParameterInfo("groupKeySetIDs", ArrayList.class);
+        new CommandParameterInfo("groupKeySetIDs", ArrayList.class, Object.class);
     groupKeyManagementkeySetReadAllIndicesCommandParams.put(
         "groupKeySetIDs", groupKeyManagementkeySetReadAllIndicesgroupKeySetIDsCommandParameterInfo);
 
@@ -9844,7 +9844,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> groupKeyManagementkeySetRemoveCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo groupKeyManagementkeySetRemovegroupKeySetIDCommandParameterInfo =
-        new CommandParameterInfo("groupKeySetID", Integer.class);
+        new CommandParameterInfo("groupKeySetID", Integer.class, Integer.class);
     groupKeyManagementkeySetRemoveCommandParams.put(
         "groupKeySetID", groupKeyManagementkeySetRemovegroupKeySetIDCommandParameterInfo);
 
@@ -9880,11 +9880,11 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> groupsaddGroupCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo groupsaddGroupgroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     groupsaddGroupCommandParams.put("groupId", groupsaddGroupgroupIdCommandParameterInfo);
 
     CommandParameterInfo groupsaddGroupgroupNameCommandParameterInfo =
-        new CommandParameterInfo("groupName", String.class);
+        new CommandParameterInfo("groupName", String.class, String.class);
     groupsaddGroupCommandParams.put("groupName", groupsaddGroupgroupNameCommandParameterInfo);
 
     InteractionInfo groupsaddGroupInteractionInfo =
@@ -9902,12 +9902,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> groupsaddGroupIfIdentifyingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo groupsaddGroupIfIdentifyinggroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     groupsaddGroupIfIdentifyingCommandParams.put(
         "groupId", groupsaddGroupIfIdentifyinggroupIdCommandParameterInfo);
 
     CommandParameterInfo groupsaddGroupIfIdentifyinggroupNameCommandParameterInfo =
-        new CommandParameterInfo("groupName", String.class);
+        new CommandParameterInfo("groupName", String.class, String.class);
     groupsaddGroupIfIdentifyingCommandParams.put(
         "groupName", groupsaddGroupIfIdentifyinggroupNameCommandParameterInfo);
 
@@ -9927,7 +9927,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> groupsgetGroupMembershipCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo groupsgetGroupMembershipgroupListCommandParameterInfo =
-        new CommandParameterInfo("groupList", ArrayList.class);
+        new CommandParameterInfo("groupList", ArrayList.class, Object.class);
     groupsgetGroupMembershipCommandParams.put(
         "groupList", groupsgetGroupMembershipgroupListCommandParameterInfo);
 
@@ -9957,7 +9957,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> groupsremoveGroupCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo groupsremoveGroupgroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     groupsremoveGroupCommandParams.put("groupId", groupsremoveGroupgroupIdCommandParameterInfo);
 
     InteractionInfo groupsremoveGroupInteractionInfo =
@@ -9974,7 +9974,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> groupsviewGroupCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo groupsviewGroupgroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     groupsviewGroupCommandParams.put("groupId", groupsviewGroupgroupIdCommandParameterInfo);
 
     InteractionInfo groupsviewGroupInteractionInfo =
@@ -9993,7 +9993,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> identifyidentifyCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo identifyidentifyidentifyTimeCommandParameterInfo =
-        new CommandParameterInfo("identifyTime", Integer.class);
+        new CommandParameterInfo("identifyTime", Integer.class, Integer.class);
     identifyidentifyCommandParams.put(
         "identifyTime", identifyidentifyidentifyTimeCommandParameterInfo);
 
@@ -10023,12 +10023,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> identifytriggerEffectCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo identifytriggerEffecteffectIdentifierCommandParameterInfo =
-        new CommandParameterInfo("effectIdentifier", Integer.class);
+        new CommandParameterInfo("effectIdentifier", Integer.class, Integer.class);
     identifytriggerEffectCommandParams.put(
         "effectIdentifier", identifytriggerEffecteffectIdentifierCommandParameterInfo);
 
     CommandParameterInfo identifytriggerEffecteffectVariantCommandParameterInfo =
-        new CommandParameterInfo("effectVariant", Integer.class);
+        new CommandParameterInfo("effectVariant", Integer.class, Integer.class);
     identifytriggerEffectCommandParams.put(
         "effectVariant", identifytriggerEffecteffectVariantCommandParameterInfo);
 
@@ -10052,7 +10052,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> keypadInputsendKeyCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo keypadInputsendKeykeyCodeCommandParameterInfo =
-        new CommandParameterInfo("keyCode", Integer.class);
+        new CommandParameterInfo("keyCode", Integer.class, Integer.class);
     keypadInputsendKeyCommandParams.put("keyCode", keypadInputsendKeykeyCodeCommandParameterInfo);
 
     InteractionInfo keypadInputsendKeyInteractionInfo =
@@ -10071,19 +10071,19 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> levelControlmoveCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlmovemoveModeCommandParameterInfo =
-        new CommandParameterInfo("moveMode", Integer.class);
+        new CommandParameterInfo("moveMode", Integer.class, Integer.class);
     levelControlmoveCommandParams.put("moveMode", levelControlmovemoveModeCommandParameterInfo);
 
     CommandParameterInfo levelControlmoverateCommandParameterInfo =
-        new CommandParameterInfo("rate", Integer.class);
+        new CommandParameterInfo("rate", Integer.class, Integer.class);
     levelControlmoveCommandParams.put("rate", levelControlmoverateCommandParameterInfo);
 
     CommandParameterInfo levelControlmoveoptionMaskCommandParameterInfo =
-        new CommandParameterInfo("optionMask", Integer.class);
+        new CommandParameterInfo("optionMask", Integer.class, Integer.class);
     levelControlmoveCommandParams.put("optionMask", levelControlmoveoptionMaskCommandParameterInfo);
 
     CommandParameterInfo levelControlmoveoptionOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionOverride", Integer.class);
+        new CommandParameterInfo("optionOverride", Integer.class, Integer.class);
     levelControlmoveCommandParams.put(
         "optionOverride", levelControlmoveoptionOverrideCommandParameterInfo);
 
@@ -10104,22 +10104,22 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> levelControlmoveToLevelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlmoveToLevellevelCommandParameterInfo =
-        new CommandParameterInfo("level", Integer.class);
+        new CommandParameterInfo("level", Integer.class, Integer.class);
     levelControlmoveToLevelCommandParams.put(
         "level", levelControlmoveToLevellevelCommandParameterInfo);
 
     CommandParameterInfo levelControlmoveToLeveltransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     levelControlmoveToLevelCommandParams.put(
         "transitionTime", levelControlmoveToLeveltransitionTimeCommandParameterInfo);
 
     CommandParameterInfo levelControlmoveToLeveloptionMaskCommandParameterInfo =
-        new CommandParameterInfo("optionMask", Integer.class);
+        new CommandParameterInfo("optionMask", Integer.class, Integer.class);
     levelControlmoveToLevelCommandParams.put(
         "optionMask", levelControlmoveToLeveloptionMaskCommandParameterInfo);
 
     CommandParameterInfo levelControlmoveToLeveloptionOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionOverride", Integer.class);
+        new CommandParameterInfo("optionOverride", Integer.class, Integer.class);
     levelControlmoveToLevelCommandParams.put(
         "optionOverride", levelControlmoveToLeveloptionOverrideCommandParameterInfo);
 
@@ -10141,12 +10141,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> levelControlmoveToLevelWithOnOffCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlmoveToLevelWithOnOfflevelCommandParameterInfo =
-        new CommandParameterInfo("level", Integer.class);
+        new CommandParameterInfo("level", Integer.class, Integer.class);
     levelControlmoveToLevelWithOnOffCommandParams.put(
         "level", levelControlmoveToLevelWithOnOfflevelCommandParameterInfo);
 
     CommandParameterInfo levelControlmoveToLevelWithOnOfftransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     levelControlmoveToLevelWithOnOffCommandParams.put(
         "transitionTime", levelControlmoveToLevelWithOnOfftransitionTimeCommandParameterInfo);
 
@@ -10166,12 +10166,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> levelControlmoveWithOnOffCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlmoveWithOnOffmoveModeCommandParameterInfo =
-        new CommandParameterInfo("moveMode", Integer.class);
+        new CommandParameterInfo("moveMode", Integer.class, Integer.class);
     levelControlmoveWithOnOffCommandParams.put(
         "moveMode", levelControlmoveWithOnOffmoveModeCommandParameterInfo);
 
     CommandParameterInfo levelControlmoveWithOnOffrateCommandParameterInfo =
-        new CommandParameterInfo("rate", Integer.class);
+        new CommandParameterInfo("rate", Integer.class, Integer.class);
     levelControlmoveWithOnOffCommandParams.put(
         "rate", levelControlmoveWithOnOffrateCommandParameterInfo);
 
@@ -10191,24 +10191,24 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> levelControlstepCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlstepstepModeCommandParameterInfo =
-        new CommandParameterInfo("stepMode", Integer.class);
+        new CommandParameterInfo("stepMode", Integer.class, Integer.class);
     levelControlstepCommandParams.put("stepMode", levelControlstepstepModeCommandParameterInfo);
 
     CommandParameterInfo levelControlstepstepSizeCommandParameterInfo =
-        new CommandParameterInfo("stepSize", Integer.class);
+        new CommandParameterInfo("stepSize", Integer.class, Integer.class);
     levelControlstepCommandParams.put("stepSize", levelControlstepstepSizeCommandParameterInfo);
 
     CommandParameterInfo levelControlsteptransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     levelControlstepCommandParams.put(
         "transitionTime", levelControlsteptransitionTimeCommandParameterInfo);
 
     CommandParameterInfo levelControlstepoptionMaskCommandParameterInfo =
-        new CommandParameterInfo("optionMask", Integer.class);
+        new CommandParameterInfo("optionMask", Integer.class, Integer.class);
     levelControlstepCommandParams.put("optionMask", levelControlstepoptionMaskCommandParameterInfo);
 
     CommandParameterInfo levelControlstepoptionOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionOverride", Integer.class);
+        new CommandParameterInfo("optionOverride", Integer.class, Integer.class);
     levelControlstepCommandParams.put(
         "optionOverride", levelControlstepoptionOverrideCommandParameterInfo);
 
@@ -10230,17 +10230,17 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> levelControlstepWithOnOffCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlstepWithOnOffstepModeCommandParameterInfo =
-        new CommandParameterInfo("stepMode", Integer.class);
+        new CommandParameterInfo("stepMode", Integer.class, Integer.class);
     levelControlstepWithOnOffCommandParams.put(
         "stepMode", levelControlstepWithOnOffstepModeCommandParameterInfo);
 
     CommandParameterInfo levelControlstepWithOnOffstepSizeCommandParameterInfo =
-        new CommandParameterInfo("stepSize", Integer.class);
+        new CommandParameterInfo("stepSize", Integer.class, Integer.class);
     levelControlstepWithOnOffCommandParams.put(
         "stepSize", levelControlstepWithOnOffstepSizeCommandParameterInfo);
 
     CommandParameterInfo levelControlstepWithOnOfftransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     levelControlstepWithOnOffCommandParams.put(
         "transitionTime", levelControlstepWithOnOfftransitionTimeCommandParameterInfo);
 
@@ -10261,11 +10261,11 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> levelControlstopCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlstopoptionMaskCommandParameterInfo =
-        new CommandParameterInfo("optionMask", Integer.class);
+        new CommandParameterInfo("optionMask", Integer.class, Integer.class);
     levelControlstopCommandParams.put("optionMask", levelControlstopoptionMaskCommandParameterInfo);
 
     CommandParameterInfo levelControlstopoptionOverrideCommandParameterInfo =
-        new CommandParameterInfo("optionOverride", Integer.class);
+        new CommandParameterInfo("optionOverride", Integer.class, Integer.class);
     levelControlstopCommandParams.put(
         "optionOverride", levelControlstopoptionOverrideCommandParameterInfo);
 
@@ -10325,11 +10325,11 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> mediaInputrenameInputCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo mediaInputrenameInputindexCommandParameterInfo =
-        new CommandParameterInfo("index", Integer.class);
+        new CommandParameterInfo("index", Integer.class, Integer.class);
     mediaInputrenameInputCommandParams.put("index", mediaInputrenameInputindexCommandParameterInfo);
 
     CommandParameterInfo mediaInputrenameInputnameCommandParameterInfo =
-        new CommandParameterInfo("name", String.class);
+        new CommandParameterInfo("name", String.class, String.class);
     mediaInputrenameInputCommandParams.put("name", mediaInputrenameInputnameCommandParameterInfo);
 
     InteractionInfo mediaInputrenameInputInteractionInfo =
@@ -10347,7 +10347,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> mediaInputselectInputCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo mediaInputselectInputindexCommandParameterInfo =
-        new CommandParameterInfo("index", Integer.class);
+        new CommandParameterInfo("index", Integer.class, Integer.class);
     mediaInputselectInputCommandParams.put("index", mediaInputselectInputindexCommandParameterInfo);
 
     InteractionInfo mediaInputselectInputInteractionInfo =
@@ -10445,7 +10445,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> mediaPlaybackseekCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo mediaPlaybackseekpositionCommandParameterInfo =
-        new CommandParameterInfo("position", Long.class);
+        new CommandParameterInfo("position", Long.class, Long.class);
     mediaPlaybackseekCommandParams.put("position", mediaPlaybackseekpositionCommandParameterInfo);
 
     InteractionInfo mediaPlaybackseekInteractionInfo =
@@ -10462,7 +10462,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> mediaPlaybackskipBackwardCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo mediaPlaybackskipBackwarddeltaPositionMillisecondsCommandParameterInfo =
-        new CommandParameterInfo("deltaPositionMilliseconds", Long.class);
+        new CommandParameterInfo("deltaPositionMilliseconds", Long.class, Long.class);
     mediaPlaybackskipBackwardCommandParams.put(
         "deltaPositionMilliseconds",
         mediaPlaybackskipBackwarddeltaPositionMillisecondsCommandParameterInfo);
@@ -10482,7 +10482,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> mediaPlaybackskipForwardCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo mediaPlaybackskipForwarddeltaPositionMillisecondsCommandParameterInfo =
-        new CommandParameterInfo("deltaPositionMilliseconds", Long.class);
+        new CommandParameterInfo("deltaPositionMilliseconds", Long.class, Long.class);
     mediaPlaybackskipForwardCommandParams.put(
         "deltaPositionMilliseconds",
         mediaPlaybackskipForwarddeltaPositionMillisecondsCommandParameterInfo);
@@ -10528,7 +10528,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> modeSelectchangeToModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo modeSelectchangeToModenewModeCommandParameterInfo =
-        new CommandParameterInfo("newMode", Integer.class);
+        new CommandParameterInfo("newMode", Integer.class, Integer.class);
     modeSelectchangeToModeCommandParams.put(
         "newMode", modeSelectchangeToModenewModeCommandParameterInfo);
 
@@ -10549,14 +10549,14 @@ public class ClusterInfoMapping {
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         networkCommissioningaddOrUpdateThreadNetworkoperationalDatasetCommandParameterInfo =
-            new CommandParameterInfo("operationalDataset", byte[].class);
+            new CommandParameterInfo("operationalDataset", byte[].class, byte[].class);
     networkCommissioningaddOrUpdateThreadNetworkCommandParams.put(
         "operationalDataset",
         networkCommissioningaddOrUpdateThreadNetworkoperationalDatasetCommandParameterInfo);
 
     CommandParameterInfo
         networkCommissioningaddOrUpdateThreadNetworkbreadcrumbCommandParameterInfo =
-            new CommandParameterInfo("breadcrumb", Optional.class);
+            new CommandParameterInfo("breadcrumb", Optional.class, Long.class);
     networkCommissioningaddOrUpdateThreadNetworkCommandParams.put(
         "breadcrumb", networkCommissioningaddOrUpdateThreadNetworkbreadcrumbCommandParameterInfo);
 
@@ -10577,17 +10577,17 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> networkCommissioningaddOrUpdateWiFiNetworkCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo networkCommissioningaddOrUpdateWiFiNetworkssidCommandParameterInfo =
-        new CommandParameterInfo("ssid", byte[].class);
+        new CommandParameterInfo("ssid", byte[].class, byte[].class);
     networkCommissioningaddOrUpdateWiFiNetworkCommandParams.put(
         "ssid", networkCommissioningaddOrUpdateWiFiNetworkssidCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningaddOrUpdateWiFiNetworkcredentialsCommandParameterInfo =
-        new CommandParameterInfo("credentials", byte[].class);
+        new CommandParameterInfo("credentials", byte[].class, byte[].class);
     networkCommissioningaddOrUpdateWiFiNetworkCommandParams.put(
         "credentials", networkCommissioningaddOrUpdateWiFiNetworkcredentialsCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningaddOrUpdateWiFiNetworkbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Optional.class);
+        new CommandParameterInfo("breadcrumb", Optional.class, Long.class);
     networkCommissioningaddOrUpdateWiFiNetworkCommandParams.put(
         "breadcrumb", networkCommissioningaddOrUpdateWiFiNetworkbreadcrumbCommandParameterInfo);
 
@@ -10609,12 +10609,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> networkCommissioningconnectNetworkCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo networkCommissioningconnectNetworknetworkIDCommandParameterInfo =
-        new CommandParameterInfo("networkID", byte[].class);
+        new CommandParameterInfo("networkID", byte[].class, byte[].class);
     networkCommissioningconnectNetworkCommandParams.put(
         "networkID", networkCommissioningconnectNetworknetworkIDCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningconnectNetworkbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Optional.class);
+        new CommandParameterInfo("breadcrumb", Optional.class, Long.class);
     networkCommissioningconnectNetworkCommandParams.put(
         "breadcrumb", networkCommissioningconnectNetworkbreadcrumbCommandParameterInfo);
 
@@ -10635,12 +10635,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> networkCommissioningremoveNetworkCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo networkCommissioningremoveNetworknetworkIDCommandParameterInfo =
-        new CommandParameterInfo("networkID", byte[].class);
+        new CommandParameterInfo("networkID", byte[].class, byte[].class);
     networkCommissioningremoveNetworkCommandParams.put(
         "networkID", networkCommissioningremoveNetworknetworkIDCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningremoveNetworkbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Optional.class);
+        new CommandParameterInfo("breadcrumb", Optional.class, Long.class);
     networkCommissioningremoveNetworkCommandParams.put(
         "breadcrumb", networkCommissioningremoveNetworkbreadcrumbCommandParameterInfo);
 
@@ -10661,17 +10661,17 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> networkCommissioningreorderNetworkCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo networkCommissioningreorderNetworknetworkIDCommandParameterInfo =
-        new CommandParameterInfo("networkID", byte[].class);
+        new CommandParameterInfo("networkID", byte[].class, byte[].class);
     networkCommissioningreorderNetworkCommandParams.put(
         "networkID", networkCommissioningreorderNetworknetworkIDCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningreorderNetworknetworkIndexCommandParameterInfo =
-        new CommandParameterInfo("networkIndex", Integer.class);
+        new CommandParameterInfo("networkIndex", Integer.class, Integer.class);
     networkCommissioningreorderNetworkCommandParams.put(
         "networkIndex", networkCommissioningreorderNetworknetworkIndexCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningreorderNetworkbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Optional.class);
+        new CommandParameterInfo("breadcrumb", Optional.class, Long.class);
     networkCommissioningreorderNetworkCommandParams.put(
         "breadcrumb", networkCommissioningreorderNetworkbreadcrumbCommandParameterInfo);
 
@@ -10693,12 +10693,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> networkCommissioningscanNetworksCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo networkCommissioningscanNetworksssidCommandParameterInfo =
-        new CommandParameterInfo("ssid", Optional.class);
+        new CommandParameterInfo("ssid", Optional.class, byte[].class);
     networkCommissioningscanNetworksCommandParams.put(
         "ssid", networkCommissioningscanNetworksssidCommandParameterInfo);
 
     CommandParameterInfo networkCommissioningscanNetworksbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("breadcrumb", Optional.class);
+        new CommandParameterInfo("breadcrumb", Optional.class, Long.class);
     networkCommissioningscanNetworksCommandParams.put(
         "breadcrumb", networkCommissioningscanNetworksbreadcrumbCommandParameterInfo);
 
@@ -10723,12 +10723,12 @@ public class ClusterInfoMapping {
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         otaSoftwareUpdateProviderapplyUpdateRequestupdateTokenCommandParameterInfo =
-            new CommandParameterInfo("updateToken", byte[].class);
+            new CommandParameterInfo("updateToken", byte[].class, byte[].class);
     otaSoftwareUpdateProviderapplyUpdateRequestCommandParams.put(
         "updateToken", otaSoftwareUpdateProviderapplyUpdateRequestupdateTokenCommandParameterInfo);
 
     CommandParameterInfo otaSoftwareUpdateProviderapplyUpdateRequestnewVersionCommandParameterInfo =
-        new CommandParameterInfo("newVersion", Long.class);
+        new CommandParameterInfo("newVersion", Long.class, Long.class);
     otaSoftwareUpdateProviderapplyUpdateRequestCommandParams.put(
         "newVersion", otaSoftwareUpdateProviderapplyUpdateRequestnewVersionCommandParameterInfo);
 
@@ -10750,13 +10750,13 @@ public class ClusterInfoMapping {
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         otaSoftwareUpdateProvidernotifyUpdateAppliedupdateTokenCommandParameterInfo =
-            new CommandParameterInfo("updateToken", byte[].class);
+            new CommandParameterInfo("updateToken", byte[].class, byte[].class);
     otaSoftwareUpdateProvidernotifyUpdateAppliedCommandParams.put(
         "updateToken", otaSoftwareUpdateProvidernotifyUpdateAppliedupdateTokenCommandParameterInfo);
 
     CommandParameterInfo
         otaSoftwareUpdateProvidernotifyUpdateAppliedsoftwareVersionCommandParameterInfo =
-            new CommandParameterInfo("softwareVersion", Long.class);
+            new CommandParameterInfo("softwareVersion", Long.class, Long.class);
     otaSoftwareUpdateProvidernotifyUpdateAppliedCommandParams.put(
         "softwareVersion",
         otaSoftwareUpdateProvidernotifyUpdateAppliedsoftwareVersionCommandParameterInfo);
@@ -10777,46 +10777,46 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> otaSoftwareUpdateProviderqueryImageCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo otaSoftwareUpdateProviderqueryImagevendorIdCommandParameterInfo =
-        new CommandParameterInfo("vendorId", Integer.class);
+        new CommandParameterInfo("vendorId", Integer.class, Integer.class);
     otaSoftwareUpdateProviderqueryImageCommandParams.put(
         "vendorId", otaSoftwareUpdateProviderqueryImagevendorIdCommandParameterInfo);
 
     CommandParameterInfo otaSoftwareUpdateProviderqueryImageproductIdCommandParameterInfo =
-        new CommandParameterInfo("productId", Integer.class);
+        new CommandParameterInfo("productId", Integer.class, Integer.class);
     otaSoftwareUpdateProviderqueryImageCommandParams.put(
         "productId", otaSoftwareUpdateProviderqueryImageproductIdCommandParameterInfo);
 
     CommandParameterInfo otaSoftwareUpdateProviderqueryImagesoftwareVersionCommandParameterInfo =
-        new CommandParameterInfo("softwareVersion", Long.class);
+        new CommandParameterInfo("softwareVersion", Long.class, Long.class);
     otaSoftwareUpdateProviderqueryImageCommandParams.put(
         "softwareVersion", otaSoftwareUpdateProviderqueryImagesoftwareVersionCommandParameterInfo);
 
     CommandParameterInfo otaSoftwareUpdateProviderqueryImageprotocolsSupportedCommandParameterInfo =
-        new CommandParameterInfo("protocolsSupported", ArrayList.class);
+        new CommandParameterInfo("protocolsSupported", ArrayList.class, Object.class);
     otaSoftwareUpdateProviderqueryImageCommandParams.put(
         "protocolsSupported",
         otaSoftwareUpdateProviderqueryImageprotocolsSupportedCommandParameterInfo);
 
     CommandParameterInfo otaSoftwareUpdateProviderqueryImagehardwareVersionCommandParameterInfo =
-        new CommandParameterInfo("hardwareVersion", Optional.class);
+        new CommandParameterInfo("hardwareVersion", Optional.class, Integer.class);
     otaSoftwareUpdateProviderqueryImageCommandParams.put(
         "hardwareVersion", otaSoftwareUpdateProviderqueryImagehardwareVersionCommandParameterInfo);
 
     CommandParameterInfo otaSoftwareUpdateProviderqueryImagelocationCommandParameterInfo =
-        new CommandParameterInfo("location", Optional.class);
+        new CommandParameterInfo("location", Optional.class, String.class);
     otaSoftwareUpdateProviderqueryImageCommandParams.put(
         "location", otaSoftwareUpdateProviderqueryImagelocationCommandParameterInfo);
 
     CommandParameterInfo
         otaSoftwareUpdateProviderqueryImagerequestorCanConsentCommandParameterInfo =
-            new CommandParameterInfo("requestorCanConsent", Optional.class);
+            new CommandParameterInfo("requestorCanConsent", Optional.class, Boolean.class);
     otaSoftwareUpdateProviderqueryImageCommandParams.put(
         "requestorCanConsent",
         otaSoftwareUpdateProviderqueryImagerequestorCanConsentCommandParameterInfo);
 
     CommandParameterInfo
         otaSoftwareUpdateProviderqueryImagemetadataForProviderCommandParameterInfo =
-            new CommandParameterInfo("metadataForProvider", Optional.class);
+            new CommandParameterInfo("metadataForProvider", Optional.class, byte[].class);
     otaSoftwareUpdateProviderqueryImageCommandParams.put(
         "metadataForProvider",
         otaSoftwareUpdateProviderqueryImagemetadataForProviderCommandParameterInfo);
@@ -10848,32 +10848,32 @@ public class ClusterInfoMapping {
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         otaSoftwareUpdateRequestorannounceOtaProviderproviderNodeIdCommandParameterInfo =
-            new CommandParameterInfo("providerNodeId", Long.class);
+            new CommandParameterInfo("providerNodeId", Long.class, Long.class);
     otaSoftwareUpdateRequestorannounceOtaProviderCommandParams.put(
         "providerNodeId",
         otaSoftwareUpdateRequestorannounceOtaProviderproviderNodeIdCommandParameterInfo);
 
     CommandParameterInfo otaSoftwareUpdateRequestorannounceOtaProvidervendorIdCommandParameterInfo =
-        new CommandParameterInfo("vendorId", Integer.class);
+        new CommandParameterInfo("vendorId", Integer.class, Integer.class);
     otaSoftwareUpdateRequestorannounceOtaProviderCommandParams.put(
         "vendorId", otaSoftwareUpdateRequestorannounceOtaProvidervendorIdCommandParameterInfo);
 
     CommandParameterInfo
         otaSoftwareUpdateRequestorannounceOtaProviderannouncementReasonCommandParameterInfo =
-            new CommandParameterInfo("announcementReason", Integer.class);
+            new CommandParameterInfo("announcementReason", Integer.class, Integer.class);
     otaSoftwareUpdateRequestorannounceOtaProviderCommandParams.put(
         "announcementReason",
         otaSoftwareUpdateRequestorannounceOtaProviderannouncementReasonCommandParameterInfo);
 
     CommandParameterInfo
         otaSoftwareUpdateRequestorannounceOtaProvidermetadataForNodeCommandParameterInfo =
-            new CommandParameterInfo("metadataForNode", Optional.class);
+            new CommandParameterInfo("metadataForNode", Optional.class, byte[].class);
     otaSoftwareUpdateRequestorannounceOtaProviderCommandParams.put(
         "metadataForNode",
         otaSoftwareUpdateRequestorannounceOtaProvidermetadataForNodeCommandParameterInfo);
 
     CommandParameterInfo otaSoftwareUpdateRequestorannounceOtaProviderendpointCommandParameterInfo =
-        new CommandParameterInfo("endpoint", Integer.class);
+        new CommandParameterInfo("endpoint", Integer.class, Integer.class);
     otaSoftwareUpdateRequestorannounceOtaProviderCommandParams.put(
         "endpoint", otaSoftwareUpdateRequestorannounceOtaProviderendpointCommandParameterInfo);
 
@@ -10911,11 +10911,11 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> onOffoffWithEffectCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo onOffoffWithEffecteffectIdCommandParameterInfo =
-        new CommandParameterInfo("effectId", Integer.class);
+        new CommandParameterInfo("effectId", Integer.class, Integer.class);
     onOffoffWithEffectCommandParams.put("effectId", onOffoffWithEffecteffectIdCommandParameterInfo);
 
     CommandParameterInfo onOffoffWithEffecteffectVariantCommandParameterInfo =
-        new CommandParameterInfo("effectVariant", Integer.class);
+        new CommandParameterInfo("effectVariant", Integer.class, Integer.class);
     onOffoffWithEffectCommandParams.put(
         "effectVariant", onOffoffWithEffecteffectVariantCommandParameterInfo);
 
@@ -10956,16 +10956,16 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> onOffonWithTimedOffCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo onOffonWithTimedOffonOffControlCommandParameterInfo =
-        new CommandParameterInfo("onOffControl", Integer.class);
+        new CommandParameterInfo("onOffControl", Integer.class, Integer.class);
     onOffonWithTimedOffCommandParams.put(
         "onOffControl", onOffonWithTimedOffonOffControlCommandParameterInfo);
 
     CommandParameterInfo onOffonWithTimedOffonTimeCommandParameterInfo =
-        new CommandParameterInfo("onTime", Integer.class);
+        new CommandParameterInfo("onTime", Integer.class, Integer.class);
     onOffonWithTimedOffCommandParams.put("onTime", onOffonWithTimedOffonTimeCommandParameterInfo);
 
     CommandParameterInfo onOffonWithTimedOffoffWaitTimeCommandParameterInfo =
-        new CommandParameterInfo("offWaitTime", Integer.class);
+        new CommandParameterInfo("offWaitTime", Integer.class, Integer.class);
     onOffonWithTimedOffCommandParams.put(
         "offWaitTime", onOffonWithTimedOffoffWaitTimeCommandParameterInfo);
 
@@ -11001,27 +11001,27 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> operationalCredentialsaddNOCCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo operationalCredentialsaddNOCNOCValueCommandParameterInfo =
-        new CommandParameterInfo("NOCValue", byte[].class);
+        new CommandParameterInfo("NOCValue", byte[].class, byte[].class);
     operationalCredentialsaddNOCCommandParams.put(
         "NOCValue", operationalCredentialsaddNOCNOCValueCommandParameterInfo);
 
     CommandParameterInfo operationalCredentialsaddNOCICACValueCommandParameterInfo =
-        new CommandParameterInfo("ICACValue", Optional.class);
+        new CommandParameterInfo("ICACValue", Optional.class, byte[].class);
     operationalCredentialsaddNOCCommandParams.put(
         "ICACValue", operationalCredentialsaddNOCICACValueCommandParameterInfo);
 
     CommandParameterInfo operationalCredentialsaddNOCIPKValueCommandParameterInfo =
-        new CommandParameterInfo("IPKValue", byte[].class);
+        new CommandParameterInfo("IPKValue", byte[].class, byte[].class);
     operationalCredentialsaddNOCCommandParams.put(
         "IPKValue", operationalCredentialsaddNOCIPKValueCommandParameterInfo);
 
     CommandParameterInfo operationalCredentialsaddNOCcaseAdminNodeCommandParameterInfo =
-        new CommandParameterInfo("caseAdminNode", Long.class);
+        new CommandParameterInfo("caseAdminNode", Long.class, Long.class);
     operationalCredentialsaddNOCCommandParams.put(
         "caseAdminNode", operationalCredentialsaddNOCcaseAdminNodeCommandParameterInfo);
 
     CommandParameterInfo operationalCredentialsaddNOCadminVendorIdCommandParameterInfo =
-        new CommandParameterInfo("adminVendorId", Integer.class);
+        new CommandParameterInfo("adminVendorId", Integer.class, Integer.class);
     operationalCredentialsaddNOCCommandParams.put(
         "adminVendorId", operationalCredentialsaddNOCadminVendorIdCommandParameterInfo);
 
@@ -11045,7 +11045,7 @@ public class ClusterInfoMapping {
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         operationalCredentialsaddTrustedRootCertificaterootCertificateCommandParameterInfo =
-            new CommandParameterInfo("rootCertificate", byte[].class);
+            new CommandParameterInfo("rootCertificate", byte[].class, byte[].class);
     operationalCredentialsaddTrustedRootCertificateCommandParams.put(
         "rootCertificate",
         operationalCredentialsaddTrustedRootCertificaterootCertificateCommandParameterInfo);
@@ -11067,7 +11067,7 @@ public class ClusterInfoMapping {
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         operationalCredentialsattestationRequestattestationNonceCommandParameterInfo =
-            new CommandParameterInfo("attestationNonce", byte[].class);
+            new CommandParameterInfo("attestationNonce", byte[].class, byte[].class);
     operationalCredentialsattestationRequestCommandParams.put(
         "attestationNonce",
         operationalCredentialsattestationRequestattestationNonceCommandParameterInfo);
@@ -11088,7 +11088,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> operationalCredentialsCSRRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo operationalCredentialsCSRRequestCSRNonceCommandParameterInfo =
-        new CommandParameterInfo("CSRNonce", byte[].class);
+        new CommandParameterInfo("CSRNonce", byte[].class, byte[].class);
     operationalCredentialsCSRRequestCommandParams.put(
         "CSRNonce", operationalCredentialsCSRRequestCSRNonceCommandParameterInfo);
 
@@ -11108,7 +11108,7 @@ public class ClusterInfoMapping {
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         operationalCredentialscertificateChainRequestcertificateTypeCommandParameterInfo =
-            new CommandParameterInfo("certificateType", Integer.class);
+            new CommandParameterInfo("certificateType", Integer.class, Integer.class);
     operationalCredentialscertificateChainRequestCommandParams.put(
         "certificateType",
         operationalCredentialscertificateChainRequestcertificateTypeCommandParameterInfo);
@@ -11129,7 +11129,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> operationalCredentialsremoveFabricCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo operationalCredentialsremoveFabricfabricIndexCommandParameterInfo =
-        new CommandParameterInfo("fabricIndex", Integer.class);
+        new CommandParameterInfo("fabricIndex", Integer.class, Integer.class);
     operationalCredentialsremoveFabricCommandParams.put(
         "fabricIndex", operationalCredentialsremoveFabricfabricIndexCommandParameterInfo);
 
@@ -11150,7 +11150,7 @@ public class ClusterInfoMapping {
             new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         operationalCredentialsremoveTrustedRootCertificatetrustedRootIdentifierCommandParameterInfo =
-            new CommandParameterInfo("trustedRootIdentifier", byte[].class);
+            new CommandParameterInfo("trustedRootIdentifier", byte[].class, byte[].class);
     operationalCredentialsremoveTrustedRootCertificateCommandParams.put(
         "trustedRootIdentifier",
         operationalCredentialsremoveTrustedRootCertificatetrustedRootIdentifierCommandParameterInfo);
@@ -11171,7 +11171,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> operationalCredentialsupdateFabricLabelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo operationalCredentialsupdateFabricLabellabelCommandParameterInfo =
-        new CommandParameterInfo("label", String.class);
+        new CommandParameterInfo("label", String.class, String.class);
     operationalCredentialsupdateFabricLabelCommandParams.put(
         "label", operationalCredentialsupdateFabricLabellabelCommandParameterInfo);
 
@@ -11190,12 +11190,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> operationalCredentialsupdateNOCCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo operationalCredentialsupdateNOCNOCValueCommandParameterInfo =
-        new CommandParameterInfo("NOCValue", byte[].class);
+        new CommandParameterInfo("NOCValue", byte[].class, byte[].class);
     operationalCredentialsupdateNOCCommandParams.put(
         "NOCValue", operationalCredentialsupdateNOCNOCValueCommandParameterInfo);
 
     CommandParameterInfo operationalCredentialsupdateNOCICACValueCommandParameterInfo =
-        new CommandParameterInfo("ICACValue", Optional.class);
+        new CommandParameterInfo("ICACValue", Optional.class, byte[].class);
     operationalCredentialsupdateNOCCommandParams.put(
         "ICACValue", operationalCredentialsupdateNOCICACValueCommandParameterInfo);
 
@@ -11233,20 +11233,20 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> scenesaddSceneCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo scenesaddScenegroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     scenesaddSceneCommandParams.put("groupId", scenesaddScenegroupIdCommandParameterInfo);
 
     CommandParameterInfo scenesaddScenesceneIdCommandParameterInfo =
-        new CommandParameterInfo("sceneId", Integer.class);
+        new CommandParameterInfo("sceneId", Integer.class, Integer.class);
     scenesaddSceneCommandParams.put("sceneId", scenesaddScenesceneIdCommandParameterInfo);
 
     CommandParameterInfo scenesaddScenetransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     scenesaddSceneCommandParams.put(
         "transitionTime", scenesaddScenetransitionTimeCommandParameterInfo);
 
     CommandParameterInfo scenesaddScenesceneNameCommandParameterInfo =
-        new CommandParameterInfo("sceneName", String.class);
+        new CommandParameterInfo("sceneName", String.class, String.class);
     scenesaddSceneCommandParams.put("sceneName", scenesaddScenesceneNameCommandParameterInfo);
 
     InteractionInfo scenesaddSceneInteractionInfo =
@@ -11268,7 +11268,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> scenesgetSceneMembershipCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo scenesgetSceneMembershipgroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     scenesgetSceneMembershipCommandParams.put(
         "groupId", scenesgetSceneMembershipgroupIdCommandParameterInfo);
 
@@ -11287,15 +11287,15 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> scenesrecallSceneCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo scenesrecallScenegroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     scenesrecallSceneCommandParams.put("groupId", scenesrecallScenegroupIdCommandParameterInfo);
 
     CommandParameterInfo scenesrecallScenesceneIdCommandParameterInfo =
-        new CommandParameterInfo("sceneId", Integer.class);
+        new CommandParameterInfo("sceneId", Integer.class, Integer.class);
     scenesrecallSceneCommandParams.put("sceneId", scenesrecallScenesceneIdCommandParameterInfo);
 
     CommandParameterInfo scenesrecallScenetransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("transitionTime", Integer.class);
+        new CommandParameterInfo("transitionTime", Integer.class, Integer.class);
     scenesrecallSceneCommandParams.put(
         "transitionTime", scenesrecallScenetransitionTimeCommandParameterInfo);
 
@@ -11315,7 +11315,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> scenesremoveAllScenesCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo scenesremoveAllScenesgroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     scenesremoveAllScenesCommandParams.put(
         "groupId", scenesremoveAllScenesgroupIdCommandParameterInfo);
 
@@ -11333,11 +11333,11 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> scenesremoveSceneCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo scenesremoveScenegroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     scenesremoveSceneCommandParams.put("groupId", scenesremoveScenegroupIdCommandParameterInfo);
 
     CommandParameterInfo scenesremoveScenesceneIdCommandParameterInfo =
-        new CommandParameterInfo("sceneId", Integer.class);
+        new CommandParameterInfo("sceneId", Integer.class, Integer.class);
     scenesremoveSceneCommandParams.put("sceneId", scenesremoveScenesceneIdCommandParameterInfo);
 
     InteractionInfo scenesremoveSceneInteractionInfo =
@@ -11355,11 +11355,11 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> scenesstoreSceneCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo scenesstoreScenegroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     scenesstoreSceneCommandParams.put("groupId", scenesstoreScenegroupIdCommandParameterInfo);
 
     CommandParameterInfo scenesstoreScenesceneIdCommandParameterInfo =
-        new CommandParameterInfo("sceneId", Integer.class);
+        new CommandParameterInfo("sceneId", Integer.class, Integer.class);
     scenesstoreSceneCommandParams.put("sceneId", scenesstoreScenesceneIdCommandParameterInfo);
 
     InteractionInfo scenesstoreSceneInteractionInfo =
@@ -11377,11 +11377,11 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> scenesviewSceneCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo scenesviewScenegroupIdCommandParameterInfo =
-        new CommandParameterInfo("groupId", Integer.class);
+        new CommandParameterInfo("groupId", Integer.class, Integer.class);
     scenesviewSceneCommandParams.put("groupId", scenesviewScenegroupIdCommandParameterInfo);
 
     CommandParameterInfo scenesviewScenesceneIdCommandParameterInfo =
-        new CommandParameterInfo("sceneId", Integer.class);
+        new CommandParameterInfo("sceneId", Integer.class, Integer.class);
     scenesviewSceneCommandParams.put("sceneId", scenesviewScenesceneIdCommandParameterInfo);
 
     InteractionInfo scenesviewSceneInteractionInfo =
@@ -11418,12 +11418,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> targetNavigatornavigateTargetCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo targetNavigatornavigateTargettargetCommandParameterInfo =
-        new CommandParameterInfo("target", Integer.class);
+        new CommandParameterInfo("target", Integer.class, Integer.class);
     targetNavigatornavigateTargetCommandParams.put(
         "target", targetNavigatornavigateTargettargetCommandParameterInfo);
 
     CommandParameterInfo targetNavigatornavigateTargetdataCommandParameterInfo =
-        new CommandParameterInfo("data", Optional.class);
+        new CommandParameterInfo("data", Optional.class, String.class);
     targetNavigatornavigateTargetCommandParams.put(
         "data", targetNavigatornavigateTargetdataCommandParameterInfo);
 
@@ -11472,12 +11472,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> testClustertestAddArgumentsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustertestAddArgumentsarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", Integer.class);
+        new CommandParameterInfo("arg1", Integer.class, Integer.class);
     testClustertestAddArgumentsCommandParams.put(
         "arg1", testClustertestAddArgumentsarg1CommandParameterInfo);
 
     CommandParameterInfo testClustertestAddArgumentsarg2CommandParameterInfo =
-        new CommandParameterInfo("arg2", Integer.class);
+        new CommandParameterInfo("arg2", Integer.class, Integer.class);
     testClustertestAddArgumentsCommandParams.put(
         "arg2", testClustertestAddArgumentsarg2CommandParameterInfo);
 
@@ -11497,17 +11497,17 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> testClustertestEmitTestEventRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustertestEmitTestEventRequestarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", Integer.class);
+        new CommandParameterInfo("arg1", Integer.class, Integer.class);
     testClustertestEmitTestEventRequestCommandParams.put(
         "arg1", testClustertestEmitTestEventRequestarg1CommandParameterInfo);
 
     CommandParameterInfo testClustertestEmitTestEventRequestarg2CommandParameterInfo =
-        new CommandParameterInfo("arg2", Integer.class);
+        new CommandParameterInfo("arg2", Integer.class, Integer.class);
     testClustertestEmitTestEventRequestCommandParams.put(
         "arg2", testClustertestEmitTestEventRequestarg2CommandParameterInfo);
 
     CommandParameterInfo testClustertestEmitTestEventRequestarg3CommandParameterInfo =
-        new CommandParameterInfo("arg3", Boolean.class);
+        new CommandParameterInfo("arg3", Boolean.class, Boolean.class);
     testClustertestEmitTestEventRequestCommandParams.put(
         "arg3", testClustertestEmitTestEventRequestarg3CommandParameterInfo);
 
@@ -11528,12 +11528,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> testClustertestEnumsRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustertestEnumsRequestarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", Integer.class);
+        new CommandParameterInfo("arg1", Integer.class, Integer.class);
     testClustertestEnumsRequestCommandParams.put(
         "arg1", testClustertestEnumsRequestarg1CommandParameterInfo);
 
     CommandParameterInfo testClustertestEnumsRequestarg2CommandParameterInfo =
-        new CommandParameterInfo("arg2", Integer.class);
+        new CommandParameterInfo("arg2", Integer.class, Integer.class);
     testClustertestEnumsRequestCommandParams.put(
         "arg2", testClustertestEnumsRequestarg2CommandParameterInfo);
 
@@ -11553,7 +11553,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> testClustertestListInt8UArgumentRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustertestListInt8UArgumentRequestarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", ArrayList.class);
+        new CommandParameterInfo("arg1", ArrayList.class, Object.class);
     testClustertestListInt8UArgumentRequestCommandParams.put(
         "arg1", testClustertestListInt8UArgumentRequestarg1CommandParameterInfo);
 
@@ -11572,7 +11572,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> testClustertestListInt8UReverseRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustertestListInt8UReverseRequestarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", ArrayList.class);
+        new CommandParameterInfo("arg1", ArrayList.class, Object.class);
     testClustertestListInt8UReverseRequestCommandParams.put(
         "arg1", testClustertestListInt8UReverseRequestarg1CommandParameterInfo);
 
@@ -11667,7 +11667,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> testClustertestNullableOptionalRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustertestNullableOptionalRequestarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", Optional.class);
+        new CommandParameterInfo("arg1", Optional.class, Integer.class);
     testClustertestNullableOptionalRequestCommandParams.put(
         "arg1", testClustertestNullableOptionalRequestarg1CommandParameterInfo);
 
@@ -11687,7 +11687,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> testClustertestSimpleOptionalArgumentRequestCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustertestSimpleOptionalArgumentRequestarg1CommandParameterInfo =
-        new CommandParameterInfo("arg1", Optional.class);
+        new CommandParameterInfo("arg1", Optional.class, Boolean.class);
     testClustertestSimpleOptionalArgumentRequestCommandParams.put(
         "arg1", testClustertestSimpleOptionalArgumentRequestarg1CommandParameterInfo);
 
@@ -11785,12 +11785,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> thermostatgetWeeklyScheduleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatgetWeeklyScheduledaysToReturnCommandParameterInfo =
-        new CommandParameterInfo("daysToReturn", Integer.class);
+        new CommandParameterInfo("daysToReturn", Integer.class, Integer.class);
     thermostatgetWeeklyScheduleCommandParams.put(
         "daysToReturn", thermostatgetWeeklyScheduledaysToReturnCommandParameterInfo);
 
     CommandParameterInfo thermostatgetWeeklySchedulemodeToReturnCommandParameterInfo =
-        new CommandParameterInfo("modeToReturn", Integer.class);
+        new CommandParameterInfo("modeToReturn", Integer.class, Integer.class);
     thermostatgetWeeklyScheduleCommandParams.put(
         "modeToReturn", thermostatgetWeeklySchedulemodeToReturnCommandParameterInfo);
 
@@ -11811,24 +11811,25 @@ public class ClusterInfoMapping {
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         thermostatsetWeeklySchedulenumberOfTransitionsForSequenceCommandParameterInfo =
-            new CommandParameterInfo("numberOfTransitionsForSequence", Integer.class);
+            new CommandParameterInfo(
+                "numberOfTransitionsForSequence", Integer.class, Integer.class);
     thermostatsetWeeklyScheduleCommandParams.put(
         "numberOfTransitionsForSequence",
         thermostatsetWeeklySchedulenumberOfTransitionsForSequenceCommandParameterInfo);
 
     CommandParameterInfo thermostatsetWeeklyScheduledayOfWeekForSequenceCommandParameterInfo =
-        new CommandParameterInfo("dayOfWeekForSequence", Integer.class);
+        new CommandParameterInfo("dayOfWeekForSequence", Integer.class, Integer.class);
     thermostatsetWeeklyScheduleCommandParams.put(
         "dayOfWeekForSequence",
         thermostatsetWeeklyScheduledayOfWeekForSequenceCommandParameterInfo);
 
     CommandParameterInfo thermostatsetWeeklySchedulemodeForSequenceCommandParameterInfo =
-        new CommandParameterInfo("modeForSequence", Integer.class);
+        new CommandParameterInfo("modeForSequence", Integer.class, Integer.class);
     thermostatsetWeeklyScheduleCommandParams.put(
         "modeForSequence", thermostatsetWeeklySchedulemodeForSequenceCommandParameterInfo);
 
     CommandParameterInfo thermostatsetWeeklySchedulepayloadCommandParameterInfo =
-        new CommandParameterInfo("payload", ArrayList.class);
+        new CommandParameterInfo("payload", ArrayList.class, Object.class);
     thermostatsetWeeklyScheduleCommandParams.put(
         "payload", thermostatsetWeeklySchedulepayloadCommandParameterInfo);
 
@@ -11850,12 +11851,12 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> thermostatsetpointRaiseLowerCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatsetpointRaiseLowermodeCommandParameterInfo =
-        new CommandParameterInfo("mode", Integer.class);
+        new CommandParameterInfo("mode", Integer.class, Integer.class);
     thermostatsetpointRaiseLowerCommandParams.put(
         "mode", thermostatsetpointRaiseLowermodeCommandParameterInfo);
 
     CommandParameterInfo thermostatsetpointRaiseLoweramountCommandParameterInfo =
-        new CommandParameterInfo("amount", Integer.class);
+        new CommandParameterInfo("amount", Integer.class, Integer.class);
     thermostatsetpointRaiseLowerCommandParams.put(
         "amount", thermostatsetpointRaiseLoweramountCommandParameterInfo);
 
@@ -11933,14 +11934,14 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> windowCoveringgoToLiftPercentageCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo windowCoveringgoToLiftPercentageliftPercentageValueCommandParameterInfo =
-        new CommandParameterInfo("liftPercentageValue", Integer.class);
+        new CommandParameterInfo("liftPercentageValue", Integer.class, Integer.class);
     windowCoveringgoToLiftPercentageCommandParams.put(
         "liftPercentageValue",
         windowCoveringgoToLiftPercentageliftPercentageValueCommandParameterInfo);
 
     CommandParameterInfo
         windowCoveringgoToLiftPercentageliftPercent100thsValueCommandParameterInfo =
-            new CommandParameterInfo("liftPercent100thsValue", Optional.class);
+            new CommandParameterInfo("liftPercent100thsValue", Optional.class, Integer.class);
     windowCoveringgoToLiftPercentageCommandParams.put(
         "liftPercent100thsValue",
         windowCoveringgoToLiftPercentageliftPercent100thsValueCommandParameterInfo);
@@ -11961,7 +11962,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> windowCoveringgoToLiftValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo windowCoveringgoToLiftValueliftValueCommandParameterInfo =
-        new CommandParameterInfo("liftValue", Integer.class);
+        new CommandParameterInfo("liftValue", Integer.class, Integer.class);
     windowCoveringgoToLiftValueCommandParams.put(
         "liftValue", windowCoveringgoToLiftValueliftValueCommandParameterInfo);
 
@@ -11980,14 +11981,14 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> windowCoveringgoToTiltPercentageCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo windowCoveringgoToTiltPercentagetiltPercentageValueCommandParameterInfo =
-        new CommandParameterInfo("tiltPercentageValue", Integer.class);
+        new CommandParameterInfo("tiltPercentageValue", Integer.class, Integer.class);
     windowCoveringgoToTiltPercentageCommandParams.put(
         "tiltPercentageValue",
         windowCoveringgoToTiltPercentagetiltPercentageValueCommandParameterInfo);
 
     CommandParameterInfo
         windowCoveringgoToTiltPercentagetiltPercent100thsValueCommandParameterInfo =
-            new CommandParameterInfo("tiltPercent100thsValue", Optional.class);
+            new CommandParameterInfo("tiltPercent100thsValue", Optional.class, Integer.class);
     windowCoveringgoToTiltPercentageCommandParams.put(
         "tiltPercent100thsValue",
         windowCoveringgoToTiltPercentagetiltPercent100thsValueCommandParameterInfo);
@@ -12008,7 +12009,7 @@ public class ClusterInfoMapping {
     Map<String, CommandParameterInfo> windowCoveringgoToTiltValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo windowCoveringgoToTiltValuetiltValueCommandParameterInfo =
-        new CommandParameterInfo("tiltValue", Integer.class);
+        new CommandParameterInfo("tiltValue", Integer.class, Integer.class);
     windowCoveringgoToTiltValueCommandParams.put(
         "tiltValue", windowCoveringgoToTiltValuetiltValueCommandParameterInfo);
 

--- a/src/controller/java/zap-generated/chip/devicecontroller/ClusterWriteMapping.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ClusterWriteMapping.java
@@ -49,7 +49,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeBasicNodeLabelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo basicnodeLabelCommandParameterInfo =
-        new CommandParameterInfo("value", String.class);
+        new CommandParameterInfo("value", String.class, String.class);
     writeBasicNodeLabelCommandParams.put("value", basicnodeLabelCommandParameterInfo);
     InteractionInfo writeBasicNodeLabelAttributeInteractionInfo =
         new InteractionInfo(
@@ -65,7 +65,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeBasicLocationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo basiclocationCommandParameterInfo =
-        new CommandParameterInfo("value", String.class);
+        new CommandParameterInfo("value", String.class, String.class);
     writeBasicLocationCommandParams.put("value", basiclocationCommandParameterInfo);
     InteractionInfo writeBasicLocationAttributeInteractionInfo =
         new InteractionInfo(
@@ -81,7 +81,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeBasicLocalConfigDisabledCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo basiclocalConfigDisabledCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeBasicLocalConfigDisabledCommandParams.put(
         "value", basiclocalConfigDisabledCommandParameterInfo);
     InteractionInfo writeBasicLocalConfigDisabledAttributeInteractionInfo =
@@ -100,7 +100,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeBinaryInputBasicOutOfServiceCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo binaryInputBasicoutOfServiceCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeBinaryInputBasicOutOfServiceCommandParams.put(
         "value", binaryInputBasicoutOfServiceCommandParameterInfo);
     InteractionInfo writeBinaryInputBasicOutOfServiceAttributeInteractionInfo =
@@ -117,7 +117,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeBinaryInputBasicPresentValueCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo binaryInputBasicpresentValueCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeBinaryInputBasicPresentValueCommandParams.put(
         "value", binaryInputBasicpresentValueCommandParameterInfo);
     InteractionInfo writeBinaryInputBasicPresentValueAttributeInteractionInfo =
@@ -142,7 +142,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeBridgedDeviceBasicNodeLabelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo bridgedDeviceBasicnodeLabelCommandParameterInfo =
-        new CommandParameterInfo("value", String.class);
+        new CommandParameterInfo("value", String.class, String.class);
     writeBridgedDeviceBasicNodeLabelCommandParams.put(
         "value", bridgedDeviceBasicnodeLabelCommandParameterInfo);
     InteractionInfo writeBridgedDeviceBasicNodeLabelAttributeInteractionInfo =
@@ -163,7 +163,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlColorControlOptionsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorControlOptionsCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlColorControlOptionsCommandParams.put(
         "value", colorControlcolorControlOptionsCommandParameterInfo);
     InteractionInfo writeColorControlColorControlOptionsAttributeInteractionInfo =
@@ -181,7 +181,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlWhitePointXCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlwhitePointXCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlWhitePointXCommandParams.put(
         "value", colorControlwhitePointXCommandParameterInfo);
     InteractionInfo writeColorControlWhitePointXAttributeInteractionInfo =
@@ -198,7 +198,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlWhitePointYCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlwhitePointYCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlWhitePointYCommandParams.put(
         "value", colorControlwhitePointYCommandParameterInfo);
     InteractionInfo writeColorControlWhitePointYAttributeInteractionInfo =
@@ -215,7 +215,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlColorPointRXCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorPointRXCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlColorPointRXCommandParams.put(
         "value", colorControlcolorPointRXCommandParameterInfo);
     InteractionInfo writeColorControlColorPointRXAttributeInteractionInfo =
@@ -232,7 +232,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlColorPointRYCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorPointRYCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlColorPointRYCommandParams.put(
         "value", colorControlcolorPointRYCommandParameterInfo);
     InteractionInfo writeColorControlColorPointRYAttributeInteractionInfo =
@@ -249,7 +249,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlColorPointRIntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorPointRIntensityCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlColorPointRIntensityCommandParams.put(
         "value", colorControlcolorPointRIntensityCommandParameterInfo);
     InteractionInfo writeColorControlColorPointRIntensityAttributeInteractionInfo =
@@ -267,7 +267,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlColorPointGXCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorPointGXCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlColorPointGXCommandParams.put(
         "value", colorControlcolorPointGXCommandParameterInfo);
     InteractionInfo writeColorControlColorPointGXAttributeInteractionInfo =
@@ -284,7 +284,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlColorPointGYCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorPointGYCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlColorPointGYCommandParams.put(
         "value", colorControlcolorPointGYCommandParameterInfo);
     InteractionInfo writeColorControlColorPointGYAttributeInteractionInfo =
@@ -301,7 +301,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlColorPointGIntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorPointGIntensityCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlColorPointGIntensityCommandParams.put(
         "value", colorControlcolorPointGIntensityCommandParameterInfo);
     InteractionInfo writeColorControlColorPointGIntensityAttributeInteractionInfo =
@@ -319,7 +319,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlColorPointBXCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorPointBXCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlColorPointBXCommandParams.put(
         "value", colorControlcolorPointBXCommandParameterInfo);
     InteractionInfo writeColorControlColorPointBXAttributeInteractionInfo =
@@ -336,7 +336,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlColorPointBYCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorPointBYCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlColorPointBYCommandParams.put(
         "value", colorControlcolorPointBYCommandParameterInfo);
     InteractionInfo writeColorControlColorPointBYAttributeInteractionInfo =
@@ -353,7 +353,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlColorPointBIntensityCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlcolorPointBIntensityCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlColorPointBIntensityCommandParams.put(
         "value", colorControlcolorPointBIntensityCommandParameterInfo);
     InteractionInfo writeColorControlColorPointBIntensityAttributeInteractionInfo =
@@ -371,7 +371,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeColorControlStartUpColorTemperatureMiredsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo colorControlstartUpColorTemperatureMiredsCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeColorControlStartUpColorTemperatureMiredsCommandParams.put(
         "value", colorControlstartUpColorTemperatureMiredsCommandParameterInfo);
     InteractionInfo writeColorControlStartUpColorTemperatureMiredsAttributeInteractionInfo =
@@ -391,7 +391,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeContentLauncherSupportedStreamingProtocolsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo contentLaunchersupportedStreamingProtocolsCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeContentLauncherSupportedStreamingProtocolsCommandParams.put(
         "value", contentLaunchersupportedStreamingProtocolsCommandParameterInfo);
     InteractionInfo writeContentLauncherSupportedStreamingProtocolsAttributeInteractionInfo =
@@ -415,7 +415,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeDoorLockLanguageCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLocklanguageCommandParameterInfo =
-        new CommandParameterInfo("value", String.class);
+        new CommandParameterInfo("value", String.class, String.class);
     writeDoorLockLanguageCommandParams.put("value", doorLocklanguageCommandParameterInfo);
     InteractionInfo writeDoorLockLanguageAttributeInteractionInfo =
         new InteractionInfo(
@@ -431,7 +431,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeDoorLockAutoRelockTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockautoRelockTimeCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeDoorLockAutoRelockTimeCommandParams.put(
         "value", doorLockautoRelockTimeCommandParameterInfo);
     InteractionInfo writeDoorLockAutoRelockTimeAttributeInteractionInfo =
@@ -448,7 +448,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeDoorLockSoundVolumeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLocksoundVolumeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeDoorLockSoundVolumeCommandParams.put("value", doorLocksoundVolumeCommandParameterInfo);
     InteractionInfo writeDoorLockSoundVolumeAttributeInteractionInfo =
         new InteractionInfo(
@@ -464,7 +464,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeDoorLockOperatingModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockoperatingModeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeDoorLockOperatingModeCommandParams.put("value", doorLockoperatingModeCommandParameterInfo);
     InteractionInfo writeDoorLockOperatingModeAttributeInteractionInfo =
         new InteractionInfo(
@@ -480,7 +480,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeDoorLockEnableOneTouchLockingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockenableOneTouchLockingCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeDoorLockEnableOneTouchLockingCommandParams.put(
         "value", doorLockenableOneTouchLockingCommandParameterInfo);
     InteractionInfo writeDoorLockEnableOneTouchLockingAttributeInteractionInfo =
@@ -498,7 +498,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeDoorLockEnablePrivacyModeButtonCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockenablePrivacyModeButtonCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeDoorLockEnablePrivacyModeButtonCommandParams.put(
         "value", doorLockenablePrivacyModeButtonCommandParameterInfo);
     InteractionInfo writeDoorLockEnablePrivacyModeButtonAttributeInteractionInfo =
@@ -516,7 +516,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeDoorLockWrongCodeEntryLimitCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockwrongCodeEntryLimitCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeDoorLockWrongCodeEntryLimitCommandParams.put(
         "value", doorLockwrongCodeEntryLimitCommandParameterInfo);
     InteractionInfo writeDoorLockWrongCodeEntryLimitAttributeInteractionInfo =
@@ -534,7 +534,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeDoorLockUserCodeTemporaryDisableTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockuserCodeTemporaryDisableTimeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeDoorLockUserCodeTemporaryDisableTimeCommandParams.put(
         "value", doorLockuserCodeTemporaryDisableTimeCommandParameterInfo);
     InteractionInfo writeDoorLockUserCodeTemporaryDisableTimeAttributeInteractionInfo =
@@ -552,7 +552,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeDoorLockRequirePINforRemoteOperationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo doorLockrequirePINforRemoteOperationCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeDoorLockRequirePINforRemoteOperationCommandParams.put(
         "value", doorLockrequirePINforRemoteOperationCommandParameterInfo);
     InteractionInfo writeDoorLockRequirePINforRemoteOperationAttributeInteractionInfo =
@@ -578,7 +578,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeFanControlFanModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo fanControlfanModeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeFanControlFanModeCommandParams.put("value", fanControlfanModeCommandParameterInfo);
     InteractionInfo writeFanControlFanModeAttributeInteractionInfo =
         new InteractionInfo(
@@ -594,7 +594,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeFanControlFanModeSequenceCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo fanControlfanModeSequenceCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeFanControlFanModeSequenceCommandParams.put(
         "value", fanControlfanModeSequenceCommandParameterInfo);
     InteractionInfo writeFanControlFanModeSequenceAttributeInteractionInfo =
@@ -611,7 +611,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeFanControlPercentSettingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo fanControlpercentSettingCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeFanControlPercentSettingCommandParams.put(
         "value", fanControlpercentSettingCommandParameterInfo);
     InteractionInfo writeFanControlPercentSettingAttributeInteractionInfo =
@@ -628,7 +628,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeFanControlSpeedSettingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo fanControlspeedSettingCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeFanControlSpeedSettingCommandParams.put(
         "value", fanControlspeedSettingCommandParameterInfo);
     InteractionInfo writeFanControlSpeedSettingAttributeInteractionInfo =
@@ -645,7 +645,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeFanControlRockSettingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo fanControlrockSettingCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeFanControlRockSettingCommandParams.put("value", fanControlrockSettingCommandParameterInfo);
     InteractionInfo writeFanControlRockSettingAttributeInteractionInfo =
         new InteractionInfo(
@@ -661,7 +661,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeFanControlWindSettingCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo fanControlwindSettingCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeFanControlWindSettingCommandParams.put("value", fanControlwindSettingCommandParameterInfo);
     InteractionInfo writeFanControlWindSettingAttributeInteractionInfo =
         new InteractionInfo(
@@ -683,7 +683,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeGeneralCommissioningBreadcrumbCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo generalCommissioningbreadcrumbCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeGeneralCommissioningBreadcrumbCommandParams.put(
         "value", generalCommissioningbreadcrumbCommandParameterInfo);
     InteractionInfo writeGeneralCommissioningBreadcrumbAttributeInteractionInfo =
@@ -708,7 +708,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeIdentifyIdentifyTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo identifyidentifyTimeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeIdentifyIdentifyTimeCommandParams.put("value", identifyidentifyTimeCommandParameterInfo);
     InteractionInfo writeIdentifyIdentifyTimeAttributeInteractionInfo =
         new InteractionInfo(
@@ -730,7 +730,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeLevelControlOptionsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControloptionsCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeLevelControlOptionsCommandParams.put("value", levelControloptionsCommandParameterInfo);
     InteractionInfo writeLevelControlOptionsAttributeInteractionInfo =
         new InteractionInfo(
@@ -746,7 +746,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeLevelControlOnOffTransitionTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlonOffTransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeLevelControlOnOffTransitionTimeCommandParams.put(
         "value", levelControlonOffTransitionTimeCommandParameterInfo);
     InteractionInfo writeLevelControlOnOffTransitionTimeAttributeInteractionInfo =
@@ -764,7 +764,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeLevelControlOnLevelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlonLevelCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeLevelControlOnLevelCommandParams.put("value", levelControlonLevelCommandParameterInfo);
     InteractionInfo writeLevelControlOnLevelAttributeInteractionInfo =
         new InteractionInfo(
@@ -780,7 +780,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeLevelControlOnTransitionTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlonTransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeLevelControlOnTransitionTimeCommandParams.put(
         "value", levelControlonTransitionTimeCommandParameterInfo);
     InteractionInfo writeLevelControlOnTransitionTimeAttributeInteractionInfo =
@@ -798,7 +798,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeLevelControlOffTransitionTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControloffTransitionTimeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeLevelControlOffTransitionTimeCommandParams.put(
         "value", levelControloffTransitionTimeCommandParameterInfo);
     InteractionInfo writeLevelControlOffTransitionTimeAttributeInteractionInfo =
@@ -816,7 +816,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeLevelControlDefaultMoveRateCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControldefaultMoveRateCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeLevelControlDefaultMoveRateCommandParams.put(
         "value", levelControldefaultMoveRateCommandParameterInfo);
     InteractionInfo writeLevelControlDefaultMoveRateAttributeInteractionInfo =
@@ -833,7 +833,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeLevelControlStartUpCurrentLevelCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo levelControlstartUpCurrentLevelCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeLevelControlStartUpCurrentLevelCommandParams.put(
         "value", levelControlstartUpCurrentLevelCommandParameterInfo);
     InteractionInfo writeLevelControlStartUpCurrentLevelAttributeInteractionInfo =
@@ -854,7 +854,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeLocalizationConfigurationActiveLocaleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo localizationConfigurationactiveLocaleCommandParameterInfo =
-        new CommandParameterInfo("value", String.class);
+        new CommandParameterInfo("value", String.class, String.class);
     writeLocalizationConfigurationActiveLocaleCommandParams.put(
         "value", localizationConfigurationactiveLocaleCommandParameterInfo);
     InteractionInfo writeLocalizationConfigurationActiveLocaleAttributeInteractionInfo =
@@ -881,7 +881,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeModeSelectStartUpModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo modeSelectstartUpModeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeModeSelectStartUpModeCommandParams.put("value", modeSelectstartUpModeCommandParameterInfo);
     InteractionInfo writeModeSelectStartUpModeAttributeInteractionInfo =
         new InteractionInfo(
@@ -897,7 +897,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeModeSelectOnModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo modeSelectonModeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeModeSelectOnModeCommandParams.put("value", modeSelectonModeCommandParameterInfo);
     InteractionInfo writeModeSelectOnModeAttributeInteractionInfo =
         new InteractionInfo(
@@ -915,7 +915,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeNetworkCommissioningInterfaceEnabledCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo networkCommissioninginterfaceEnabledCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeNetworkCommissioningInterfaceEnabledCommandParams.put(
         "value", networkCommissioninginterfaceEnabledCommandParameterInfo);
     InteractionInfo writeNetworkCommissioningInterfaceEnabledAttributeInteractionInfo =
@@ -945,7 +945,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeOnOffOnTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo onOffonTimeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeOnOffOnTimeCommandParams.put("value", onOffonTimeCommandParameterInfo);
     InteractionInfo writeOnOffOnTimeAttributeInteractionInfo =
         new InteractionInfo(
@@ -960,7 +960,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeOnOffOffWaitTimeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo onOffoffWaitTimeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeOnOffOffWaitTimeCommandParams.put("value", onOffoffWaitTimeCommandParameterInfo);
     InteractionInfo writeOnOffOffWaitTimeAttributeInteractionInfo =
         new InteractionInfo(
@@ -976,7 +976,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeOnOffStartUpOnOffCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo onOffstartUpOnOffCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeOnOffStartUpOnOffCommandParams.put("value", onOffstartUpOnOffCommandParameterInfo);
     InteractionInfo writeOnOffStartUpOnOffAttributeInteractionInfo =
         new InteractionInfo(
@@ -995,7 +995,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeOnOffSwitchConfigurationSwitchActionsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo onOffSwitchConfigurationswitchActionsCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeOnOffSwitchConfigurationSwitchActionsCommandParams.put(
         "value", onOffSwitchConfigurationswitchActionsCommandParameterInfo);
     InteractionInfo writeOnOffSwitchConfigurationSwitchActionsAttributeInteractionInfo =
@@ -1026,7 +1026,7 @@ public class ClusterWriteMapping {
         writePumpConfigurationAndControlLifetimeRunningHoursCommandParams =
             new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo pumpConfigurationAndControllifetimeRunningHoursCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writePumpConfigurationAndControlLifetimeRunningHoursCommandParams.put(
         "value", pumpConfigurationAndControllifetimeRunningHoursCommandParameterInfo);
     InteractionInfo writePumpConfigurationAndControlLifetimeRunningHoursAttributeInteractionInfo =
@@ -1045,7 +1045,7 @@ public class ClusterWriteMapping {
         writePumpConfigurationAndControlLifetimeEnergyConsumedCommandParams =
             new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo pumpConfigurationAndControllifetimeEnergyConsumedCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writePumpConfigurationAndControlLifetimeEnergyConsumedCommandParams.put(
         "value", pumpConfigurationAndControllifetimeEnergyConsumedCommandParameterInfo);
     InteractionInfo writePumpConfigurationAndControlLifetimeEnergyConsumedAttributeInteractionInfo =
@@ -1063,7 +1063,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writePumpConfigurationAndControlOperationModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo pumpConfigurationAndControloperationModeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writePumpConfigurationAndControlOperationModeCommandParams.put(
         "value", pumpConfigurationAndControloperationModeCommandParameterInfo);
     InteractionInfo writePumpConfigurationAndControlOperationModeAttributeInteractionInfo =
@@ -1081,7 +1081,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writePumpConfigurationAndControlControlModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo pumpConfigurationAndControlcontrolModeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writePumpConfigurationAndControlControlModeCommandParams.put(
         "value", pumpConfigurationAndControlcontrolModeCommandParameterInfo);
     InteractionInfo writePumpConfigurationAndControlControlModeAttributeInteractionInfo =
@@ -1116,7 +1116,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterBooleanCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterbooleanCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeTestClusterBooleanCommandParams.put("value", testClusterbooleanCommandParameterInfo);
     InteractionInfo writeTestClusterBooleanAttributeInteractionInfo =
         new InteractionInfo(
@@ -1132,7 +1132,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterBitmap8CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterbitmap8CommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterBitmap8CommandParams.put("value", testClusterbitmap8CommandParameterInfo);
     InteractionInfo writeTestClusterBitmap8AttributeInteractionInfo =
         new InteractionInfo(
@@ -1148,7 +1148,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterBitmap16CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterbitmap16CommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterBitmap16CommandParams.put("value", testClusterbitmap16CommandParameterInfo);
     InteractionInfo writeTestClusterBitmap16AttributeInteractionInfo =
         new InteractionInfo(
@@ -1164,7 +1164,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterBitmap32CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterbitmap32CommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterBitmap32CommandParams.put("value", testClusterbitmap32CommandParameterInfo);
     InteractionInfo writeTestClusterBitmap32AttributeInteractionInfo =
         new InteractionInfo(
@@ -1180,7 +1180,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterBitmap64CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterbitmap64CommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterBitmap64CommandParams.put("value", testClusterbitmap64CommandParameterInfo);
     InteractionInfo writeTestClusterBitmap64AttributeInteractionInfo =
         new InteractionInfo(
@@ -1196,7 +1196,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt8uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint8uCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterInt8uCommandParams.put("value", testClusterint8uCommandParameterInfo);
     InteractionInfo writeTestClusterInt8uAttributeInteractionInfo =
         new InteractionInfo(
@@ -1212,7 +1212,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt16uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint16uCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterInt16uCommandParams.put("value", testClusterint16uCommandParameterInfo);
     InteractionInfo writeTestClusterInt16uAttributeInteractionInfo =
         new InteractionInfo(
@@ -1228,7 +1228,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt24uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint24uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt24uCommandParams.put("value", testClusterint24uCommandParameterInfo);
     InteractionInfo writeTestClusterInt24uAttributeInteractionInfo =
         new InteractionInfo(
@@ -1244,7 +1244,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt32uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint32uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt32uCommandParams.put("value", testClusterint32uCommandParameterInfo);
     InteractionInfo writeTestClusterInt32uAttributeInteractionInfo =
         new InteractionInfo(
@@ -1260,7 +1260,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt40uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint40uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt40uCommandParams.put("value", testClusterint40uCommandParameterInfo);
     InteractionInfo writeTestClusterInt40uAttributeInteractionInfo =
         new InteractionInfo(
@@ -1276,7 +1276,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt48uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint48uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt48uCommandParams.put("value", testClusterint48uCommandParameterInfo);
     InteractionInfo writeTestClusterInt48uAttributeInteractionInfo =
         new InteractionInfo(
@@ -1292,7 +1292,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt56uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint56uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt56uCommandParams.put("value", testClusterint56uCommandParameterInfo);
     InteractionInfo writeTestClusterInt56uAttributeInteractionInfo =
         new InteractionInfo(
@@ -1308,7 +1308,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt64uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint64uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt64uCommandParams.put("value", testClusterint64uCommandParameterInfo);
     InteractionInfo writeTestClusterInt64uAttributeInteractionInfo =
         new InteractionInfo(
@@ -1324,7 +1324,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt8sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint8sCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterInt8sCommandParams.put("value", testClusterint8sCommandParameterInfo);
     InteractionInfo writeTestClusterInt8sAttributeInteractionInfo =
         new InteractionInfo(
@@ -1340,7 +1340,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt16sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint16sCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterInt16sCommandParams.put("value", testClusterint16sCommandParameterInfo);
     InteractionInfo writeTestClusterInt16sAttributeInteractionInfo =
         new InteractionInfo(
@@ -1356,7 +1356,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt24sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint24sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt24sCommandParams.put("value", testClusterint24sCommandParameterInfo);
     InteractionInfo writeTestClusterInt24sAttributeInteractionInfo =
         new InteractionInfo(
@@ -1372,7 +1372,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt32sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint32sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt32sCommandParams.put("value", testClusterint32sCommandParameterInfo);
     InteractionInfo writeTestClusterInt32sAttributeInteractionInfo =
         new InteractionInfo(
@@ -1388,7 +1388,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt40sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint40sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt40sCommandParams.put("value", testClusterint40sCommandParameterInfo);
     InteractionInfo writeTestClusterInt40sAttributeInteractionInfo =
         new InteractionInfo(
@@ -1404,7 +1404,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt48sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint48sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt48sCommandParams.put("value", testClusterint48sCommandParameterInfo);
     InteractionInfo writeTestClusterInt48sAttributeInteractionInfo =
         new InteractionInfo(
@@ -1420,7 +1420,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt56sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint56sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt56sCommandParams.put("value", testClusterint56sCommandParameterInfo);
     InteractionInfo writeTestClusterInt56sAttributeInteractionInfo =
         new InteractionInfo(
@@ -1436,7 +1436,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterInt64sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterint64sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterInt64sCommandParams.put("value", testClusterint64sCommandParameterInfo);
     InteractionInfo writeTestClusterInt64sAttributeInteractionInfo =
         new InteractionInfo(
@@ -1452,7 +1452,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterEnum8CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterenum8CommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterEnum8CommandParams.put("value", testClusterenum8CommandParameterInfo);
     InteractionInfo writeTestClusterEnum8AttributeInteractionInfo =
         new InteractionInfo(
@@ -1468,7 +1468,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterEnum16CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterenum16CommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterEnum16CommandParams.put("value", testClusterenum16CommandParameterInfo);
     InteractionInfo writeTestClusterEnum16AttributeInteractionInfo =
         new InteractionInfo(
@@ -1484,7 +1484,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterFloatSingleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterfloatSingleCommandParameterInfo =
-        new CommandParameterInfo("value", Float.class);
+        new CommandParameterInfo("value", Float.class, Float.class);
     writeTestClusterFloatSingleCommandParams.put(
         "value", testClusterfloatSingleCommandParameterInfo);
     InteractionInfo writeTestClusterFloatSingleAttributeInteractionInfo =
@@ -1501,7 +1501,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterFloatDoubleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterfloatDoubleCommandParameterInfo =
-        new CommandParameterInfo("value", Double.class);
+        new CommandParameterInfo("value", Double.class, Double.class);
     writeTestClusterFloatDoubleCommandParams.put(
         "value", testClusterfloatDoubleCommandParameterInfo);
     InteractionInfo writeTestClusterFloatDoubleAttributeInteractionInfo =
@@ -1518,7 +1518,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterOctetStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusteroctetStringCommandParameterInfo =
-        new CommandParameterInfo("value", byte[].class);
+        new CommandParameterInfo("value", byte[].class, byte[].class);
     writeTestClusterOctetStringCommandParams.put(
         "value", testClusteroctetStringCommandParameterInfo);
     InteractionInfo writeTestClusterOctetStringAttributeInteractionInfo =
@@ -1535,7 +1535,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterLongOctetStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterlongOctetStringCommandParameterInfo =
-        new CommandParameterInfo("value", byte[].class);
+        new CommandParameterInfo("value", byte[].class, byte[].class);
     writeTestClusterLongOctetStringCommandParams.put(
         "value", testClusterlongOctetStringCommandParameterInfo);
     InteractionInfo writeTestClusterLongOctetStringAttributeInteractionInfo =
@@ -1552,7 +1552,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterCharStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustercharStringCommandParameterInfo =
-        new CommandParameterInfo("value", String.class);
+        new CommandParameterInfo("value", String.class, String.class);
     writeTestClusterCharStringCommandParams.put("value", testClustercharStringCommandParameterInfo);
     InteractionInfo writeTestClusterCharStringAttributeInteractionInfo =
         new InteractionInfo(
@@ -1568,7 +1568,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterLongCharStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterlongCharStringCommandParameterInfo =
-        new CommandParameterInfo("value", String.class);
+        new CommandParameterInfo("value", String.class, String.class);
     writeTestClusterLongCharStringCommandParams.put(
         "value", testClusterlongCharStringCommandParameterInfo);
     InteractionInfo writeTestClusterLongCharStringAttributeInteractionInfo =
@@ -1585,7 +1585,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterEpochUsCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterepochUsCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterEpochUsCommandParams.put("value", testClusterepochUsCommandParameterInfo);
     InteractionInfo writeTestClusterEpochUsAttributeInteractionInfo =
         new InteractionInfo(
@@ -1601,7 +1601,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterEpochSCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterepochSCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterEpochSCommandParams.put("value", testClusterepochSCommandParameterInfo);
     InteractionInfo writeTestClusterEpochSAttributeInteractionInfo =
         new InteractionInfo(
@@ -1617,7 +1617,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterVendorIdCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustervendorIdCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterVendorIdCommandParams.put("value", testClustervendorIdCommandParameterInfo);
     InteractionInfo writeTestClusterVendorIdAttributeInteractionInfo =
         new InteractionInfo(
@@ -1633,7 +1633,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterEnumAttrCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterenumAttrCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterEnumAttrCommandParams.put("value", testClusterenumAttrCommandParameterInfo);
     InteractionInfo writeTestClusterEnumAttrAttributeInteractionInfo =
         new InteractionInfo(
@@ -1649,7 +1649,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterRangeRestrictedInt8uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterrangeRestrictedInt8uCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterRangeRestrictedInt8uCommandParams.put(
         "value", testClusterrangeRestrictedInt8uCommandParameterInfo);
     InteractionInfo writeTestClusterRangeRestrictedInt8uAttributeInteractionInfo =
@@ -1667,7 +1667,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterRangeRestrictedInt8sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterrangeRestrictedInt8sCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterRangeRestrictedInt8sCommandParams.put(
         "value", testClusterrangeRestrictedInt8sCommandParameterInfo);
     InteractionInfo writeTestClusterRangeRestrictedInt8sAttributeInteractionInfo =
@@ -1685,7 +1685,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterRangeRestrictedInt16uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterrangeRestrictedInt16uCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterRangeRestrictedInt16uCommandParams.put(
         "value", testClusterrangeRestrictedInt16uCommandParameterInfo);
     InteractionInfo writeTestClusterRangeRestrictedInt16uAttributeInteractionInfo =
@@ -1703,7 +1703,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterRangeRestrictedInt16sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterrangeRestrictedInt16sCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterRangeRestrictedInt16sCommandParams.put(
         "value", testClusterrangeRestrictedInt16sCommandParameterInfo);
     InteractionInfo writeTestClusterRangeRestrictedInt16sAttributeInteractionInfo =
@@ -1721,7 +1721,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterTimedWriteBooleanCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustertimedWriteBooleanCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeTestClusterTimedWriteBooleanCommandParams.put(
         "value", testClustertimedWriteBooleanCommandParameterInfo);
     InteractionInfo writeTestClusterTimedWriteBooleanAttributeInteractionInfo =
@@ -1741,7 +1741,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterGeneralErrorBooleanCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClustergeneralErrorBooleanCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeTestClusterGeneralErrorBooleanCommandParams.put(
         "value", testClustergeneralErrorBooleanCommandParameterInfo);
     InteractionInfo writeTestClusterGeneralErrorBooleanAttributeInteractionInfo =
@@ -1759,7 +1759,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterClusterErrorBooleanCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterclusterErrorBooleanCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeTestClusterClusterErrorBooleanCommandParams.put(
         "value", testClusterclusterErrorBooleanCommandParameterInfo);
     InteractionInfo writeTestClusterClusterErrorBooleanAttributeInteractionInfo =
@@ -1777,7 +1777,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterUnsupportedCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusterunsupportedCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeTestClusterUnsupportedCommandParams.put(
         "value", testClusterunsupportedCommandParameterInfo);
     InteractionInfo writeTestClusterUnsupportedAttributeInteractionInfo =
@@ -1794,7 +1794,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableBooleanCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableBooleanCommandParameterInfo =
-        new CommandParameterInfo("value", Boolean.class);
+        new CommandParameterInfo("value", Boolean.class, Boolean.class);
     writeTestClusterNullableBooleanCommandParams.put(
         "value", testClusternullableBooleanCommandParameterInfo);
     InteractionInfo writeTestClusterNullableBooleanAttributeInteractionInfo =
@@ -1811,7 +1811,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableBitmap8CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableBitmap8CommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableBitmap8CommandParams.put(
         "value", testClusternullableBitmap8CommandParameterInfo);
     InteractionInfo writeTestClusterNullableBitmap8AttributeInteractionInfo =
@@ -1828,7 +1828,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableBitmap16CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableBitmap16CommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableBitmap16CommandParams.put(
         "value", testClusternullableBitmap16CommandParameterInfo);
     InteractionInfo writeTestClusterNullableBitmap16AttributeInteractionInfo =
@@ -1845,7 +1845,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableBitmap32CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableBitmap32CommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableBitmap32CommandParams.put(
         "value", testClusternullableBitmap32CommandParameterInfo);
     InteractionInfo writeTestClusterNullableBitmap32AttributeInteractionInfo =
@@ -1862,7 +1862,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableBitmap64CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableBitmap64CommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableBitmap64CommandParams.put(
         "value", testClusternullableBitmap64CommandParameterInfo);
     InteractionInfo writeTestClusterNullableBitmap64AttributeInteractionInfo =
@@ -1879,7 +1879,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt8uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt8uCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableInt8uCommandParams.put(
         "value", testClusternullableInt8uCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt8uAttributeInteractionInfo =
@@ -1896,7 +1896,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt16uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt16uCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableInt16uCommandParams.put(
         "value", testClusternullableInt16uCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt16uAttributeInteractionInfo =
@@ -1913,7 +1913,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt24uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt24uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt24uCommandParams.put(
         "value", testClusternullableInt24uCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt24uAttributeInteractionInfo =
@@ -1930,7 +1930,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt32uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt32uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt32uCommandParams.put(
         "value", testClusternullableInt32uCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt32uAttributeInteractionInfo =
@@ -1947,7 +1947,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt40uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt40uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt40uCommandParams.put(
         "value", testClusternullableInt40uCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt40uAttributeInteractionInfo =
@@ -1964,7 +1964,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt48uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt48uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt48uCommandParams.put(
         "value", testClusternullableInt48uCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt48uAttributeInteractionInfo =
@@ -1981,7 +1981,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt56uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt56uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt56uCommandParams.put(
         "value", testClusternullableInt56uCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt56uAttributeInteractionInfo =
@@ -1998,7 +1998,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt64uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt64uCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt64uCommandParams.put(
         "value", testClusternullableInt64uCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt64uAttributeInteractionInfo =
@@ -2015,7 +2015,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt8sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt8sCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableInt8sCommandParams.put(
         "value", testClusternullableInt8sCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt8sAttributeInteractionInfo =
@@ -2032,7 +2032,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt16sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt16sCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableInt16sCommandParams.put(
         "value", testClusternullableInt16sCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt16sAttributeInteractionInfo =
@@ -2049,7 +2049,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt24sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt24sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt24sCommandParams.put(
         "value", testClusternullableInt24sCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt24sAttributeInteractionInfo =
@@ -2066,7 +2066,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt32sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt32sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt32sCommandParams.put(
         "value", testClusternullableInt32sCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt32sAttributeInteractionInfo =
@@ -2083,7 +2083,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt40sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt40sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt40sCommandParams.put(
         "value", testClusternullableInt40sCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt40sAttributeInteractionInfo =
@@ -2100,7 +2100,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt48sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt48sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt48sCommandParams.put(
         "value", testClusternullableInt48sCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt48sAttributeInteractionInfo =
@@ -2117,7 +2117,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt56sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt56sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt56sCommandParams.put(
         "value", testClusternullableInt56sCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt56sAttributeInteractionInfo =
@@ -2134,7 +2134,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableInt64sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableInt64sCommandParameterInfo =
-        new CommandParameterInfo("value", Long.class);
+        new CommandParameterInfo("value", Long.class, Long.class);
     writeTestClusterNullableInt64sCommandParams.put(
         "value", testClusternullableInt64sCommandParameterInfo);
     InteractionInfo writeTestClusterNullableInt64sAttributeInteractionInfo =
@@ -2151,7 +2151,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableEnum8CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableEnum8CommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableEnum8CommandParams.put(
         "value", testClusternullableEnum8CommandParameterInfo);
     InteractionInfo writeTestClusterNullableEnum8AttributeInteractionInfo =
@@ -2168,7 +2168,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableEnum16CommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableEnum16CommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableEnum16CommandParams.put(
         "value", testClusternullableEnum16CommandParameterInfo);
     InteractionInfo writeTestClusterNullableEnum16AttributeInteractionInfo =
@@ -2185,7 +2185,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableFloatSingleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableFloatSingleCommandParameterInfo =
-        new CommandParameterInfo("value", Float.class);
+        new CommandParameterInfo("value", Float.class, Float.class);
     writeTestClusterNullableFloatSingleCommandParams.put(
         "value", testClusternullableFloatSingleCommandParameterInfo);
     InteractionInfo writeTestClusterNullableFloatSingleAttributeInteractionInfo =
@@ -2203,7 +2203,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableFloatDoubleCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableFloatDoubleCommandParameterInfo =
-        new CommandParameterInfo("value", Double.class);
+        new CommandParameterInfo("value", Double.class, Double.class);
     writeTestClusterNullableFloatDoubleCommandParams.put(
         "value", testClusternullableFloatDoubleCommandParameterInfo);
     InteractionInfo writeTestClusterNullableFloatDoubleAttributeInteractionInfo =
@@ -2221,7 +2221,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableOctetStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableOctetStringCommandParameterInfo =
-        new CommandParameterInfo("value", byte[].class);
+        new CommandParameterInfo("value", byte[].class, byte[].class);
     writeTestClusterNullableOctetStringCommandParams.put(
         "value", testClusternullableOctetStringCommandParameterInfo);
     InteractionInfo writeTestClusterNullableOctetStringAttributeInteractionInfo =
@@ -2239,7 +2239,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableCharStringCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableCharStringCommandParameterInfo =
-        new CommandParameterInfo("value", String.class);
+        new CommandParameterInfo("value", String.class, String.class);
     writeTestClusterNullableCharStringCommandParams.put(
         "value", testClusternullableCharStringCommandParameterInfo);
     InteractionInfo writeTestClusterNullableCharStringAttributeInteractionInfo =
@@ -2257,7 +2257,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableEnumAttrCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableEnumAttrCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableEnumAttrCommandParams.put(
         "value", testClusternullableEnumAttrCommandParameterInfo);
     InteractionInfo writeTestClusterNullableEnumAttrAttributeInteractionInfo =
@@ -2274,7 +2274,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableRangeRestrictedInt8uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableRangeRestrictedInt8uCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableRangeRestrictedInt8uCommandParams.put(
         "value", testClusternullableRangeRestrictedInt8uCommandParameterInfo);
     InteractionInfo writeTestClusterNullableRangeRestrictedInt8uAttributeInteractionInfo =
@@ -2292,7 +2292,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableRangeRestrictedInt8sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableRangeRestrictedInt8sCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableRangeRestrictedInt8sCommandParams.put(
         "value", testClusternullableRangeRestrictedInt8sCommandParameterInfo);
     InteractionInfo writeTestClusterNullableRangeRestrictedInt8sAttributeInteractionInfo =
@@ -2310,7 +2310,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableRangeRestrictedInt16uCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableRangeRestrictedInt16uCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableRangeRestrictedInt16uCommandParams.put(
         "value", testClusternullableRangeRestrictedInt16uCommandParameterInfo);
     InteractionInfo writeTestClusterNullableRangeRestrictedInt16uAttributeInteractionInfo =
@@ -2328,7 +2328,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTestClusterNullableRangeRestrictedInt16sCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo testClusternullableRangeRestrictedInt16sCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTestClusterNullableRangeRestrictedInt16sCommandParams.put(
         "value", testClusternullableRangeRestrictedInt16sCommandParameterInfo);
     InteractionInfo writeTestClusterNullableRangeRestrictedInt16sAttributeInteractionInfo =
@@ -2348,7 +2348,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeThermostatOccupiedCoolingSetpointCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatoccupiedCoolingSetpointCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatOccupiedCoolingSetpointCommandParams.put(
         "value", thermostatoccupiedCoolingSetpointCommandParameterInfo);
     InteractionInfo writeThermostatOccupiedCoolingSetpointAttributeInteractionInfo =
@@ -2366,7 +2366,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeThermostatOccupiedHeatingSetpointCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatoccupiedHeatingSetpointCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatOccupiedHeatingSetpointCommandParams.put(
         "value", thermostatoccupiedHeatingSetpointCommandParameterInfo);
     InteractionInfo writeThermostatOccupiedHeatingSetpointAttributeInteractionInfo =
@@ -2384,7 +2384,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeThermostatMinHeatSetpointLimitCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatminHeatSetpointLimitCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatMinHeatSetpointLimitCommandParams.put(
         "value", thermostatminHeatSetpointLimitCommandParameterInfo);
     InteractionInfo writeThermostatMinHeatSetpointLimitAttributeInteractionInfo =
@@ -2402,7 +2402,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeThermostatMaxHeatSetpointLimitCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatmaxHeatSetpointLimitCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatMaxHeatSetpointLimitCommandParams.put(
         "value", thermostatmaxHeatSetpointLimitCommandParameterInfo);
     InteractionInfo writeThermostatMaxHeatSetpointLimitAttributeInteractionInfo =
@@ -2420,7 +2420,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeThermostatMinCoolSetpointLimitCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatminCoolSetpointLimitCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatMinCoolSetpointLimitCommandParams.put(
         "value", thermostatminCoolSetpointLimitCommandParameterInfo);
     InteractionInfo writeThermostatMinCoolSetpointLimitAttributeInteractionInfo =
@@ -2438,7 +2438,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeThermostatMaxCoolSetpointLimitCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatmaxCoolSetpointLimitCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatMaxCoolSetpointLimitCommandParams.put(
         "value", thermostatmaxCoolSetpointLimitCommandParameterInfo);
     InteractionInfo writeThermostatMaxCoolSetpointLimitAttributeInteractionInfo =
@@ -2456,7 +2456,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeThermostatMinSetpointDeadBandCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatminSetpointDeadBandCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatMinSetpointDeadBandCommandParams.put(
         "value", thermostatminSetpointDeadBandCommandParameterInfo);
     InteractionInfo writeThermostatMinSetpointDeadBandAttributeInteractionInfo =
@@ -2474,7 +2474,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeThermostatControlSequenceOfOperationCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatcontrolSequenceOfOperationCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatControlSequenceOfOperationCommandParams.put(
         "value", thermostatcontrolSequenceOfOperationCommandParameterInfo);
     InteractionInfo writeThermostatControlSequenceOfOperationAttributeInteractionInfo =
@@ -2492,7 +2492,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeThermostatSystemModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatsystemModeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatSystemModeCommandParams.put("value", thermostatsystemModeCommandParameterInfo);
     InteractionInfo writeThermostatSystemModeAttributeInteractionInfo =
         new InteractionInfo(
@@ -2513,7 +2513,7 @@ public class ClusterWriteMapping {
             new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         thermostatUserInterfaceConfigurationtemperatureDisplayModeCommandParameterInfo =
-            new CommandParameterInfo("value", Integer.class);
+            new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatUserInterfaceConfigurationTemperatureDisplayModeCommandParams.put(
         "value", thermostatUserInterfaceConfigurationtemperatureDisplayModeCommandParameterInfo);
     InteractionInfo
@@ -2534,7 +2534,7 @@ public class ClusterWriteMapping {
         writeThermostatUserInterfaceConfigurationKeypadLockoutCommandParams =
             new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo thermostatUserInterfaceConfigurationkeypadLockoutCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatUserInterfaceConfigurationKeypadLockoutCommandParams.put(
         "value", thermostatUserInterfaceConfigurationkeypadLockoutCommandParameterInfo);
     InteractionInfo writeThermostatUserInterfaceConfigurationKeypadLockoutAttributeInteractionInfo =
@@ -2554,7 +2554,7 @@ public class ClusterWriteMapping {
             new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo
         thermostatUserInterfaceConfigurationscheduleProgrammingVisibilityCommandParameterInfo =
-            new CommandParameterInfo("value", Integer.class);
+            new CommandParameterInfo("value", Integer.class, Integer.class);
     writeThermostatUserInterfaceConfigurationScheduleProgrammingVisibilityCommandParams.put(
         "value",
         thermostatUserInterfaceConfigurationscheduleProgrammingVisibilityCommandParameterInfo);
@@ -2582,7 +2582,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTimeFormatLocalizationHourFormatCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo timeFormatLocalizationhourFormatCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTimeFormatLocalizationHourFormatCommandParams.put(
         "value", timeFormatLocalizationhourFormatCommandParameterInfo);
     InteractionInfo writeTimeFormatLocalizationHourFormatAttributeInteractionInfo =
@@ -2599,7 +2599,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeTimeFormatLocalizationActiveCalendarTypeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo timeFormatLocalizationactiveCalendarTypeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeTimeFormatLocalizationActiveCalendarTypeCommandParams.put(
         "value", timeFormatLocalizationactiveCalendarTypeCommandParameterInfo);
     InteractionInfo writeTimeFormatLocalizationActiveCalendarTypeAttributeInteractionInfo =
@@ -2619,7 +2619,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeUnitLocalizationTemperatureUnitCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo unitLocalizationtemperatureUnitCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeUnitLocalizationTemperatureUnitCommandParams.put(
         "value", unitLocalizationtemperatureUnitCommandParameterInfo);
     InteractionInfo writeUnitLocalizationTemperatureUnitAttributeInteractionInfo =
@@ -2645,7 +2645,7 @@ public class ClusterWriteMapping {
     Map<String, CommandParameterInfo> writeWindowCoveringModeCommandParams =
         new LinkedHashMap<String, CommandParameterInfo>();
     CommandParameterInfo windowCoveringmodeCommandParameterInfo =
-        new CommandParameterInfo("value", Integer.class);
+        new CommandParameterInfo("value", Integer.class, Integer.class);
     writeWindowCoveringModeCommandParams.put("value", windowCoveringmodeCommandParameterInfo);
     InteractionInfo writeWindowCoveringModeAttributeInteractionInfo =
         new InteractionInfo(

--- a/src/lib/support/JniReferences.cpp
+++ b/src/lib/support/JniReferences.cpp
@@ -210,7 +210,7 @@ CHIP_ERROR JniReferences::GetOptionalValue(jobject optionalObj, jobject & option
 
     jmethodID isPresentMethod = env->GetMethodID(optionalCls, "isPresent", "()Z");
     VerifyOrReturnError(isPresentMethod != nullptr, CHIP_JNI_ERROR_METHOD_NOT_FOUND);
-    jboolean isPresent = env->CallBooleanMethod(optionalObj, isPresentMethod);
+    jboolean isPresent = optionalObj && env->CallBooleanMethod(optionalObj, isPresentMethod);
 
     if (!isPresent)
     {


### PR DESCRIPTION
[nrf noup] [android] Fix crash on DoorLock.lockDoor command

Cluster Interaction Tool screen would crash when trying  to send a command that takes an optional argument. The reason was that optional arguments were incorrectly converted in the application and the underlying JNI layer.

[nrf noup] Build OTA Provider for Linux in release_tools
    
Build OTA Provider for Linux in release_tools workflow. Also, disable debug symbols for chip-tool binaries.