### PR TITLE
[nrf noup] Wi-Fi status handling fixes

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -271,7 +271,7 @@ config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
     int
-    default 1120
+    default 2048
 
 # align these numbers to match the OpenThread config
 config NET_IF_UNICAST_IPV6_ADDR_COUNT

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -105,7 +105,7 @@ CHIP_ERROR NrfWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     {
         WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
                                                   [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
-                                                  System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds } };
+                                                  System::Clock::Seconds32{ kWiFiConnectNetworkTimeoutSeconds } };
         ReturnErrorOnFailure(
             WiFiManager::Instance().Connect(mStagingNetwork.GetSsidSpan(), mStagingNetwork.GetPassSpan(), handling));
     }
@@ -158,7 +158,7 @@ CHIP_ERROR NrfWiFiDriver::RevertConfiguration()
     {
         WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
                                                   [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
-                                                  System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds } };
+                                                  System::Clock::Seconds32{ kWiFiConnectNetworkTimeoutSeconds } };
         ReturnErrorOnFailure(
             WiFiManager::Instance().Connect(mStagingNetwork.GetSsidSpan(), mStagingNetwork.GetPassSpan(), handling));
     }
@@ -212,7 +212,7 @@ void NrfWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callbac
     Status status = Status::kSuccess;
     WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
                                               [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
-                                              System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds } };
+                                              System::Clock::Seconds32{ kWiFiConnectNetworkTimeoutSeconds } };
 
     VerifyOrExit(WiFiManager::StationStatus::CONNECTING != WiFiManager::Instance().GetStationStatus(),
                  status = Status::kOtherConnectionFailure);

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -105,7 +105,7 @@ CHIP_ERROR NrfWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     {
         WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
                                                   [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
-                                                  System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds * 1000 } };
+                                                  System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds } };
         ReturnErrorOnFailure(
             WiFiManager::Instance().Connect(mStagingNetwork.GetSsidSpan(), mStagingNetwork.GetPassSpan(), handling));
     }
@@ -158,7 +158,7 @@ CHIP_ERROR NrfWiFiDriver::RevertConfiguration()
     {
         WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
                                                   [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
-                                                  System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds * 1000 } };
+                                                  System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds } };
         ReturnErrorOnFailure(
             WiFiManager::Instance().Connect(mStagingNetwork.GetSsidSpan(), mStagingNetwork.GetPassSpan(), handling));
     }
@@ -212,7 +212,7 @@ void NrfWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callbac
     Status status = Status::kSuccess;
     WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
                                               [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
-                                              System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds * 1000 } };
+                                              System::Clock::Timeout{ kWiFiConnectNetworkTimeoutSeconds } };
 
     VerifyOrExit(WiFiManager::StationStatus::CONNECTING != WiFiManager::Instance().GetStationStatus(),
                  status = Status::kOtherConnectionFailure);

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
@@ -27,7 +27,7 @@ namespace NetworkCommissioning {
 
 constexpr uint8_t kMaxWiFiNetworks                  = 1;
 constexpr uint8_t kWiFiScanNetworksTimeOutSeconds   = 10;
-constexpr uint8_t kWiFiConnectNetworkTimeoutSeconds = 120;
+constexpr uint8_t kWiFiConnectNetworkTimeoutSeconds = 35;
 
 class NrfWiFiScanResponseIterator : public Iterator<WiFiScanResponse>
 {

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -190,7 +190,7 @@ CHIP_ERROR WiFiManager::Connect(const ByteSpan & ssid, const ByteSpan & credenti
 
     mHandling.mOnConnectionSuccess = handling.mOnConnectionSuccess;
     mHandling.mOnConnectionFailed  = handling.mOnConnectionFailed;
-    mHandling.mConnectionTimeoutMs = handling.mConnectionTimeoutMs;
+    mHandling.mConnectionTimeout   = handling.mConnectionTimeout;
 
     mWiFiState = WIFI_STATE_ASSOCIATING;
 
@@ -308,7 +308,7 @@ void WiFiManager::ScanResultHandler(uint8_t * data)
                 Instance().mWiFiParams.mParams.psk = Instance().mWantedNetwork.pass;
             }
 
-            Instance().mWiFiParams.mParams.timeout = Instance().mHandling.mConnectionTimeoutMs.count();
+            Instance().mWiFiParams.mParams.timeout = Instance().mHandling.mConnectionTimeout.count();
             Instance().mWiFiParams.mParams.channel = scanResult->channel;
             Instance().mWiFiParams.mRssi           = scanResult->rssi;
         }

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -330,7 +330,7 @@ void WiFiManager::ScanDoneHandler(uint8_t * data)
         Instance().mScanDoneCallback(requestStatus);
     }
 
-    if (requestStatus == WiFiRequestStatus::FAIL)
+    if (requestStatus == WiFiRequestStatus::FAILURE)
     {
         ChipLogDetail(DeviceLayer, "Scan request failed (%d)", status->status);
     }
@@ -385,9 +385,9 @@ void WiFiManager::ConnectHandler(uint8_t * data)
     const wifi_status * status      = reinterpret_cast<const wifi_status *>(data);
     WiFiRequestStatus requestStatus = static_cast<WiFiRequestStatus>(status->status);
 
-    if (requestStatus == WiFiRequestStatus::FAIL)
+    if (requestStatus == WiFiRequestStatus::FAILURE || requestStatus == WiFiRequestStatus::TERMINATED)
     {
-        ChipLogDetail(DeviceLayer, "Connection to WiFi network failed");
+        ChipLogDetail(DeviceLayer, "Connection to WiFi network failed or was terminated by another request");
         Instance().mWiFiState = WIFI_STATE_DISCONNECTED;
         if (Instance().mHandling.mOnConnectionFailed)
         {

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -90,8 +90,9 @@ class WiFiManager
 public:
     enum WiFiRequestStatus : int
     {
-        FAIL    = -1,
-        SUCCESS = 0
+        SUCCESS    = 0,
+        FAILURE    = 1,
+        TERMINATED = 2
     };
 
     using ScanResultCallback = void (*)(const NetworkCommissioning::WiFiScanResponse &);

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -122,7 +122,7 @@ public:
     {
         ConnectionCallback mOnConnectionSuccess{};
         ConnectionCallback mOnConnectionFailed{};
-        System::Clock::Timeout mConnectionTimeoutMs{};
+        System::Clock::Seconds32 mConnectionTimeout{};
     };
 
     struct WiFiInfo


### PR DESCRIPTION
* Increase the SYSTEM_WORKQUEUE_STACK_SIZE to match supplicant needs
* Decrease the connection timeout to be lower than failsafe (35s)
* Adapt WiFiRequestStatus to follow supplicant implementation
* All of above makes the failsafe more robust

Note that the following patch in wpa_supplicant is needed to have the proper connection timeout handling:
https://github.com/nrfconnect/sdk-hostap/pull/45

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>