### PR TITLE
[nrf noup] Aligned Matter SDK to Zephyr 0.15.x revision

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -169,7 +169,9 @@ config BT_DEVICE_NAME_MAX
 
 config BT_MAX_CONN
     int
-    default 1
+    default 2 # a workaround for non-unreferenced BLE connection object
+              # when restaring the BLE advertising in disconnect callback
+              # TODO: analyze and revert to 1 if proper fix exists
 
 config BT_L2CAP_TX_MTU
     int

--- a/examples/all-clusters-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
+++ b/examples/all-clusters-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
@@ -37,9 +37,6 @@
 &uart1 {
 	status = "disabled";
 };
-&gpio1 {
-	status = "disabled";
-};
 &i2c0 {
 	status = "disabled";
 };

--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -42,7 +42,7 @@
 
 #include <dk_buttons_and_leds.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 using namespace ::chip;
 using namespace ::chip::Credentials;

--- a/examples/all-clusters-minimal-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
+++ b/examples/all-clusters-minimal-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
@@ -37,9 +37,6 @@
 &uart1 {
 	status = "disabled";
 };
-&gpio1 {
-	status = "disabled";
-};
 &i2c0 {
 	status = "disabled";
 };

--- a/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
@@ -37,8 +37,8 @@
 #endif
 
 #include <dk_buttons_and_leds.h>
-#include <logging/log.h>
-#include <zephyr.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/kernel.h>
 
 using namespace ::chip;
 using namespace ::chip::Credentials;

--- a/examples/all-clusters-minimal-app/nrfconnect/main/main.cpp
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/main.cpp
@@ -17,11 +17,11 @@
 
 #include "AppTask.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #if DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_console), zephyr_cdc_acm_uart)
-#include <drivers/uart.h>
-#include <usb/usb_device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/usb/usb_device.h>
 #endif
 
 LOG_MODULE_REGISTER(app, CONFIG_MATTER_LOG_LEVEL);

