### PR TITLE
[nrf noup] WiFi fail-safe related fixes

### DIFF
--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -147,6 +147,11 @@ CHIP_ERROR NrfWiFiDriver::CommitConfiguration()
 
 CHIP_ERROR NrfWiFiDriver::RevertConfiguration()
 {
+    if (WiFiManager::StationStatus::CONNECTING <= WiFiManager::Instance().GetStationStatus())
+    {
+        WiFiManager::Instance().Disconnect();
+    }
+
     LoadFromStorage();
 
     if (mStagingNetwork.IsConfigured())
@@ -171,6 +176,7 @@ Status NrfWiFiDriver::AddOrUpdateNetwork(ByteSpan ssid, ByteSpan credentials, Mu
     VerifyOrReturnError(ssid.size() <= sizeof(mStagingNetwork.ssid), Status::kOutOfRange);
     VerifyOrReturnError(credentials.size() <= sizeof(mStagingNetwork.pass), Status::kOutOfRange);
 
+    mStagingNetwork.Erase();
     memcpy(mStagingNetwork.ssid, ssid.data(), ssid.size());
     memcpy(mStagingNetwork.pass, credentials.data(), credentials.size());
     mStagingNetwork.ssidLen = ssid.size();

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -193,7 +193,8 @@ CHIP_ERROR WiFiManager::Connect(const ByteSpan & ssid, const ByteSpan & credenti
     mWiFiState = WIFI_STATE_ASSOCIATING;
 
     // Store SSID and credentials and perform the scan to detect the security mode supported by the AP.
-    // Connect() will be called in the callback when we have the SSID match.
+    // Zephyr WiFi connect request will be issued in the callback when we have the SSID match.
+    mWantedNetwork.Erase();
     memcpy(mWantedNetwork.ssid, ssid.data(), ssid.size());
     memcpy(mWantedNetwork.pass, credentials.data(), credentials.size());
     mWantedNetwork.ssidLen = ssid.size();
@@ -382,6 +383,8 @@ void WiFiManager::ConnectHandler(uint8_t * data)
         }
         Instance().PostConnectivityStatusChange(kConnectivity_Established);
     }
+    // cleanup the provisioning data as it is configured per each connect request
+    Instance().ClearStationProvisioningData();
 }
 
 void WiFiManager::DisconnectHandler(uint8_t * data)

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -155,6 +155,13 @@ public:
         ByteSpan GetSsidSpan() const { return ByteSpan(ssid, ssidLen); }
         ByteSpan GetPassSpan() const { return ByteSpan(pass, passLen); }
         void Clear() { ssidLen = 0; }
+        void Erase()
+        {
+            memset(ssid, 0, DeviceLayer::Internal::kMaxWiFiSSIDLength);
+            memset(pass, 0, DeviceLayer::Internal::kMaxWiFiKeyLength);
+            ssidLen = 0;
+            passLen = 0;
+        }
     };
 
     CHIP_ERROR Init();


### PR DESCRIPTION
Make sure the fail-safe works as expected with WiFi networking:
- disconnect when reverting the configuration
- always cleanup the provisioning data structures before connecting to avoid dummy buffer overwriting and data length issues

Tested the following scenarios manually with `chip-tool`:

**Commissioning (failure)**
1. GeneralCommissioning.ArmFailSafe
2. NetworkCommissioning.AddOrUpdateWifiNetwork
3. NetworkCommissioning.ConnectNetwork
4. DNS-SD -> failure
5. Failsafe timeout - RevertConfiguration - disconnect from tentative Wi-Fi network

**Commissioning (success)**
1. GeneralCommissioning.ArmFailSafe
2. NetworkCommissioning.AddOrUpdateWifiNetwork
3. NNetworkCommissioning.ConnectNetwork
4. DNS-SD -> success
5. [over IP] GeneralCommissioning.CommissioningComplete - disarm failsafe/CommitConfiguration

**Reconfiguration, device already in Wi-Fi network (failure)**
1. GeneralCommissioning.ArmFailSafe
2. NetworkCommissioning.RemoveNetwork
3. NetworkCommissioning.AddOrUpdateWifiNetwork(new SSID, new password)
4. NetworkCommissioning.ConnectNetwork
5. DNS-SD -> failure - RevertConfiguration - fallback to the last valid network

**Reconfiguration, device already in Wi-Fi network (success)** -> hard to test with `chip-tool` as it would require to configure 2 WiFi networks in parallel.

