### PR TITLE
[nrf noup] Enter QSPI NOR deep sleep mode on nRF52, too

### DIFF
--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -211,7 +211,7 @@ void OTAImageProcessorImpl::TriggerFlashAction(FlashHandler::Action action)
 // external flash power consumption optimization
 void FlashHandler::DoAction(Action aAction)
 {
-#if CONFIG_PM_DEVICE && CONFIG_NORDIC_QSPI_NOR && !CONFIG_SOC_NRF52840 // nRF52 is optimized per default
+#if CONFIG_PM_DEVICE && CONFIG_NORDIC_QSPI_NOR
     // utilize the QSPI driver sleep power mode
     const auto * qspi_dev = DEVICE_DT_GET(DT_INST(0, nordic_qspi_nor));
     if (qspi_dev)


### PR DESCRIPTION
Unblock the code for controlling QSPI NOR power state based on the state of the DFU on the device.