### PR TITLE
[nrf noup] Start using WiFi events instead of using wpa_supplicant

### DIFF
--- a/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
+++ b/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.cpp
@@ -57,27 +57,9 @@ ConnectivityManager::WiFiStationMode ConnectivityManagerImplWiFi::_GetWiFiStatio
 
 CHIP_ERROR ConnectivityManagerImplWiFi::_SetWiFiStationMode(ConnectivityManager::WiFiStationMode aMode)
 {
-    VerifyOrReturnError(ConnectivityManager::WiFiStationMode::kWiFiStationMode_NotSupported != aMode,
-                        CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE);
+    VerifyOrReturnError(ConnectivityManager::WiFiStationMode::kWiFiStationMode_NotSupported != aMode, CHIP_ERROR_INVALID_ARGUMENT);
 
-    if (aMode != mStationMode)
-    {
-        mStationMode = aMode;
-        if (mStationMode != ConnectivityManager::WiFiStationMode::kWiFiStationMode_ApplicationControlled)
-        {
-            bool doEnable{ ConnectivityManager::WiFiStationMode::kWiFiStationMode_Enabled == mStationMode };
-            // TODO: when the connection/disconnection callback API is provided
-            // below calls should be used as a base of disconnect callback
-            if (doEnable)
-            {
-                OnStationConnected();
-            }
-            else
-            {
-                OnStationDisconnected();
-            }
-        }
-    }
+    mStationMode = aMode;
 
     return CHIP_NO_ERROR;
 }
@@ -94,7 +76,7 @@ bool ConnectivityManagerImplWiFi::_IsWiFiStationApplicationControlled(void)
 
 bool ConnectivityManagerImplWiFi::_IsWiFiStationConnected(void)
 {
-    return (WiFiManager::StationStatus::FULLY_PROVISIONED == WiFiManager().Instance().GetStationStatus());
+    return (WiFiManager::StationStatus::CONNECTED == WiFiManager().Instance().GetStationStatus());
 }
 
 System::Clock::Timeout ConnectivityManagerImplWiFi::_GetWiFiStationReconnectInterval(void)
@@ -144,38 +126,6 @@ CHIP_ERROR ConnectivityManagerImplWiFi::_GetAndLogWiFiStatsCounters(void)
 {
     // TODO: when network statistics are enabled
     return CHIP_NO_ERROR;
-}
-
-void ConnectivityManagerImplWiFi::OnStationConnected()
-{
-    // ensure the station is connected
-    if (_IsWiFiStationConnected())
-    {
-        ChipDeviceEvent connectEvent{};
-        connectEvent.Type                          = DeviceEventType::kWiFiConnectivityChange;
-        connectEvent.WiFiConnectivityChange.Result = kConnectivity_Established;
-        PlatformMgr().PostEventOrDie(&connectEvent);
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "WiFi Station is not connected!");
-    }
-}
-
-void ConnectivityManagerImplWiFi::OnStationDisconnected()
-{
-    // ensure the station is disconnected
-    if (WiFiManager::StationStatus::DISCONNECTED == WiFiManager().Instance().GetStationStatus())
-    {
-        ChipDeviceEvent disconnectEvent{};
-        disconnectEvent.Type                          = DeviceEventType::kWiFiConnectivityChange;
-        disconnectEvent.WiFiConnectivityChange.Result = kConnectivity_Lost;
-        PlatformMgr().PostEventOrDie(&disconnectEvent);
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "WiFi Station is not disconnected!");
-    }
 }
 
 ConnectivityManager::WiFiAPMode ConnectivityManagerImplWiFi::_GetWiFiAPMode(void)

--- a/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.h
+++ b/src/platform/nrfconnect/wifi/ConnectivityManagerImplWiFi.h
@@ -54,8 +54,6 @@ private:
     bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
-    void OnStationConnected();
-    void OnStationDisconnected();
 
     // Wi-Fi access point - not supported
     ConnectivityManager::WiFiAPMode _GetWiFiAPMode(void);

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -17,7 +17,6 @@
 
 #include "NrfWiFiDriver.h"
 
-#include "WiFiManager.h"
 #include <platform/KeyValueStoreManager.h>
 
 #include <lib/support/CodeUtils.h>
@@ -27,6 +26,7 @@
 using namespace ::chip;
 using namespace ::chip::DeviceLayer::Internal;
 using namespace ::chip::DeviceLayer::PersistedStorage;
+using namespace ::chip::app::Clusters::NetworkCommissioning;
 
 namespace chip {
 namespace DeviceLayer {
@@ -105,7 +105,7 @@ CHIP_ERROR NrfWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     {
         WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
                                                   [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
-                                                  System::Clock::Timeout{ 40000 } };
+                                                  System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds * 1000 } };
         ReturnErrorOnFailure(
             WiFiManager::Instance().Connect(mStagingNetwork.GetSsidSpan(), mStagingNetwork.GetPassSpan(), handling));
     }
@@ -121,7 +121,15 @@ void NrfWiFiDriver::OnNetworkStatusChanged(Status status)
     }
 
     if (mpNetworkStatusChangeCallback)
+    {
         mpNetworkStatusChangeCallback->OnNetworkingStatusChange(status, NullOptional, NullOptional);
+    }
+
+    if (mpConnectCallback)
+    {
+        mpConnectCallback->OnResult(status, CharSpan(), 0);
+        mpConnectCallback = nullptr;
+    }
 }
 
 void NrfWiFiDriver::Shutdown()