--- a/examples/common/pigweed/nrfconnect/PigweedLoggerMutex.h
+++ b/examples/common/pigweed/nrfconnect/PigweedLoggerMutex.h
@@ -20,7 +20,7 @@
 
 #include "PigweedLogger.h"
 #include "pigweed/RpcService.h"
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 namespace chip {
 namespace rpc {

--- a/examples/light-switch-app/nrfconnect/main/AppTask.cpp
+++ b/examples/light-switch-app/nrfconnect/main/AppTask.cpp
@@ -40,7 +40,7 @@
 
 #include <dk_buttons_and_leds.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 using namespace ::chip;
 using namespace ::chip::app;

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -46,7 +46,7 @@
 
 #include <dk_buttons_and_leds.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 

--- a/examples/lock-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
+++ b/examples/lock-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
@@ -37,9 +37,6 @@
 &uart1 {
 	status = "disabled";
 };
-&gpio1 {
-	status = "disabled";
-};
 &i2c0 {
 	status = "disabled";
 };

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -43,7 +43,7 @@
 
 #include <dk_buttons_and_leds.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 using namespace ::chip;
 using namespace ::chip::app;

--- a/examples/lock-app/nrfconnect/main/include/BoltLockManager.h
+++ b/examples/lock-app/nrfconnect/main/include/BoltLockManager.h
@@ -23,7 +23,7 @@
 #include <lib/core/ClusterEnums.h>
 #include <lib/support/ScopedBuffer.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include <cstdint>
 

--- a/examples/pigweed-app/nrfconnect/main/main.cpp
+++ b/examples/pigweed-app/nrfconnect/main/main.cpp
@@ -19,7 +19,7 @@
 #include "LEDWidget.h"
 #include "PigweedLoggerMutex.h"
 #include "pigweed/RpcService.h"
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #include "pw_rpc/echo_service_nanopb.h"
 #include "pw_sys_io/sys_io.h"

--- a/examples/platform/nrfconnect/util/LEDWidget.cpp
+++ b/examples/platform/nrfconnect/util/LEDWidget.cpp
@@ -20,7 +20,7 @@
 #include "LEDWidget.h"
 
 #include <dk_buttons_and_leds.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 static LEDWidget::LEDWidgetStateUpdateHandler sStateUpdateCallback;
 

--- a/examples/platform/nrfconnect/util/PWMDevice.cpp
+++ b/examples/platform/nrfconnect/util/PWMDevice.cpp
@@ -24,7 +24,7 @@
 
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 

--- a/examples/platform/nrfconnect/util/PigweedLogger.cpp
+++ b/examples/platform/nrfconnect/util/PigweedLogger.cpp
@@ -28,7 +28,7 @@
 #include <zephyr/logging/log_backend.h>
 #include <zephyr/logging/log_backend_std.h>
 #include <zephyr/logging/log_output.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include <pw_hdlc/encoder.h>
 #include <pw_stream/sys_io_stream.h>

--- a/examples/platform/nrfconnect/util/include/DFUOverSMP.h
+++ b/examples/platform/nrfconnect/util/include/DFUOverSMP.h
@@ -25,7 +25,7 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 typedef void (*DFUOverSMPRestartAdvertisingHandler)(void);
 

--- a/examples/platform/nrfconnect/util/include/LEDWidget.h
+++ b/examples/platform/nrfconnect/util/include/LEDWidget.h
@@ -20,7 +20,7 @@
 
 #include <cstdint>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 class LEDWidget
 {

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -43,7 +43,7 @@
 
 #include <dk_buttons_and_leds.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 using namespace ::chip;
 using namespace ::chip::app::Clusters;

--- a/examples/pump-app/nrfconnect/main/PumpManager.cpp
+++ b/examples/pump-app/nrfconnect/main/PumpManager.cpp
@@ -23,7 +23,7 @@
 #include "AppTask.h"
 
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -43,7 +43,7 @@
 
 #include <dk_buttons_and_leds.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 using namespace ::chip;
 using namespace ::chip::app;

--- a/examples/pump-controller-app/nrfconnect/main/PumpManager.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/PumpManager.cpp
@@ -23,7 +23,7 @@
 #include "AppTask.h"
 
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 

--- a/examples/window-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
+++ b/examples/window-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
@@ -58,9 +58,6 @@
 &uart1 {
 	status = "disabled";
 };
-&gpio1 {
-	status = "disabled";
-};
 &i2c0 {
 	status = "disabled";
 };

--- a/examples/window-app/nrfconnect/main/AppTask.cpp
+++ b/examples/window-app/nrfconnect/main/AppTask.cpp
@@ -41,7 +41,7 @@
 
 #include <dk_buttons_and_leds.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #define FACTORY_RESET_TRIGGER_TIMEOUT 3000
 #define FACTORY_RESET_CANCEL_WINDOW_TIMEOUT 3000

--- a/examples/window-app/nrfconnect/main/WindowCovering.cpp
+++ b/examples/window-app/nrfconnect/main/WindowCovering.cpp
@@ -25,7 +25,7 @@
 #include <app/util/af.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <zephyr/logging/log.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -100,7 +100,7 @@ CHIP_ERROR AutoCommissioner::SetCommissioningParameters(const CommissioningParam
 
     if (params.GetCountryCode().HasValue())
     {
-        auto & code = params.GetCountryCode().Value();
+        auto code = params.GetCountryCode().Value();
         MutableCharSpan copiedCode(mCountryCode);
         if (CopyCharSpanToMutableCharSpan(code, copiedCode) == CHIP_NO_ERROR)
         {

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.h
@@ -27,7 +27,7 @@
 #include <platform/internal/GenericPlatformManagerImpl.h>
 
 #include <sys/select.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/lib/shell/MainLoopZephyr.cpp
+++ b/src/lib/shell/MainLoopZephyr.cpp
@@ -14,8 +14,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-#include <init.h>
-#include <shell/shell.h>
+#include <zephyr/init.h>
+#include <zephyr/shell/shell.h>
 
 #include <lib/core/CHIPError.h>
 #include <lib/shell/Engine.h>

--- a/src/lib/shell/streamer_zephyr.cpp
+++ b/src/lib/shell/streamer_zephyr.cpp
@@ -24,8 +24,8 @@
 
 #include <cassert>
 
-#include <shell/shell.h>
-#include <shell/shell_uart.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_uart.h>
 
 namespace chip {
 namespace Shell {

--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -37,11 +37,11 @@
 #include <setup_payload/AdditionalDataPayloadGenerator.h>
 #endif
 
-#include <bluetooth/addr.h>
-#include <bluetooth/gatt.h>
-#include <random/rand32.h>
-#include <sys/byteorder.h>
-#include <sys/util.h>
+#include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/random/rand32.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
 using namespace ::chip;
 using namespace ::chip::Ble;

--- a/src/platform/Zephyr/BLEManagerImpl.h
+++ b/src/platform/Zephyr/BLEManagerImpl.h
@@ -25,9 +25,9 @@
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
 
 #include <lib/support/logging/CHIPLogging.h>
 

--- a/src/platform/Zephyr/CHIPDevicePlatformEvent.h
+++ b/src/platform/Zephyr/CHIPDevicePlatformEvent.h
@@ -25,7 +25,7 @@
 
 #include <platform/CHIPDeviceEvent.h>
 
-#include <bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/bluetooth.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Zephyr/KeyValueStoreManagerImpl.h
+++ b/src/platform/Zephyr/KeyValueStoreManagerImpl.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Zephyr/NFCManagerImpl.cpp
+++ b/src/platform/Zephyr/NFCManagerImpl.cpp
@@ -26,7 +26,7 @@
 #include <nfc/ndef/uri_msg.h>
 #include <nfc/ndef/uri_rec.h>
 #include <nfc_t2t_lib.h>
-#include <zephyr.h>
+#include <zephyr/kernel.h>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Zephyr/SysHeapMalloc.cpp
+++ b/src/platform/Zephyr/SysHeapMalloc.cpp
@@ -21,10 +21,10 @@
 #include <system/SystemError.h>
 
 extern "C" {
-#include <init.h>
-#include <sys/math_extras.h>
-#include <sys/mutex.h>
-#include <sys/sys_heap.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/mutex.h>
+#include <zephyr/sys/sys_heap.h>
 }
 
 #include <cstdint>

--- a/src/platform/Zephyr/SystemTimeSupport.cpp
+++ b/src/platform/Zephyr/SystemTimeSupport.cpp
@@ -26,7 +26,7 @@
 
 #include <system/SystemError.h>
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #if !CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS
 

--- a/src/platform/Zephyr/ThreadStackManagerImpl.h
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.h
@@ -26,7 +26,7 @@
 #include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h>
 
 #include <zephyr/net/openthread.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 
 #include <openthread/thread.h>
 #if !CONFIG_SOC_SERIES_RISCV_TELINK_B91

--- a/src/platform/nrfconnect/FactoryDataParser.c
+++ b/src/platform/nrfconnect/FactoryDataParser.c
@@ -17,7 +17,7 @@
 
 #include "FactoryDataParser.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 #include <zcbor_decode.h>
 
 #include <ctype.h>

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -24,7 +24,7 @@
 #include <platform/Zephyr/ZephyrConfig.h>
 #endif
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 namespace chip {
 namespace {

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -21,7 +21,7 @@
 #include <platform/CommissionableDataProvider.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 
-#include <drivers/flash.h>
+#include <zephyr/drivers/flash.h>
 #include <fprotect.h>
 #include <pm_config.h>
 #include <system/SystemError.h>

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -28,15 +28,15 @@
 #if CONFIG_CHIP_CERTIFICATION_DECLARATION_STORAGE
 #include <credentials/CertificationDeclaration.h>
 #include <platform/Zephyr/ZephyrConfig.h>
-#include <settings/settings.h>
+#include <zephyr/settings/settings.h>
 #endif
 
 #include <dfu/dfu_multi_image.h>
 #include <dfu/dfu_target.h>
 #include <dfu/dfu_target_mcuboot.h>
-#include <dfu/mcuboot.h>
-#include <logging/log.h>
-#include <pm/device.h>
+#include <zephyr/dfu/mcuboot.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/device.h>
 
 #if CONFIG_CHIP_CERTIFICATION_DECLARATION_STORAGE
 // Cd globals are needed to be accessed from dfu image writer lambdas

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -28,8 +28,8 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/Zephyr/InetUtils.h>
 
-#include <net/net_stats.h>
-#include <zephyr.h>
+#include <zephyr/net/net_stats.h>
+#include <zephyr/kernel.h>
 #include <zephyr/net/net_event.h>
 
 extern "C" {

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -28,8 +28,8 @@
 #include <platform/NetworkCommissioning.h>
 #include <system/SystemLayer.h>
 
-#include <net/net_if.h>
-#include <net/wifi_mgmt.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/wifi_mgmt.h>
 
 extern "C" {
 #include <src/utils/common.h>

--- a/src/test_driver/nrfconnect/main/runner.cpp
+++ b/src/test_driver/nrfconnect/main/runner.cpp
@@ -19,8 +19,8 @@
 #include <lib/support/UnitTestRegistration.h>
 #include <platform/CHIPDeviceLayer.h>
 
-#include <logging/log.h>
-#include <settings/settings.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/settings/settings.h>
 
 using namespace ::chip;
 using namespace ::chip::DeviceLayer;


### PR DESCRIPTION
#### Problem
We need to align Matter to the recent Zephyr revision

#### Change overview
These changes were implied the the recent Zephyr upmerge:
- updates of Zephyr include paths
- removal of disabling of gpio1 in board DTS overlays
- fix for the possible dangling pointer compilation error after gcc got more picky about that (v10.3 vs. v12.1)
 
#### Testing
Built all NCS samples with aforementioned updates for nRF52/nRF53 and NCS upmerge branch but without LEGACY_INCLUDE_PATH.
For nRF53 builds the following fix must be included:
https://github.com/anangl/sdk-zephyr/pull/4
