### PR TITLE
[nrf noup] Introduced a workaround to send Router Solicitation after …

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -107,11 +107,6 @@ config CHIP_DEVICE_PRODUCT_ID
 	int
 	default 32768
 
-# Disable certain parts of Zephyr IPv6 stack
-config NET_IPV6_NBR_CACHE
-    bool
-    default n
-
 config NET_IPV6_MLD
     bool
     default y
@@ -242,6 +237,11 @@ config NET_L2_OPENTHREAD
     default y if !WIFI_NRF700X
 
 if NET_L2_OPENTHREAD
+
+# Disable certain parts of Zephyr IPv6 stack
+config NET_IPV6_NBR_CACHE
+    bool
+    default n
 
 # Increase the default RX stack size
 config IEEE802154_NRF5_RX_STACK_SIZE

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -164,6 +164,10 @@ public:
         }
     };
 
+    static constexpr uint16_t kRouterSolicitationIntervalMs        = 4000;
+    static constexpr uint16_t kMaxInitialRouterSolicitationDelayMs = 1000;
+    static constexpr uint8_t kRouterSolicitationMaxCount           = 3;
+
     CHIP_ERROR Init();
     CHIP_ERROR Scan(const ByteSpan & ssid, ScanResultCallback resultCallback, ScanDoneCallback doneCallback,
                     bool internalScan = false);
@@ -193,6 +197,7 @@ private:
     static void ConnectHandler(uint8_t * data);
     static void DisconnectHandler(uint8_t * data);
     static void PostConnectivityStatusChange(ConnectivityChange changeType);
+    static void SendRouterSolicitation(System::Layer * layer, void * param);
 
     ConnectionParams mWiFiParams{};
     ConnectionHandling mHandling;
@@ -202,6 +207,7 @@ private:
     ScanDoneCallback mScanDoneCallback{ nullptr };
     WiFiNetwork mWantedNetwork{};
     bool mInternalScan{ false };
+    uint8_t mRouterSolicitationCounter = 0;
     static const Map<wifi_iface_state, StationStatus, 10> sStatusMap;
     static const Map<uint32_t, NetEventHandler, 4> sEventHandlerMap;
 };


### PR DESCRIPTION
Router Solicitation is not sent after connecting to the Wi-Fi network by the Wi-Fi driver, so in result Thread Border Router doesn't send Router Advertisement to the device. As a workaround sending RS was added in the Matter platform code.
