### PR TITLE
[nrf fromtree] Update light switch doc.

### DIFF
--- a/examples/light-switch-app/nrfconnect/README.md
+++ b/examples/light-switch-app/nrfconnect/README.md
@@ -695,35 +695,20 @@ To perform the unicast binding process, complete the following steps:
 1.  Build the CHIP Tool according to the steps from the
     [CHIP Tool user guide](../../../docs/guides/chip_tool_guide.md#building).
 2.  Go to the CHIP Tool build directory.
-3.  Add an ACL to the [lighting endpoint](../../lighting-app/nrfconnect/)
-    permissions by running the following command:
 
-         chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233], "targets": null}, {"fabricIndex": 1, "privilege": 3, "authMode": 2, "subjects": [2], "targets": [{"cluster": 6, "endpoint": 1, "deviceType": null}, {"cluster": 8, "endpoint": 1, "deviceType": null}]}]' 1 0
-
-    In this command:
-
-    -   `{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233], "targets": null}`
-        is an ACL for the communication with the CHIP Tool.
-    -   `{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [2], "targets": [{"cluster": 6, "endpoint": 1, "deviceType": null}, {"cluster": 8, "endpoint": 1, "deviceType": null}]}`
-        is an ACL for binding (cluster `no. 6` is the On/Off cluster and the
-        cluster `no. 8` is the Level Control cluster).
-
-    This allows the lighting application device to receive commands from the
-    light switch device.
-
-4.  Add the light switch device to the multicast group by running the following
+3.  Add the light switch device to the multicast group by running the following
     command:
 
         chip-tool tests TestGroupDemoConfig --nodeId 1
 
-5.  Add all light bulbs to the same multicast group by applying command below
+4.  Add all light bulbs to the same multicast group by applying command below
     for each of the light bulbs, using the appropriate `<node_id>` (the
     user-defined ID of the node being commissioned except `2` due to use this
     `<node_id>` for light-switch) for each of them:
 
         chip-tool tests TestGroupDemoConfig --nodeId <node_id>
 
-6.  Add Binding commands for group multicast:
+5.  Add Binding commands for group multicast:
 
         chip-tool binding write binding '[{"fabricIndex": 1, "group": 257}]' 2 1
 

--- a/src/app/tests/suites/TestGroupDemoConfig.yaml
+++ b/src/app/tests/suites/TestGroupDemoConfig.yaml
@@ -27,7 +27,7 @@ name: Group Messaging Demo - Configuration
 
 config:
     nodeId: 0x12344321
-    cluster: "Groups"
+    cluster: "Group Key Management"
     endpoint: 0
 
 tests:
@@ -39,23 +39,7 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "Add Group 1 - endpoint 1"
-      command: "AddGroup"
-      endpoint: 1
-      arguments:
-          values:
-              - name: "groupId"
-                value: 0x0101
-              - name: "groupName"
-                value: "Group #1"
-      response:
-          values:
-              - name: "status"
-                value: 0
-              - name: "groupId"
-                value: 0x0101
-
-    - label: "KeySet Write 1"
+    - label: "KeySet Write 1 (endpoint 0)"
       cluster: "Group Key Management"
       command: "KeySetWrite"
       arguments:
@@ -74,32 +58,49 @@ tests:
                         EpochStartTime2: 1110002,
                     }
 
-    - label: "Map Group Key Set to group ID on a given fabric"
+    - label: "Write Group Keys (endpoint 0)"
       cluster: "Group Key Management"
       command: "writeAttribute"
       attribute: "GroupKeyMap"
       arguments:
-          value: [{ FabricIndex: 1, GroupId: 0x0101, GroupKeySetID: 0x01a1 }]
+          value: [{ FabricIndex: 0, GroupId: 0x0101, GroupKeySetID: 0x01a1 }]
 
-    - label: "Install ACLs for test"
+    - label: "Add Group 1 (endpoint 1)"
+      cluster: "Groups"
+      command: "AddGroup"
+      endpoint: 1
+      arguments:
+          values:
+              - name: "groupId"
+                value: 0x0101
+              - name: "groupName"
+                value: "Group #1"
+      response:
+          values:
+              - name: "status"
+                value: 0
+              - name: "groupId"
+                value: 0x0101
+
+    - label: "Install ACLs"
       cluster: "Access Control"
       command: "writeAttribute"
       attribute: "ACL"
       arguments:
           value: [
-                  # Any CASE can admin
+                  # Any CASE can administer
                   {
                       FabricIndex: 1,
-                      Privilege: 5,
-                      AuthMode: 2,
+                      Privilege: 5, # administer
+                      AuthMode: 2, # case
                       Subjects: null,
                       Targets: null,
                   },
-                  # These groups can operate
+                  # Any group can operate
                   {
                       FabricIndex: 1,
-                      Privilege: 3,
-                      AuthMode: 3,
+                      Privilege: 3, # operate
+                      AuthMode: 3, # group
                       Subjects: [0x0101],
                       Targets: null,
                   },


### PR DESCRIPTION
Downstreaming changes related to light switch multicast communication.
This allows usage of the simplified chip-tool command when setting up
a group communication. Also corresponding docs update.

