### PR TITLE
[nrf fromlist] Moved FlashHandler implementation to separate file

### DIFF
--- a/examples/all-clusters-app/nrfconnect/CMakeLists.txt
+++ b/examples/all-clusters-app/nrfconnect/CMakeLists.txt
@@ -68,7 +68,7 @@ chip_configure_data_model(app
     ZAP_FILE ${ALL_CLUSTERS_COMMON_DIR}/all-clusters-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 

--- a/examples/all-clusters-minimal-app/nrfconnect/CMakeLists.txt
+++ b/examples/all-clusters-minimal-app/nrfconnect/CMakeLists.txt
@@ -67,7 +67,7 @@ chip_configure_data_model(app
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../all-clusters-common/all-clusters-minimal-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 

--- a/examples/light-switch-app/nrfconnect/CMakeLists.txt
+++ b/examples/light-switch-app/nrfconnect/CMakeLists.txt
@@ -63,7 +63,7 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp)
 
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -69,7 +69,7 @@ chip_configure_data_model(app
     GEN_DIR ${GEN_DIR}/lighting-app/zap-generated
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -65,7 +65,7 @@ chip_configure_data_model(app
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lock-common/lock-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 

--- a/examples/platform/nrfconnect/util/DFUOverSMP.cpp
+++ b/examples/platform/nrfconnect/util/DFUOverSMP.cpp
@@ -51,8 +51,8 @@ void DFUOverSMP::Init(DFUOverSMPRestartAdvertisingHandler startAdvertisingCb)
 
     bt_conn_cb_register(&mBleConnCallbacks);
 
-    k_work_init(&mFlashSleepWork, [](k_work *) { GetFlashHandler().DoAction(FlashHandler::Action::SLEEP); });
-    k_work_init(&mFlashWakeUpWork, [](k_work *) { GetFlashHandler().DoAction(FlashHandler::Action::WAKE_UP); });
+    k_work_init(&mFlashSleepWork, [](k_work *) { GetFlashHandler().DoAction(ExternalFlashManager::Action::SLEEP); });
+    k_work_init(&mFlashWakeUpWork, [](k_work *) { GetFlashHandler().DoAction(ExternalFlashManager::Action::WAKE_UP); });
 
     restartAdvertisingCallback = startAdvertisingCb;
 

--- a/examples/platform/nrfconnect/util/OTAUtil.cpp
+++ b/examples/platform/nrfconnect/util/OTAUtil.cpp
@@ -15,15 +15,21 @@
  *    limitations under the License.
  */
 
+#include "OTAUtil.h"
+
+#if CONFIG_CHIP_OTA_REQUESTOR
 #include <app/clusters/ota-requestor/BDXDownloader.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestor.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
 #include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/server/Server.h>
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
+#endif
 
 using namespace chip;
 using namespace chip::DeviceLayer;
+
+#if CONFIG_CHIP_OTA_REQUESTOR
 
 namespace {
 
@@ -32,12 +38,6 @@ DefaultOTARequestorDriver sOTARequestorDriver;
 chip::BDXDownloader sBDXDownloader;
 chip::DefaultOTARequestor sOTARequestor;
 } // namespace
-
-FlashHandler & GetFlashHandler()
-{
-    static FlashHandler sFlashHandler;
-    return sFlashHandler;
-}
 
 // compile-time factory method
 OTAImageProcessorImpl & GetOTAImageProcessor()
@@ -61,5 +61,12 @@ void InitBasicOTARequestor()
     sOTARequestor.Init(Server::GetInstance(), sOTARequestorStorage, sOTARequestorDriver, sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
     sOTARequestorDriver.Init(&sOTARequestor, &imageProcessor);
-    imageProcessor.TriggerFlashAction(FlashHandler::Action::SLEEP);
+    imageProcessor.TriggerFlashAction(ExternalFlashManager::Action::SLEEP);
+}
+#endif
+
+ExternalFlashManager & GetFlashHandler()
+{
+    static ExternalFlashManager sFlashHandler;
+    return sFlashHandler;
 }

--- a/examples/platform/nrfconnect/util/include/OTAUtil.h
+++ b/examples/platform/nrfconnect/util/include/OTAUtil.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <platform/nrfconnect/ExternalFlashManager.h>
+
+#if CONFIG_CHIP_OTA_REQUESTOR
 #include <platform/nrfconnect/OTAImageProcessorImpl.h>
 
 namespace chip {
@@ -24,14 +27,6 @@ namespace DeviceLayer {
 class OTAImageProcessorImpl;
 } // namespace DeviceLayer
 } // namespace chip
-
-/**
- * Get FlashHandler static instance.
- *
- * Returned object can be used to control the QSPI external flash,
- * which can be introduced into sleep mode and woken up on demand.
- */
-chip::DeviceLayer::FlashHandler & GetFlashHandler();
 
 /**
  * Select recommended OTA image processor implementation.
@@ -50,3 +45,13 @@ chip::DeviceLayer::OTAImageProcessorImpl & GetOTAImageProcessor();
  * an update so the confirmation must be done on the OTA provider side.
  */
 void InitBasicOTARequestor();
+
+#endif // CONFIG_CHIP_OTA_REQUESTOR
+
+/**
+ * Get ExternalFlashManager static instance.
+ *
+ * Returned object can be used to control the QSPI external flash,
+ * which can be introduced into sleep mode and woken up on demand.
+ */
+chip::DeviceLayer::ExternalFlashManager & GetFlashHandler();

--- a/examples/pump-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-app/nrfconnect/CMakeLists.txt
@@ -65,7 +65,7 @@ chip_configure_data_model(app
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../pump-common/pump-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 

--- a/examples/pump-controller-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-controller-app/nrfconnect/CMakeLists.txt
@@ -65,7 +65,7 @@ chip_configure_data_model(app
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../pump-controller-common/pump-controller-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 

--- a/examples/window-app/nrfconnect/CMakeLists.txt
+++ b/examples/window-app/nrfconnect/CMakeLists.txt
@@ -68,7 +68,7 @@ chip_configure_data_model(app
     ZAP_FILE ${WIN_APP_COMMON_DIR}/window-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -45,6 +45,7 @@ static_library("nrfconnect") {
     "DeviceNetworkProvisioningDelegateImpl.h",
     "DiagnosticDataProviderImplNrf.cpp",
     "DiagnosticDataProviderImplNrf.h",
+    "ExternalFlashManager.h",
     "InetPlatformConfig.h",
     "KeyValueStoreManagerImpl.h",
     "PlatformManagerImpl.h",

--- a/src/platform/nrfconnect/ExternalFlashManager.h
+++ b/src/platform/nrfconnect/ExternalFlashManager.h
@@ -1,0 +1,51 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <zephyr/device.h>
+#include <zephyr/pm/device.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+class ExternalFlashManager
+{
+public:
+    enum class Action : uint8_t
+    {
+        WAKE_UP,
+        SLEEP
+    };
+
+    virtual ~ExternalFlashManager() {}
+
+    virtual void DoAction(Action aAction)
+    {
+#if CONFIG_PM_DEVICE && CONFIG_NORDIC_QSPI_NOR
+        // utilize the QSPI driver sleep power mode
+        const auto * qspi_dev = DEVICE_DT_GET(DT_INST(0, nordic_qspi_nor));
+        if (device_is_ready(qspi_dev))
+        {
+            const auto requestedAction = Action::WAKE_UP == aAction ? PM_DEVICE_ACTION_RESUME : PM_DEVICE_ACTION_SUSPEND;
+            (void) pm_device_action_run(qspi_dev, requestedAction); // not much can be done in case of a failure
+        }
+#endif
+    }
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.h
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.h
@@ -19,6 +19,7 @@
 #include <lib/core/OTAImageHeader.h>
 #include <lib/support/Span.h>
 #include <platform/OTAImageProcessor.h>
+#include <platform/nrfconnect/ExternalFlashManager.h>
 
 namespace chip {
 
@@ -26,27 +27,15 @@ class OTADownloader;
 
 namespace DeviceLayer {
 
-class FlashHandler
-{
-public:
-    enum class Action : uint8_t
-    {
-        WAKE_UP,
-        SLEEP
-    };
-    virtual ~FlashHandler() {}
-    virtual void DoAction(Action aAction);
-};
-
 class OTAImageProcessorImpl : public OTAImageProcessorInterface
 {
 public:
     static constexpr size_t kBufferSize = CONFIG_CHIP_OTA_REQUESTOR_BUFFER_SIZE;
 
-    explicit OTAImageProcessorImpl(FlashHandler * flashHandler = nullptr) : mFlashHandler(flashHandler) {}
+    explicit OTAImageProcessorImpl(ExternalFlashManager * flashHandler = nullptr) : mFlashHandler(flashHandler) {}
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; };
-    void TriggerFlashAction(FlashHandler::Action action);
+    void TriggerFlashAction(ExternalFlashManager::Action action);
 
     CHIP_ERROR PrepareDownload() override;
     CHIP_ERROR Finalize() override;
@@ -63,7 +52,7 @@ protected:
     OTADownloader * mDownloader = nullptr;
     OTAImageHeaderParser mHeaderParser;
     uint8_t mBuffer[kBufferSize];
-    FlashHandler * mFlashHandler;
+    ExternalFlashManager * mFlashHandler;
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
The FlashHandler implementation was coupled with Matter OTAImageProcessorImpl, what resulted with the fact that it was not possible to use build other DFU mechanisms, like DFU over BT SMP without Matter OTA enabled.

Summary of changes:
* Moved FlashHandler to separate file called ExternalFlashManager
* Added ifdefs to OTAUtil that prevents from building Matter OTA dependencies while Matter OTA is disabled.

(cherry picked from commit d9936213e6714137ec49446ba6bd46c687c6d249)
