### PR TITLE
[nrf noup] wifi: set CONFIG_NRF700X_REV_A to ease builds for nRF700x rev A.

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -248,6 +248,10 @@ endif
 
 if CHIP_WIFI
 
+config NRF700X_REV_A # we need this config until the revB RPU is supported
+    bool
+    default y
+
 config NRF_WIFI_LOW_POWER
     bool
     default n


### PR DESCRIPTION
Currently the RPU revision B is built by default. However we still need the revision A support.
This change makes the builds easier because the CONFIG_NRF700X_REV_A=y does not have
to be passed to the build command every time.

This will need to be aligned when the rev B is officially supported.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>