@@ -143,9 +151,9 @@ CHIP_ERROR NrfWiFiDriver::RevertConfiguration()
 
     if (mStagingNetwork.IsConfigured())
     {
-        WiFiManager::ConnectionHandling handling{ [] { Instance().OnConnectWiFiNetwork(); },
-                                                  [] { Instance().OnConnectWiFiNetworkFailed(); },
-                                                  System::Clock::Timeout{ 40000 } };
+        WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
+                                                  [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
+                                                  System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds * 1000 } };
         ReturnErrorOnFailure(
             WiFiManager::Instance().Connect(mStagingNetwork.GetSsidSpan(), mStagingNetwork.GetPassSpan(), handling));
     }
@@ -196,9 +204,12 @@ Status NrfWiFiDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, MutableC
 void NrfWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callback)
 {
     Status status = Status::kSuccess;
-    WiFiManager::ConnectionHandling handling{ [] { Instance().OnConnectWiFiNetwork(); },
-                                              [] { Instance().OnConnectWiFiNetworkFailed(); }, System::Clock::Timeout{ 40000 } };
+    WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
+                                              [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
+                                              System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds * 1000 } };
 
+    VerifyOrExit(WiFiManager::StationStatus::CONNECTING != WiFiManager::Instance().GetStationStatus(),
+                 status = Status::kOtherConnectionFailure);
     VerifyOrExit(networkId.data_equal(mStagingNetwork.GetSsidSpan()), status = Status::kNetworkIDNotFound);
     VerifyOrExit(mpConnectCallback == nullptr, status = Status::kUnknownError);
 
@@ -206,67 +217,11 @@ void NrfWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callbac
     WiFiManager::Instance().Connect(mStagingNetwork.GetSsidSpan(), mStagingNetwork.GetPassSpan(), handling);
 
 exit:
-    if (status != Status::kSuccess)
+    if (status != Status::kSuccess && mpConnectCallback)
     {
-        mpConnectCallback = nullptr;
-        callback->OnResult(status, CharSpan(), 0);
-    }
-}
-
-CHIP_ERROR GetConfiguredNetwork(Network & network)
-{
-    return CHIP_NO_ERROR;
-}
-
-void NrfWiFiDriver::OnConnectWiFiNetwork()
-{
-    ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Enabled);
-
-    if (mpConnectCallback)
-    {
-        mpConnectCallback->OnResult(Status::kSuccess, CharSpan(), 0);
+        mpConnectCallback->OnResult(status, CharSpan(), 0);
         mpConnectCallback = nullptr;
     }
-}
-
-void NrfWiFiDriver::OnConnectWiFiNetworkFailed()
-{
-    if (mpConnectCallback)
-    {
-        mpConnectCallback->OnResult(Status::kNetworkNotFound, CharSpan(), 0);
-        mpConnectCallback = nullptr;
-    }
-}
-
-void NrfWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callback)
-{
-    mScanCallback    = callback;
-    CHIP_ERROR error = WiFiManager::Instance().Scan(
-        ssid, [](int status, WiFiScanResponse * response) { Instance().OnScanWiFiNetworkDone(status, response); });
-
-    if (error != CHIP_NO_ERROR)
-    {
-        mScanCallback = nullptr;
-        callback->OnFinished(Status::kUnknownError, CharSpan(), nullptr);
-    }
-}
-
-void NrfWiFiDriver::OnScanWiFiNetworkDone(int status, WiFiScanResponse * response)
-{
-    if (response != nullptr)
-    {
-        StackLock lock;
-        VerifyOrReturn(mScanCallback != nullptr);
-        mScanResponseIterator.Add(*response);
-        return;
-    }
-
-    // Scan complete
-    DeviceLayer::SystemLayer().ScheduleLambda([this, status]() {
-        VerifyOrReturn(mScanCallback != nullptr);
-        mScanCallback->OnFinished(status == 0 ? Status::kSuccess : Status::kUnknownError, CharSpan(), &mScanResponseIterator);
-        mScanCallback = nullptr;
-    });
 }
 
 void NrfWiFiDriver::LoadFromStorage()
@@ -277,6 +232,37 @@ void NrfWiFiDriver::LoadFromStorage()
     ReturnOnFailure(KeyValueStoreMgr().Get(kSsidKey, network.ssid, sizeof(network.ssid), &network.ssidLen));
     ReturnOnFailure(KeyValueStoreMgr().Get(kPassKey, network.pass, sizeof(network.pass), &network.passLen));
     mStagingNetwork = network;
+}
+
+void NrfWiFiDriver::OnScanWiFiNetworkDone(WiFiManager::WiFiRequestStatus status)
+{
+    VerifyOrReturn(mScanCallback != nullptr);
+    mScanCallback->OnFinished(status == WiFiManager::WiFiRequestStatus::SUCCESS ? Status::kSuccess : Status::kUnknownError,
+                              CharSpan(), &mScanResponseIterator);
+    mScanCallback = nullptr;
+}
+
+void NrfWiFiDriver::OnScanWiFiNetworkResult(WiFiScanResponse * response)
+{
+    if (response != nullptr)
+    {
+        mScanResponseIterator.Add(*response);
+        return;
+    }
+}
+
+void NrfWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callback)
+{
+    mScanCallback    = callback;
+    CHIP_ERROR error = WiFiManager::Instance().Scan(
+        ssid, [](WiFiScanResponse * response) { Instance().OnScanWiFiNetworkResult(response); },
+        [](WiFiManager::WiFiRequestStatus status) { Instance().OnScanWiFiNetworkDone(status); });
+
+    if (error != CHIP_NO_ERROR)
+    {
+        mScanCallback = nullptr;
+        callback->OnFinished(Status::kUnknownError, CharSpan(), nullptr);
+    }
 }
 
 } // namespace NetworkCommissioning

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
@@ -16,6 +16,9 @@
  */
 
 #pragma once
