### PR TITLE
[nrf noup] Implemented WiFi security modes handling

### DIFF
--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -226,7 +226,7 @@ exit:
 
 void NrfWiFiDriver::LoadFromStorage()
 {
-    WiFiNetwork network;
+    WiFiManager::WiFiNetwork network;
 
     mStagingNetwork = {};
     ReturnOnFailure(KeyValueStoreMgr().Get(kSsidKey, network.ssid, sizeof(network.ssid), &network.ssidLen));
@@ -242,20 +242,16 @@ void NrfWiFiDriver::OnScanWiFiNetworkDone(WiFiManager::WiFiRequestStatus status)
     mScanCallback = nullptr;
 }
 
-void NrfWiFiDriver::OnScanWiFiNetworkResult(WiFiScanResponse * response)
+void NrfWiFiDriver::OnScanWiFiNetworkResult(const WiFiScanResponse & response)
 {
-    if (response != nullptr)
-    {
-        mScanResponseIterator.Add(*response);
-        return;
-    }
+    mScanResponseIterator.Add(response);
 }
 
 void NrfWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callback)
 {
     mScanCallback    = callback;
     CHIP_ERROR error = WiFiManager::Instance().Scan(
-        ssid, [](WiFiScanResponse * response) { Instance().OnScanWiFiNetworkResult(response); },
+        ssid, [](const WiFiScanResponse & response) { Instance().OnScanWiFiNetworkResult(response); },
         [](WiFiManager::WiFiRequestStatus status) { Instance().OnScanWiFiNetworkDone(status); });
 
     if (error != CHIP_NO_ERROR)

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
@@ -65,19 +65,6 @@ public:
         bool mExhausted{ false };
     };
 
-    struct WiFiNetwork
-    {
-        uint8_t ssid[DeviceLayer::Internal::kMaxWiFiSSIDLength];
-        size_t ssidLen = 0;
-        uint8_t pass[DeviceLayer::Internal::kMaxWiFiKeyLength];
-        size_t passLen = 0;
-
-        bool IsConfigured() const { return ssidLen > 0; }
-        ByteSpan GetSsidSpan() const { return ByteSpan(ssid, ssidLen); }
-        ByteSpan GetPassSpan() const { return ByteSpan(pass, passLen); }
-        void Clear() { ssidLen = 0; }
-    };
-
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
@@ -107,7 +94,7 @@ public:
     }
 
     void OnNetworkStatusChanged(Status status);
-    void OnScanWiFiNetworkResult(WiFiScanResponse * result);
+    void OnScanWiFiNetworkResult(const WiFiScanResponse & result);
     void OnScanWiFiNetworkDone(WiFiManager::WiFiRequestStatus status);
 
 private:
@@ -115,7 +102,7 @@ private:
 
     ConnectCallback * mpConnectCallback{ nullptr };
     NetworkStatusChangeCallback * mpNetworkStatusChangeCallback{ nullptr };
-    WiFiNetwork mStagingNetwork;
+    WiFiManager::WiFiNetwork mStagingNetwork;
     NrfWiFiScanResponseIterator mScanResponseIterator;
     ScanCallback * mScanCallback{ nullptr };
 };

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -94,8 +94,9 @@ public:
         SUCCESS = 0
     };
 
-    using ScanResultCallback = void (*)(NetworkCommissioning::WiFiScanResponse *);
+    using ScanResultCallback = void (*)(const NetworkCommissioning::WiFiScanResponse &);
     using ScanDoneCallback   = void (*)(WiFiRequestStatus);
+    using ConnectionCallback = void (*)();
 
     enum class StationStatus : uint8_t
     {
@@ -115,8 +116,6 @@ public:
         static WiFiManager sInstance;
         return sInstance;
     }
-
-    using ConnectionCallback = void (*)();
 
     struct ConnectionHandling
     {
@@ -145,8 +144,22 @@ public:
         uint32_t mOverruns{};
     };
 
