### PR TITLE
[nrf noup] Set NVS_LOOKUP_CACHE_SIZE in the Matter Kconfig.defaults

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -91,6 +91,10 @@ config CHIP_DEVICE_PRODUCT_ID
 	int
 	default 32768
 
+config NVS_LOOKUP_CACHE_SIZE
+	int
+	default 512
+
 # Disable certain parts of Zephyr IPv6 stack
 config NET_IPV6_NBR_CACHE
     bool


### PR DESCRIPTION
The nrf noup commit from sdk-zephyr will be removed, so it was
decided to set this value in the Matter samples configuration.
