### PR TITLE
[DNM] [zephyr] Remove log_strdup call

### DIFF
--- a/src/platform/Zephyr/Logging.cpp
+++ b/src/platform/Zephyr/Logging.cpp
@@ -49,8 +49,6 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
     const size_t prefixLen = strlen(formattedMsg);
     vsnprintfcb(formattedMsg + prefixLen, sizeof(formattedMsg) - prefixLen, msg, v);
 
-    const char * allocatedMsg = log_strdup(formattedMsg);
-
     // Invoke the Zephyr logging library to log the message.
     //
     // Unfortunately the Zephyr logging macros end up assigning uint16_t
@@ -62,14 +60,14 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
     switch (category)
     {
     case kLogCategory_Error:
-        LOG_ERR(LOG_FORMAT, LOG_MESSAGE(allocatedMsg));
+        LOG_ERR(LOG_FORMAT, LOG_MESSAGE(formattedMsg));
         break;
     case kLogCategory_Progress:
     default:
-        LOG_INF(LOG_FORMAT, LOG_MESSAGE(allocatedMsg));
+        LOG_INF(LOG_FORMAT, LOG_MESSAGE(formattedMsg));
         break;
     case kLogCategory_Detail:
-        LOG_DBG(LOG_FORMAT, LOG_MESSAGE(allocatedMsg));
+        LOG_DBG(LOG_FORMAT, LOG_MESSAGE(formattedMsg));
         break;
     }
 #pragma GCC diagnostic pop


### PR DESCRIPTION
DNM: This is fix for the auto-upmerge test; it is needed because upstream/Zephyr removes log_strdup function.

It is no longer needed to call log_strdup while providing string
for LOG_ macros.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>

#### Problem
What is being fixed?  Examples:
* Fix crash on startup
* Fixes #12345 Frobnozzle is leaky (exactly like that, so GitHub will auto-close the issue).

#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
