### PR TITLE
[nrf noup] Selected override config for SPI external flash

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -63,6 +63,7 @@ config CHIP_SPI_NOR
 	imply SPI
 	imply SPI_NOR
 	imply MULTITHREADING
+	imply PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
 	help
 		Enables SPI NOR with the set of options
 		configuring pages and buffer sizes.

--- a/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
@@ -75,6 +75,10 @@ config MULTITHREADING
     bool
     default y
 
+config PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
+    bool
+    default y
+
 endif
 
 # All boards beside nRF7002DK use QSPI NOR external flash


### PR DESCRIPTION
By default PM selects QSPI external flash. In case other
backend is used the override config should be set.

