### PR TITLE
[nrf noup] Disable Wi-Fi low-power mode

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -246,6 +246,10 @@ endif
 
 if CHIP_WIFI
 
+config NRF_WIFI_LOW_POWER
+    bool
+    default n
+
 config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
     bool
     default n

--- a/docs/guides/nrfconnect_android_commissioning.md
+++ b/docs/guides/nrfconnect_android_commissioning.md
@@ -210,7 +210,7 @@ Check the IPv6 connectivity with the device using the following steps:
 
 1. Tap **LIGHT ON/OFF & LEVEL CLUSTER**. The following screen appears:
 
-    ![CHIPTool device control screen](./images/CHIPTool_device_commissioned.jpg)
+    ![CHIPTool device control screen](./images/CHIPTool_device_commissioned.png)
 
     The two textboxes at the top contain **Fabric ID** and **Node ID** of the
     last commissioned device.


### PR DESCRIPTION
Noticed Wi-Fi low-power mode causes performance issues,
at least with some APs.