### PR TITLE
[nrf noup] Added support for SPI NOR external flash

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -201,9 +201,24 @@ config CHIP_OTA_REQUESTOR
     bool
     default y
 
+# All boards besides nRF7002DK use QSPI NOR external flash
+if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840
+
 config CHIP_QSPI_NOR
     bool
     default y
+
+endif # BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840
+
+# nRF7002DK uses SPI NOR external flash
+
+if BOARD_NRF7002DK_NRF5340_CPUAPP
+
+config CHIP_SPI_NOR
+    bool
+    default y
+
+endif # BOARD_NRF7002DK_NRF5340_CPUAPP
 
 # Enable extended discovery
 config CHIP_EXTENDED_DISCOVERY

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -58,9 +58,27 @@ config NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE
 
 endif # CHIP_QSPI_NOR
 
+config CHIP_SPI_NOR
+	bool "Enable SPI NOR feature set"
+	imply SPI
+	imply SPI_NOR
+	imply MULTITHREADING
+	help
+		Enables SPI NOR with the set of options
+		configuring pages and buffer sizes.
+
+if CHIP_SPI_NOR
+
+config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
+	int
+	default 4096
+
+endif # CHIP_SPI_NOR
+
 config CHIP_DFU_OVER_BT_SMP
 	bool "Enable DFU over Bluetooth LE SMP feature set"
-	imply CHIP_QSPI_NOR
+	imply CHIP_QSPI_NOR if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840
+	imply CHIP_SPI_NOR if BOARD_NRF7002DK_NRF5340_CPUAPP
 	imply BOOTLOADER_MCUBOOT
 	help
 		Enables Device Firmware Upgrade over Bluetoot LE with SMP

--- a/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
@@ -52,6 +52,34 @@ config FPROTECT
     bool
     default y
 
+# nRF7002DK uses SPI NOR external flash
+if BOARD_NRF7002DK_NRF5340_CPUAPP
+
+config SPI
+    bool
+    default y
+
+config SPI_NOR
+    bool
+    default y
+
+choice SPI_NOR_SFDP
+	default SPI_NOR_SFDP_DEVICETREE
+endchoice
+
+config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
+    int
+    default 4096
+
+config MULTITHREADING
+    bool
+    default y
+
+endif
+
+# All boards beside nRF7002DK use QSPI NOR external flash
+if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840
+
 config NORDIC_QSPI_NOR
     bool
     default y
@@ -63,6 +91,8 @@ config NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 config NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE
     int
     default 16
+
+endif
 
 config BOOT_MAX_IMG_SECTORS
     int


### PR DESCRIPTION
Added configs allowing to enable external flash and DFU using SPI NOR for application and mcuboot images.

