### PR TITLE
[nrf noup] Set NEWLIB_LIBC_NANO to y as default

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -81,6 +81,10 @@ config HWINFO
     bool
     default y
 
+config NEWLIB_LIBC_NANO
+    bool
+    default y
+
 # Generic networking options
 config NET_SOCKETS_POSIX_NAMES
     bool


### PR DESCRIPTION
NEWLIB_LIBC_NANO config has been set to n by default in Zephyr. This caused a FLASH overflow in Matter wifi samples.

To repair that, the NEWLIB_LIBC_NANO config  should be set to y by default within our configuration system.

