### PR TITLE
[nrf noup] Fix WiFi Manager initialization

### DIFF
--- a/src/platform/nrfconnect/ConnectivityManagerImpl.cpp
+++ b/src/platform/nrfconnect/ConnectivityManagerImpl.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
     GenericConnectivityManagerImpl_Thread<ConnectivityManagerImpl>::_Init();
 #endif
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    InitWiFi();
+    ReturnErrorOnFailure(InitWiFi());
 #endif
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
The WiFi Manager initialization was prone to failures due to
timing dependencies with the supplicant thread. Harden the
solution by waiting for the suppicant initialization.

Also, propagate the WiFi Manager initialization error up the
stack.