### PR TITLE
Wi-Fi network iterator fix

### DIFF
--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -71,7 +71,7 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
         writer.image_id = image_id;
         writer.open     = [](int id, size_t size) { return dfu_target_init(DFU_TARGET_IMAGE_TYPE_MCUBOOT, id, size, nullptr); };
         writer.write    = [](const uint8_t * chunk, size_t chunk_size) { return dfu_target_write(chunk, chunk_size); };
-        writer.close    = [](bool success) { return dfu_target_done(success); };
+        writer.close    = [](bool success) { return success ? dfu_target_done(success) : dfu_target_reset(); };
 
         ReturnErrorOnFailure(System::MapErrorZephyr(dfu_multi_image_register_writer(&writer)));
     };

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.h
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.h
@@ -56,7 +56,7 @@ public:
     bool IsFirstImageRun() override;
     CHIP_ERROR ConfirmCurrentImage() override;
 
-private:
+protected:
     CHIP_ERROR PrepareDownloadImpl();
     CHIP_ERROR ProcessHeader(ByteSpan & aBlock);
 

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
@@ -52,13 +52,14 @@ public:
     {
     public:
         WiFiNetworkIterator(NrfWiFiDriver * aDriver) : mDriver(aDriver) {}
-        size_t Count() override { return 0; };
-        bool Next(Network & item) override { return true; }
+        size_t Count() override;
+        bool Next(Network & item) override;
         void Release() override { delete this; }
         ~WiFiNetworkIterator() = default;
 
     private:
         NrfWiFiDriver * mDriver;
+        bool mExhausted{ false };
     };
 
     struct WiFiNetwork

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -344,6 +344,7 @@ void WiFiManager::PollTimerCallback()
 CHIP_ERROR WiFiManager::GetWiFiInfo(WiFiInfo & info) const
 {
     VerifyOrReturnError(nullptr != wpa_s, CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(nullptr != mpWpaNetwork, CHIP_ERROR_INTERNAL);
 
     static uint8_t sBssid[ETH_ALEN];
     if (WiFiManager::StationStatus::CONNECTED <= GetStationStatus())
@@ -369,6 +370,10 @@ CHIP_ERROR WiFiManager::GetWiFiInfo(WiFiInfo & info) const
             info.mRssi    = std::numeric_limits<decltype(info.mRssi)>::min();
             info.mChannel = std::numeric_limits<decltype(info.mChannel)>::min();
         }
+
+        memcpy(info.mSsid, mpWpaNetwork->ssid, mpWpaNetwork->ssid_len);
+        info.mSsidLen = mpWpaNetwork->ssid_len;
+
         return CHIP_NO_ERROR;
     }
 

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -122,6 +122,8 @@ public:
         uint8_t mWiFiVersion{};
         uint16_t mChannel{};
         int8_t mRssi{};
+        uint8_t mSsid[DeviceLayer::Internal::kMaxWiFiSSIDLength];
+        size_t mSsidLen{ 0 };
     };
 
     struct NetworkStatistics


### PR DESCRIPTION
#### Problem
The dummy WiFiNetworkIterator causes the infinite loop when reading
network attribute from networkcommissioning cluster.

#### Change overview
Implementation of WiFiNetworkIterator.
This PR also pulls in the BDX transfer fix from the upstream.

#### Testing
* commissioned with `chip-tool` to Matter with WiFi backend
* run `./chip-tool networkcommissioning read networks 1 0`
* received a list with one connected network