+
+#include "WiFiManager.h"
+
 #include <platform/NetworkCommissioning.h>
 
 namespace chip {
@@ -103,10 +106,9 @@ public:
         return sInstance;
     }
 
-    void OnConnectWiFiNetwork();
-    void OnConnectWiFiNetworkFailed();
     void OnNetworkStatusChanged(Status status);
-    void OnScanWiFiNetworkDone(int status, WiFiScanResponse * result);
+    void OnScanWiFiNetworkResult(WiFiScanResponse * result);
+    void OnScanWiFiNetworkDone(WiFiManager::WiFiRequestStatus status);
 
 private:
     void LoadFromStorage();

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -30,25 +30,25 @@
 
 #include <net/net_stats.h>
 #include <zephyr.h>
+#include <zephyr/net/net_event.h>
 
 extern "C" {
 #include <common/defs.h>
 #include <wpa_supplicant/config.h>
 #include <wpa_supplicant/driver_i.h>
 #include <wpa_supplicant/scan.h>
-#include <zephyr/net/wifi_mgmt.h>
+
+// extern function to obtain bssid from status buffer
+// It is defined in zephyr/subsys/net/ip/utils.c
+extern char * net_sprint_ll_addr_buf(const uint8_t * ll, uint8_t ll_len, char * buf, int buflen);
 }
