### PR TITLE
[nrf noup] Prepare configuration for hci_rpmsg

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
@@ -1,0 +1,99 @@
+#
+#   Copyright (c) 2022 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# The purpose of this file is to define new default values of settings used when building hci_rpmsg child image for Matter samples.
+
+config LOG
+    bool
+    default n
+
+config HEAP_MEM_POOL_SIZE
+    int
+    default 8192
+
+config MAIN_STACK_SIZE
+    int
+    default 2048
+
+config SYSTEM_WORKQUEUE_STACK_SIZE
+    int
+    default 2048
+
+config BT
+    bool
+    default y
+
+config BT_HCI_RAW
+    bool
+    default y
+
+config BT_MAX_CONN
+    int
+    default 1
+
+config BT_PERIPHERAL
+    bool
+    default y
+
+config BT_CENTRAL
+    bool
+    default n
+
+config BT_BUF_ACL_RX_SIZE
+    int
+    default 502
+
+config BT_BUF_ACL_TX_SIZE
+    int
+    default 251
+
+config BT_CTLR_DATA_LENGTH_MAX
+    int
+    default 251
+
+config BT_CTLR_ASSERT_HANDLER
+    bool
+    default y
+
+config BT_HCI_RAW_RESERVE
+    int
+    default 1
+
+# Workaround: Unable to allocate command buffer when using K_NO_WAIT since
+# Host number of completed commands does not follow normal flow control.
+config BT_BUF_CMD_TX_COUNT
+    int
+    default 10
+
+config ASSERT
+    bool
+    default y
+
+config DEBUG_INFO
+    bool
+    default y
+
+config EXCEPTION_STACK_TRACE
+    bool
+    default y
+
+config IPC_SERVICE
+    bool
+    default y
+
+config MBOX
+    bool
+    default y

--- a/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.root
+++ b/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.root
@@ -1,0 +1,21 @@
+#
+#   Copyright (c) 2022 Project CHIP Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# The purpose of this file is to create a wrapper Kconfig file that will be set as
+# hci_rpmsg_KCONFIG_ROOT and processed before any other Kconfig for hci_rpmsg child image.
+
+rsource "Kconfig.hci_rpmsg.defaults"
+source "Kconfig.zephyr"


### PR DESCRIPTION
Create configuration for hci_rpmsg image used by WiFi build targets.