### PR TITLE
[nrf noup] Decrease the minimum heap size for newlibc

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -88,7 +88,7 @@ config NEWLIB_LIBC_NANO
 # Warn a user if memory left for the heap is too small
 config NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE
     int
-    default 16384
+    default 12288 # 12kB
 
 # Generic networking options
 config NET_SOCKETS_POSIX_NAMES


### PR DESCRIPTION
In some configurations (i.e. with BLE SMP enabled) we cannot achieve 16kB of free RAM for newlibc. 16kB was set with redundancy in mind, so we can make this requirement less strict (12kB).

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>