-
-extern struct wpa_global * global;
-
-static struct wpa_supplicant * wpa_s;
 
 namespace chip {
 namespace DeviceLayer {
 
 namespace {
 
-NetworkCommissioning::WiFiScanResponse ToScanResponse(wifi_scan_result * result)
+NetworkCommissioning::WiFiScanResponse ToScanResponse(const wifi_scan_result * result)
 {
     NetworkCommissioning::WiFiScanResponse response = {};
 
@@ -73,49 +73,34 @@ NetworkCommissioning::WiFiScanResponse ToScanResponse(wifi_scan_result * result)
 
 } // namespace
 
-// These enums shall reflect the overall ordered disconnected->connected flow
-const Map<wpa_states, WiFiManager::StationStatus, 10>
-    WiFiManager::sStatusMap({ { WPA_DISCONNECTED, WiFiManager::StationStatus::DISCONNECTED },
-                              { WPA_INTERFACE_DISABLED, WiFiManager::StationStatus::DISABLED },
-                              { WPA_INACTIVE, WiFiManager::StationStatus::DISABLED },
-                              { WPA_SCANNING, WiFiManager::StationStatus::SCANNING },
-                              { WPA_AUTHENTICATING, WiFiManager::StationStatus::CONNECTING },
-                              { WPA_ASSOCIATING, WiFiManager::StationStatus::CONNECTING },
-                              { WPA_ASSOCIATED, WiFiManager::StationStatus::CONNECTED },
-                              { WPA_4WAY_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
-                              { WPA_GROUP_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
-                              { WPA_COMPLETED, WiFiManager::StationStatus::FULLY_PROVISIONED } });
+const Map<wifi_iface_state, WiFiManager::StationStatus, 10>
+    WiFiManager::sStatusMap({ { WIFI_STATE_DISCONNECTED, WiFiManager::StationStatus::DISCONNECTED },
+                              { WIFI_STATE_INTERFACE_DISABLED, WiFiManager::StationStatus::DISABLED },
+                              { WIFI_STATE_INACTIVE, WiFiManager::StationStatus::DISABLED },
+                              { WIFI_STATE_SCANNING, WiFiManager::StationStatus::SCANNING },
+                              { WIFI_STATE_AUTHENTICATING, WiFiManager::StationStatus::CONNECTING },
+                              { WIFI_STATE_ASSOCIATING, WiFiManager::StationStatus::CONNECTING },
+                              { WIFI_STATE_ASSOCIATED, WiFiManager::StationStatus::CONNECTED },
+                              { WIFI_STATE_4WAY_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
+                              { WIFI_STATE_GROUP_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
+                              { WIFI_STATE_COMPLETED, WiFiManager::StationStatus::FULLY_PROVISIONED } });
 
-// Map WiFi center frequency to the corresponding channel number
-const Map<uint16_t, uint8_t, 42> WiFiManager::sFreqChannelMap(
-    { { 4915, 183 }, { 4920, 184 }, { 4925, 185 }, { 4935, 187 }, { 4940, 188 }, { 4945, 189 }, { 4960, 192 },
-      { 4980, 196 }, { 5035, 7 },   { 5040, 8 },   { 5045, 9 },   { 5055, 11 },  { 5060, 12 },  { 5080, 16 },
-      { 5170, 34 },  { 5180, 36 },  { 5190, 38 },  { 5200, 40 },  { 5210, 42 },  { 5220, 44 },  { 5230, 46 },
-      { 5240, 48 },  { 5260, 52 },  { 5280, 56 },  { 5300, 60 },  { 5320, 64 },  { 5500, 100 }, { 5520, 104 },
-      { 5540, 108 }, { 5560, 112 }, { 5580, 116 }, { 5600, 120 }, { 5620, 124 }, { 5640, 128 }, { 5660, 132 },
-      { 5680, 136 }, { 5700, 140 }, { 5745, 149 }, { 5765, 153 }, { 5785, 157 }, { 5805, 161 }, { 5825, 165 } });
+const Map<uint32_t, WiFiManager::NetEventHandler, 4>
+    WiFiManager::sEventHandlerMap({ { NET_EVENT_WIFI_SCAN_RESULT, WiFiManager::ScanResultClbk },
+                                    { NET_EVENT_WIFI_SCAN_DONE, WiFiManager::ScanDoneClbk },
+                                    { NET_EVENT_WIFI_CONNECT_RESULT, WiFiManager::ConnectClbk },
+                                    { NET_EVENT_WIFI_DISCONNECT_RESULT, WiFiManager::DisconnectClbk } });
+
+void WiFiManager::WifiMgmtEventHandler(NetEventCallback * cb, uint32_t mgmtEvent, struct net_if * iface)
+{
+    if (0 == strcmp(iface->if_dev->dev->name, "wlan0"))
+    {
+        DeviceLayer::SystemLayer().ScheduleLambda([cb, mgmtEvent] { sEventHandlerMap[mgmtEvent](cb); });
+    }
+}
 
 CHIP_ERROR WiFiManager::Init()
 {
-    // wpa_supplicant instance is initialized in dedicated supplicant thread, so wait until
-    // the initialization is completed.
-    // TODO: fix thread-safety of the solution.
-    constexpr size_t kInitTimeoutMs = 5000;
-    const int64_t initStartTime     = k_uptime_get();
-    // TODO: Handle multiple VIFs
-    const char * ifname = "wlan0";
-
-    while (!global || !(wpa_s = wpa_supplicant_get_iface(global, ifname)))
-    {
-        if (k_uptime_get() > initStartTime + kInitTimeoutMs)
-        {
-            ChipLogError(DeviceLayer, "wpa_supplicant is not initialized!");
-            return CHIP_ERROR_INTERNAL;
-        }
-
-        k_msleep(200);
-    }
-
     // TODO: consider moving these to ConnectivityManagerImpl to be prepared for handling multiple interfaces on a single device.
     Inet::UDPEndPointImplSockets::SetJoinMulticastGroupHandler([](Inet::InterfaceId interfaceId, const Inet::IPAddress & address) {
         const in6_addr addr = InetUtils::ToZephyrAddr(address);
@@ -145,286 +130,130 @@ CHIP_ERROR WiFiManager::Init()
         return CHIP_NO_ERROR;
     });
 
-    ChipLogDetail(DeviceLayer, "wpa_supplicant has been initialized");
+    net_mgmt_init_event_callback(&mWiFiMgmtClbk, WifiMgmtEventHandler, kWifiManagementEvents);
+    net_mgmt_add_event_callback(&mWiFiMgmtClbk);
+
+    ChipLogDetail(DeviceLayer, "WiFiManager has been initialized");
 
     return CHIP_NO_ERROR;
 }
-
-CHIP_ERROR WiFiManager::AddNetwork(const ByteSpan & ssid, const ByteSpan & credentials)
+CHIP_ERROR WiFiManager::Scan(const ByteSpan & ssid, ScanResultCallback resultCallback, ScanDoneCallback doneCallback)
 {
-    ChipLogDetail(DeviceLayer, "Adding WiFi network");
-    mpWpaNetwork = wpa_supplicant_add_network(wpa_s);
-    if (mpWpaNetwork)
+    struct net_if * iface = InetUtils::GetInterface();
+    VerifyOrReturnError(nullptr != iface, CHIP_ERROR_INTERNAL);
+
+    mScanResultCallback = resultCallback;
+    mScanDoneCallback   = doneCallback;
+    mWiFiState          = WIFI_STATE_SCANNING;
+
+    if (net_mgmt(NET_REQUEST_WIFI_SCAN, iface, NULL, 0))
     {
-        static constexpr size_t kMaxSsidLen{ 32 };
-        mpWpaNetwork->ssid = (u8 *) k_malloc(kMaxSsidLen);
-
-        if (mpWpaNetwork->ssid)
-        {
-            memcpy(mpWpaNetwork->ssid, ssid.data(), ssid.size());
-            mpWpaNetwork->ssid_len    = ssid.size();
-            mpWpaNetwork->key_mgmt    = WPA_KEY_MGMT_NONE;
-            mpWpaNetwork->disabled    = 1;
-            wpa_s->conf->filter_ssids = 1;
-
-            return AddPsk(credentials);
-        }
+        ChipLogError(DeviceLayer, "Scan request failed");
+        return CHIP_ERROR_INTERNAL;
     }
 
-    return CHIP_ERROR_INTERNAL;
-}
-
-CHIP_ERROR WiFiManager::Scan(const ByteSpan & ssid, ScanCallback callback)
-{
-    const StationStatus stationStatus = GetStationStatus();
-    VerifyOrReturnError(stationStatus != StationStatus::DISABLED && stationStatus != StationStatus::SCANNING &&
-                            stationStatus != StationStatus::CONNECTING,
-                        CHIP_ERROR_INCORRECT_STATE);
-
-    net_if * const iface = InetUtils::GetInterface();
-    VerifyOrReturnError(iface != nullptr, CHIP_ERROR_INTERNAL);
-
-    const device * dev = net_if_get_device(iface);
-    VerifyOrReturnError(dev != nullptr, CHIP_ERROR_INTERNAL);
-
-    const net_wifi_mgmt_offload * ops = static_cast<const net_wifi_mgmt_offload *>(dev->api);
-    VerifyOrReturnError(ops != nullptr, CHIP_ERROR_INTERNAL);
-
-    mScanCallback = callback;
-
-    // TODO: Use saner API once such exists.
-    // TODO: Take 'ssid' into account.
-    VerifyOrReturnError(ops->scan(dev,
-                                  [](net_if *, int status, wifi_scan_result * result) {
-                                      VerifyOrReturn(Instance().mScanCallback != nullptr);
-                                      NetworkCommissioning::WiFiScanResponse response = ToScanResponse(result);
-                                      Instance().mScanCallback(status, result != nullptr ? &response : nullptr);
-                                  }) == 0,
-                        CHIP_ERROR_INTERNAL);
-
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR WiFiManager::Connect(const ByteSpan & ssid, const ByteSpan & credentials, const ConnectionHandling & handling)
-{
-    ChipLogDetail(DeviceLayer, "Connecting to WiFi network");
-
-    mConnectionSuccessClbk = handling.mOnConnectionSuccess;
-    mConnectionFailedClbk  = handling.mOnConnectionFailed;
-    mConnectionTimeoutMs   = handling.mConnectionTimeoutMs;
-
-    CHIP_ERROR err = AddNetwork(ssid, credentials);
-    if (CHIP_NO_ERROR == err)
-    {
-        EnableStation(true);
-        wpa_supplicant_select_network(wpa_s, mpWpaNetwork);
-        WaitForConnectionAsync();
-    }
-    else
-    {
-        OnConnectionFailed();
-    }
-    return err;
-}
-
-void WiFiManager::OnConnectionSuccess()
-{
-    if (mConnectionSuccessClbk)
-        mConnectionSuccessClbk();
-}
-
-void WiFiManager::OnConnectionFailed()
-{
-    if (mConnectionFailedClbk)
-        mConnectionFailedClbk();
-}
-
-CHIP_ERROR WiFiManager::AddPsk(const ByteSpan & credentials)
-{
-    mpWpaNetwork->key_mgmt = WPA_KEY_MGMT_PSK;
-    str_clear_free(mpWpaNetwork->passphrase);
-    mpWpaNetwork->passphrase = dup_binstr(credentials.data(), credentials.size());
-
-    if (mpWpaNetwork->passphrase)
-    {
-        wpa_config_update_psk(mpWpaNetwork);
-        return CHIP_NO_ERROR;
-    }
-
-    return CHIP_ERROR_INTERNAL;
-}
-
-WiFiManager::StationStatus WiFiManager::GetStationStatus() const
-{
-    if (wpa_s)
-    {
-        return StatusFromWpaStatus(wpa_s->wpa_state);
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "wpa_supplicant is not initialized!");
-        return StationStatus::NONE;
-    }
-}
-
-WiFiManager::StationStatus WiFiManager::StatusFromWpaStatus(const wpa_states & status)
-{
-    ChipLogDetail(DeviceLayer, "WPA internal status: %d", static_cast<int>(status));
-    return WiFiManager::sStatusMap[status];
-}
-
-CHIP_ERROR WiFiManager::EnableStation(bool enable)
-{
-    VerifyOrReturnError(nullptr != wpa_s && nullptr != mpWpaNetwork, CHIP_ERROR_INTERNAL);
-    if (enable)
-    {
-        wpa_supplicant_enable_network(wpa_s, mpWpaNetwork);
-    }
-    else
-    {
-        wpa_supplicant_disable_network(wpa_s, mpWpaNetwork);
-    }
+    ChipLogDetail(DeviceLayer, "WiFi scanning started...");
 
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR WiFiManager::ClearStationProvisioningData()
 {
-    VerifyOrReturnError(nullptr != wpa_s && nullptr != mpWpaNetwork, CHIP_ERROR_INTERNAL);
-    wpa_supplicant_cancel_scan(wpa_s);
-    wpa_clear_keys(wpa_s, mpWpaNetwork->bssid);
-    str_clear_free(mpWpaNetwork->passphrase);
-    wpa_config_update_psk(mpWpaNetwork);
-    wpa_supplicant_set_state(wpa_s, WPA_INACTIVE);
-
+    memset(&mWiFiParams, 0, sizeof(mWiFiParams));
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WiFiManager::DisconnectStation()
+CHIP_ERROR WiFiManager::Connect(const ByteSpan & ssid, const ByteSpan & credentials, const ConnectionHandling & handling)
 {
-    VerifyOrReturnError(nullptr != wpa_s, CHIP_ERROR_INTERNAL);
-    wpa_supplicant_cancel_scan(wpa_s);
-    wpas_request_disconnection(wpa_s);
+    ChipLogDetail(DeviceLayer, "Connecting to WiFi network: %*s", ssid.size(), ssid.data());
 
-    return CHIP_NO_ERROR;
-}
+    mHandling.mOnConnectionSuccess = handling.mOnConnectionSuccess;
+    mHandling.mOnConnectionFailed  = handling.mOnConnectionFailed;
 
-void WiFiManager::WaitForConnectionAsync()
-{
-    chip::DeviceLayer::SystemLayer().StartTimer(
-        static_cast<System::Clock::Timeout>(1000), [](System::Layer *, void *) { Instance().PollTimerCallback(); }, nullptr);
-}
+    mWiFiState = WIFI_STATE_ASSOCIATING;
 
-void WiFiManager::PollTimerCallback()
-{
-    const uint32_t kMaxRetriesNumber{ mConnectionTimeoutMs.count() / 1000 };
-    static uint32_t retriesNumber{ 0 };
+    struct net_if * iface = InetUtils::GetInterface();
 
-    if (WiFiManager::StationStatus::FULLY_PROVISIONED == GetStationStatus())
+    VerifyOrReturnError(nullptr != iface, CHIP_ERROR_INTERNAL);
+
+    // We can use pointers for ssid and credentials without clone them because setting new ones is blocked during associating.
+    mWiFiParams.ssid        = ssid.data();
+    mWiFiParams.ssid_length = ssid.size();
+    mWiFiParams.psk         = const_cast<unsigned char *>(credentials.data());
+    mWiFiParams.psk_length  = credentials.size();
+    mWiFiParams.security    = WIFI_SECURITY_TYPE_PSK;
+    mWiFiParams.timeout     = handling.mConnectionTimeoutMs.count();
+    mWiFiParams.channel     = WIFI_CHANNEL_ANY;
+
+    if (net_mgmt(NET_REQUEST_WIFI_CONNECT, iface, &mWiFiParams, sizeof(ConnectionParams)))
     {
-        retriesNumber = 0;
-        OnConnectionSuccess();
+        ChipLogError(DeviceLayer, "Connection request failed");
+        if (Instance().mHandling.mOnConnectionFailed)
+            Instance().mHandling.mOnConnectionFailed();
+        return CHIP_ERROR_INTERNAL;
     }
-    else
+
+    ChipLogError(DeviceLayer, "Connection to %s requested", ssid.data());
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR WiFiManager::Disconnect()
+{
+    struct net_if * iface = InetUtils::GetInterface();
+    VerifyOrReturnError(nullptr != iface, CHIP_ERROR_INTERNAL);
+
+    int status = net_mgmt(NET_REQUEST_WIFI_DISCONNECT, iface, NULL, 0);
+
+    if (status)
     {
-        if (retriesNumber++ < kMaxRetriesNumber)
+        if (status == -EALREADY)
         {
-            // wait more time
-            WaitForConnectionAsync();
+            ChipLogDetail(DeviceLayer, "Already disconnected");
         }
         else
         {
-            // connection timeout
-            retriesNumber = 0;
-            OnConnectionFailed();
+            ChipLogDetail(DeviceLayer, "Disconnect request failed");
+            return CHIP_ERROR_INTERNAL;
         }
     }
+    else
+    {
+        ChipLogDetail(DeviceLayer, "Disconnect requested");
+    }
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR WiFiManager::GetWiFiInfo(WiFiInfo & info) const
 {
-    VerifyOrReturnError(nullptr != wpa_s, CHIP_ERROR_INTERNAL);
-    VerifyOrReturnError(nullptr != mpWpaNetwork, CHIP_ERROR_INTERNAL);
+    struct net_if * iface = InetUtils::GetInterface();
+    VerifyOrReturnError(nullptr != iface, CHIP_ERROR_INTERNAL);
+    struct wifi_iface_status status = { 0 };
 
-    static uint8_t sBssid[ETH_ALEN];
-    if (WiFiManager::StationStatus::CONNECTED <= GetStationStatus())
+    if (net_mgmt(NET_REQUEST_WIFI_IFACE_STATUS, iface, &status, sizeof(struct wifi_iface_status)))
     {
-        memcpy(sBssid, wpa_s->bssid, ETH_ALEN);
-        info.mBssId        = ByteSpan(sBssid, ETH_ALEN);
-        info.mSecurityType = GetSecurityType();
-        // TODO: this should reflect the real connection compliance
-        // i.e. the AP might support WiFi 5 only even though the station
-        // is WiFi 6 ready (so the connection is WiFi 5 effectively).
-        // For now just return what the station supports.
-        info.mWiFiVersion = EMBER_ZCL_WI_FI_VERSION_TYPE_802__11AX;
+        ChipLogError(DeviceLayer, "Status request failed");
+        return CHIP_ERROR_INTERNAL;
+    }
 
-        wpa_signal_info signalInfo{};
-        if (0 == wpa_drv_signal_poll(wpa_s, &signalInfo))
-        {
-            info.mRssi    = signalInfo.current_signal; // dBm
-            info.mChannel = FrequencyToChannel(signalInfo.frequency);
-        }
-        else
-        {
-            // this values should be nullable according to the Matter spec
-            info.mRssi    = std::numeric_limits<decltype(info.mRssi)>::min();
-            info.mChannel = std::numeric_limits<decltype(info.mChannel)>::min();
-        }
-
-        memcpy(info.mSsid, mpWpaNetwork->ssid, mpWpaNetwork->ssid_len);
-        info.mSsidLen = mpWpaNetwork->ssid_len;
+    if (status.state >= WIFI_STATE_ASSOCIATED)
+    {
+        uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
+        net_sprint_ll_addr_buf(reinterpret_cast<const uint8_t *>(status.bssid), WIFI_MAC_ADDR_LEN,
+                               reinterpret_cast<char *>(mac_string_buf), sizeof(mac_string_buf));
+        info.mBssId        = ByteSpan(mac_string_buf, sizeof(mac_string_buf));
+        info.mSecurityType = static_cast<uint8_t>(status.security);
+        info.mWiFiVersion  = static_cast<uint8_t>(status.link_mode);
+        info.mRssi         = status.rssi;
+        info.mChannel      = status.channel;
+        info.mSsidLen      = status.ssid_len;
+        memcpy(info.mSsid, status.ssid, status.ssid_len);
 
         return CHIP_NO_ERROR;
     }
 
     return CHIP_ERROR_INTERNAL;
-}
-
-uint8_t WiFiManager::GetSecurityType() const
-{
-    VerifyOrReturnValue(nullptr != mpWpaNetwork, EMBER_ZCL_SECURITY_TYPE_UNSPECIFIED);
-
-    if ((mpWpaNetwork->key_mgmt & WPA_KEY_MGMT_NONE) || !wpa_key_mgmt_wpa_any(mpWpaNetwork->key_mgmt))
-    {
-        return EMBER_ZCL_SECURITY_TYPE_NONE;
-    }
-    else if (wpa_key_mgmt_wpa_psk_no_sae(mpWpaNetwork->key_mgmt))
-    {
-        return (mpWpaNetwork->pairwise_cipher & (WPA_CIPHER_TKIP | WPA_CIPHER_CCMP)) ? EMBER_ZCL_SECURITY_TYPE_WPA2
-                                                                                     : EMBER_ZCL_SECURITY_TYPE_WPA3;
-    }
-    else if (wpa_key_mgmt_sae(mpWpaNetwork->key_mgmt))
-    {
-        return EMBER_ZCL_SECURITY_TYPE_WPA3;
-    }
-    else
-    {
-        return EMBER_ZCL_SECURITY_TYPE_WEP;
-    }
-
-    return EMBER_ZCL_SECURITY_TYPE_UNSPECIFIED;
-}
-
-uint8_t WiFiManager::FrequencyToChannel(uint16_t freq)
-{
-    static constexpr uint16_t k24MinFreq{ 2401 };
-    static constexpr uint16_t k24MaxFreq{ 2484 };
-    static constexpr uint8_t k24FreqConstDiff{ 5 };
-
-    if (freq >= k24MinFreq && freq < k24MaxFreq)
-    {
-        return static_cast<uint8_t>((freq - k24MinFreq) / k24FreqConstDiff + 1);
-    }
-    else if (freq == k24MaxFreq)
-    {
-        return 14;
-    }
-    else if (freq > k24MaxFreq)
-    {
-        // assume we are in 5GH band
-        return sFreqChannelMap[freq];
-    }
-    return 0;
 }
 
 CHIP_ERROR WiFiManager::GetNetworkStatistics(NetworkStatistics & stats) const
@@ -441,6 +270,78 @@ CHIP_ERROR WiFiManager::GetNetworkStatistics(NetworkStatistics & stats) const
     stats.mOverruns               = 0; // TODO: clarify if this can be queried from mgmt API (e.g. data.tx_dropped)
 
     return CHIP_NO_ERROR;
+}
+
+void WiFiManager::ScanResultClbk(NetEventCallback * cb)
+{
+    VerifyOrReturn(Instance().mScanResultCallback != nullptr);
+    const struct wifi_scan_result * scanResult      = (const struct wifi_scan_result *) cb->info;
+    NetworkCommissioning::WiFiScanResponse response = ToScanResponse(scanResult);
+    Instance().mScanResultCallback(scanResult != nullptr ? &response : nullptr);
+}
+
+void WiFiManager::ScanDoneClbk(NetEventCallback * cb)
+{
+    VerifyOrReturn(Instance().mScanDoneCallback != nullptr);
+    const WiFiStatus * status       = static_cast<const WiFiStatus *>(cb->info);
+    WiFiRequestStatus requestStatus = static_cast<WiFiRequestStatus>(status->status);
+
+    if (requestStatus == WiFiRequestStatus::FAIL)
+    {
+        ChipLogDetail(DeviceLayer, "Scan request failed (%d)", status->status);
+    }
+    else
+    {
+        ChipLogDetail(DeviceLayer, "Scan request done (%d)", status->status);
+    }
+
+    Instance().mScanDoneCallback(requestStatus);
+}
+
+void WiFiManager::ConnectClbk(NetEventCallback * cb)
+{
+    const WiFiStatus * status       = static_cast<const WiFiStatus *>(cb->info);
+    WiFiRequestStatus requestStatus = static_cast<WiFiRequestStatus>(status->status);
+
+    if (requestStatus == WiFiRequestStatus::FAIL)
+    {
+        ChipLogDetail(DeviceLayer, "Connection to WiFi network failed");
+        Instance().mWiFiState = WIFI_STATE_DISCONNECTED;
+        if (Instance().mHandling.mOnConnectionFailed)
+        {
+            Instance().mHandling.mOnConnectionFailed();
+        }
+    }
+    else
+    {
+        ChipLogDetail(DeviceLayer, "Connected to WiFi network");
+        Instance().mWiFiState = WIFI_STATE_COMPLETED;
+        if (Instance().mHandling.mOnConnectionSuccess)
+        {
+            Instance().mHandling.mOnConnectionSuccess();
+        }
+        Instance().PostConnectivityStatusChange(kConnectivity_Established);
+    }
+}
+
+void WiFiManager::DisconnectClbk(NetEventCallback * cb)
+{
+    ChipLogDetail(DeviceLayer, "WiFi station disconnected");
+    Instance().mWiFiState = WIFI_STATE_DISCONNECTED;
+    Instance().PostConnectivityStatusChange(kConnectivity_Lost);
+}
+
+WiFiManager::StationStatus WiFiManager::GetStationStatus() const
+{
+    return WiFiManager::sStatusMap[mWiFiState];
+}
+
+void WiFiManager::PostConnectivityStatusChange(ConnectivityChange changeType)
+{
+    ChipDeviceEvent networkEvent{};
+    networkEvent.Type                          = DeviceEventType::kWiFiConnectivityChange;
+    networkEvent.WiFiConnectivityChange.Result = changeType;
+    PlatformMgr().PostEventOrDie(&networkEvent);
 }
 
 } // namespace DeviceLayer

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -24,10 +24,12 @@
 
 #include <lib/core/CHIPError.h>
 #include <lib/support/Span.h>
+#include <platform/CHIPDeviceLayer.h>
 #include <platform/NetworkCommissioning.h>
 #include <system/SystemLayer.h>
 
 #include <net/net_if.h>
+#include <net/wifi_mgmt.h>
 
 extern "C" {
 #include <src/utils/common.h>
@@ -85,9 +87,16 @@ private:
 
 class WiFiManager
 {
-    using ConnectionCallback = void (*)();
-
 public:
+    enum WiFiRequestStatus : int
+    {
+        FAIL    = -1,
+        SUCCESS = 0
+    };
+
+    using ScanResultCallback = void (*)(NetworkCommissioning::WiFiScanResponse *);
+    using ScanDoneCallback   = void (*)(WiFiRequestStatus);
+
     enum class StationStatus : uint8_t
     {
         NONE,
@@ -97,7 +106,8 @@ public:
         CONNECTING,
         CONNECTED,
         PROVISIONING,
-        FULLY_PROVISIONED
+        FULLY_PROVISIONED,
+        UNKNOWN
     };
 
     static WiFiManager & Instance()
@@ -106,7 +116,7 @@ public:
         return sInstance;
     }
 
-    using ScanCallback = void (*)(int /* status */, NetworkCommissioning::WiFiScanResponse *);
+    using ConnectionCallback = void (*)();
 
     struct ConnectionHandling
     {
@@ -136,35 +146,50 @@ public:
     };
 
     CHIP_ERROR Init();
-    CHIP_ERROR Scan(const ByteSpan & ssid, ScanCallback callback);
+    CHIP_ERROR Scan(const ByteSpan & ssid, ScanResultCallback resultCallback, ScanDoneCallback doneCallback);
     CHIP_ERROR Connect(const ByteSpan & ssid, const ByteSpan & credentials, const ConnectionHandling & handling);
     StationStatus GetStationStatus() const;
     CHIP_ERROR ClearStationProvisioningData();
-    CHIP_ERROR DisconnectStation();
+    CHIP_ERROR Disconnect();
     CHIP_ERROR GetWiFiInfo(WiFiInfo & info) const;
     CHIP_ERROR GetNetworkStatistics(NetworkStatistics & stats) const;
 
 private:
-    CHIP_ERROR AddPsk(const ByteSpan & credentials);
+    using ConnectionParams = wifi_connect_req_params;
+    using NetEventCallback = net_mgmt_event_callback;
+    using WiFiStatus       = wifi_status;
+    using NetEventHandler  = void (*)(NetEventCallback *);
+
+    struct NetworkEventData
+    {
+        NetEventCallback * mCallback;
+        uint32_t mEvent;
+    };
+
+    constexpr static uint32_t kWifiManagementEvents = NET_EVENT_WIFI_SCAN_RESULT | NET_EVENT_WIFI_SCAN_DONE |
+        NET_EVENT_WIFI_CONNECT_RESULT | NET_EVENT_WIFI_DISCONNECT_RESULT | NET_EVENT_WIFI_IFACE_STATUS;
+
+    CHIP_ERROR AddPsk(wifi_connect_req_params * params, const ByteSpan & credentials);
     CHIP_ERROR EnableStation(bool enable);
     CHIP_ERROR AddNetwork(const ByteSpan & ssid, const ByteSpan & credentials);
-    void PollTimerCallback();
-    void WaitForConnectionAsync();
-    void OnConnectionSuccess();
-    void OnConnectionFailed();
     uint8_t GetSecurityType() const;
 
-    WpaNetwork * mpWpaNetwork{ nullptr };
-    ConnectionCallback mConnectionSuccessClbk;
-    ConnectionCallback mConnectionFailedClbk;
-    System::Clock::Timeout mConnectionTimeoutMs;
-    ScanCallback mScanCallback{ nullptr };
+    // Event handling
+    static void WifiMgmtEventHandler(NetEventCallback * cb, uint32_t mgmtEvent, struct net_if * iface);
+    static void ScanResultClbk(NetEventCallback * cb);
+    static void ScanDoneClbk(NetEventCallback * cb);
+    static void ConnectClbk(NetEventCallback * cb);
+    static void DisconnectClbk(NetEventCallback * cb);
+    static void PostConnectivityStatusChange(ConnectivityChange changeType);
 
-    static uint8_t FrequencyToChannel(uint16_t freq);
-    static StationStatus StatusFromWpaStatus(const wpa_states & status);
-
-    static const Map<wpa_states, StationStatus, 10> sStatusMap;
-    static const Map<uint16_t, uint8_t, 42> sFreqChannelMap;
+    ConnectionParams mWiFiParams{};
+    ConnectionHandling mHandling;
+    wifi_iface_state mWiFiState;
+    NetEventCallback mWiFiMgmtClbk{};
+    ScanResultCallback mScanResultCallback{ nullptr };
+    ScanDoneCallback mScanDoneCallback{ nullptr };
+    static const Map<wifi_iface_state, StationStatus, 10> sStatusMap;
+    static const Map<uint32_t, NetEventHandler, 4> sEventHandlerMap;
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem
Switching from wpa_supplicant API to WiFi mgmt events

#### Change overview
- Removed wpa_supplicant calls from WiFiManager and replaced them with WiFi events from wifi_mgmt.
- Removed a workaround from ConnectivityManagerImplWifi in _SetWiFiStationMode.
- Added ConnectionWorkerHandler to switch context during calling OnResult wifi connection callback.
- Removed a workaround from ConnectivityManagerImplWifi in _SetWiFiStationMode.

