### PR TITLE
[nrf noup] Minor fixes for heap usage

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -85,6 +85,11 @@ config NEWLIB_LIBC_NANO
     bool
     default y
 
+# Warn a user if memory left for the heap is too small
+config NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE
+    int
+    default 16384
+
 # Generic networking options
 config NET_SOCKETS_POSIX_NAMES
     bool

--- a/src/platform/Zephyr/SysHeapMalloc.cpp
+++ b/src/platform/Zephyr/SysHeapMalloc.cpp
@@ -131,7 +131,7 @@ CHIP_ERROR GetStats(Stats & stats)
     LockGuard lockGuard;
     ReturnErrorOnFailure(lockGuard.Error());
 
-    sys_heap_runtime_stats sysHeapStats;
+    sys_memory_stats sysHeapStats;
     ReturnErrorOnFailure(System::MapErrorZephyr(sys_heap_runtime_stats_get(&sHeap, &sysHeapStats)));
 
     stats.free    = sysHeapStats.free_bytes;


### PR DESCRIPTION
* Fix build with CHIP_MALLOC_SYS_HEAP Kconfig option that replaces default malloc/free with alternatives based on Zephyr's sys_heap.
* If the default heap is used, error out if less than 16kB of RAM has been left for the heap.