+    struct WiFiNetwork
+    {
+        uint8_t ssid[DeviceLayer::Internal::kMaxWiFiSSIDLength];
+        size_t ssidLen = 0;
+        uint8_t pass[DeviceLayer::Internal::kMaxWiFiKeyLength];
+        size_t passLen = 0;
+
+        bool IsConfigured() const { return ssidLen > 0; }
+        ByteSpan GetSsidSpan() const { return ByteSpan(ssid, ssidLen); }
+        ByteSpan GetPassSpan() const { return ByteSpan(pass, passLen); }
+        void Clear() { ssidLen = 0; }
+    };
+
     CHIP_ERROR Init();
-    CHIP_ERROR Scan(const ByteSpan & ssid, ScanResultCallback resultCallback, ScanDoneCallback doneCallback);
+    CHIP_ERROR Scan(const ByteSpan & ssid, ScanResultCallback resultCallback, ScanDoneCallback doneCallback,
+                    bool internalScan = false);
     CHIP_ERROR Connect(const ByteSpan & ssid, const ByteSpan & credentials, const ConnectionHandling & handling);
     StationStatus GetStationStatus() const;
     CHIP_ERROR ClearStationProvisioningData();
@@ -155,39 +168,33 @@ public:
     CHIP_ERROR GetNetworkStatistics(NetworkStatistics & stats) const;
 
 private:
-    using ConnectionParams = wifi_connect_req_params;
-    using NetEventCallback = net_mgmt_event_callback;
-    using WiFiStatus       = wifi_status;
-    using NetEventHandler  = void (*)(NetEventCallback *);
+    using NetEventHandler = void (*)(uint8_t *);
 
-    struct NetworkEventData
+    struct ConnectionParams
     {
-        NetEventCallback * mCallback;
-        uint32_t mEvent;
+        wifi_connect_req_params mParams;
+        int8_t mRssi{ std::numeric_limits<int8_t>::min() };
     };
 
     constexpr static uint32_t kWifiManagementEvents = NET_EVENT_WIFI_SCAN_RESULT | NET_EVENT_WIFI_SCAN_DONE |
         NET_EVENT_WIFI_CONNECT_RESULT | NET_EVENT_WIFI_DISCONNECT_RESULT | NET_EVENT_WIFI_IFACE_STATUS;
 
-    CHIP_ERROR AddPsk(wifi_connect_req_params * params, const ByteSpan & credentials);
-    CHIP_ERROR EnableStation(bool enable);
-    CHIP_ERROR AddNetwork(const ByteSpan & ssid, const ByteSpan & credentials);
-    uint8_t GetSecurityType() const;
-
     // Event handling
-    static void WifiMgmtEventHandler(NetEventCallback * cb, uint32_t mgmtEvent, struct net_if * iface);
-    static void ScanResultClbk(NetEventCallback * cb);
-    static void ScanDoneClbk(NetEventCallback * cb);
-    static void ConnectClbk(NetEventCallback * cb);
-    static void DisconnectClbk(NetEventCallback * cb);
+    static void WifiMgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface);
+    static void ScanResultHandler(uint8_t * data);
+    static void ScanDoneHandler(uint8_t * data);
+    static void ConnectHandler(uint8_t * data);
+    static void DisconnectHandler(uint8_t * data);
     static void PostConnectivityStatusChange(ConnectivityChange changeType);
 
     ConnectionParams mWiFiParams{};
     ConnectionHandling mHandling;
     wifi_iface_state mWiFiState;
-    NetEventCallback mWiFiMgmtClbk{};
+    net_mgmt_event_callback mWiFiMgmtClbk{};
     ScanResultCallback mScanResultCallback{ nullptr };
     ScanDoneCallback mScanDoneCallback{ nullptr };
+    WiFiNetwork mWantedNetwork{};
+    bool mInternalScan{ false };
     static const Map<wifi_iface_state, StationStatus, 10> sStatusMap;
     static const Map<uint32_t, NetEventHandler, 4> sEventHandlerMap;
 };


### PR DESCRIPTION
#### Problem
We need proper security modes handling to allow our devices to connect to AP supporting various security modes.

#### Change overview
Utilized net_mgmt API to perform scanning before the actual connection request.
By doing so, we can cache the security mode advertised by every AP in the area
and filter the interested one by SSID.

Also fixed the bug with incorrect net_mgmt events lifetime management.

#### Testing
Tested by commissioning the light switch app to the networks with:
* WPA2 
* open security mode
* WPA3 (tested with iPhone working as an access point)
