### PR TITLE
[nrf noup] wifi: implemented most of the Wi-Fi DiagnosticDataProvider

### DIFF
--- a/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.cpp
+++ b/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.cpp
@@ -82,34 +82,52 @@ CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiRssi(int8_t & rssi)
     return err;
 }
 
-// below will be implemented when the WiFi driver exposes Zephyr NET_STATISTICS API
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBeaconLostCount(uint32_t & beaconLostCount)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    WiFiManager::NetworkStatistics stats;
+    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    beaconLostCount = stats.mBeaconsLostCount;
+    return err;
 }
 
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBeaconRxCount(uint32_t & beaconRxCount)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    WiFiManager::NetworkStatistics stats;
+    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    beaconRxCount = stats.mBeaconsSuccessCount;
+    return err;
 }
 
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    WiFiManager::NetworkStatistics stats;
+    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    packetMulticastRxCount = stats.mPacketMulticastRxCount;
+    return err;
 }
+
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    WiFiManager::NetworkStatistics stats;
+    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    packetMulticastTxCount = stats.mPacketMulticastTxCount;
+    return err;
 }
 
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    WiFiManager::NetworkStatistics stats;
+    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    packetUnicastRxCount = stats.mPacketUnicastRxCount;
+    return err;
 }
 
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    WiFiManager::NetworkStatistics stats;
+    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    packetUnicastTxCount = stats.mPacketUnicastTxCount;
+    return err;
 }
 
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiCurrentMaxRate(uint64_t & currentMaxRate)

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -265,16 +265,15 @@ CHIP_ERROR WiFiManager::GetWiFiInfo(WiFiInfo & info) const
 
 CHIP_ERROR WiFiManager::GetNetworkStatistics(NetworkStatistics & stats) const
 {
-    // TODO: below will not work (result will be all zeros) until
-    // the get_stats handler is implemented in WiFi driver
-    net_stats_eth data{};
-    net_mgmt(NET_REQUEST_STATS_GET_ETHERNET, InetUtils::GetInterface(), &data, sizeof(data));
+    net_stats_wifi data{};
+    net_mgmt(NET_REQUEST_STATS_GET_WIFI, InetUtils::GetInterface(), &data, sizeof(data));
 
     stats.mPacketMulticastRxCount = data.multicast.rx;
     stats.mPacketMulticastTxCount = data.multicast.tx;
     stats.mPacketUnicastRxCount   = data.pkts.rx - data.multicast.rx - data.broadcast.rx;
     stats.mPacketUnicastTxCount   = data.pkts.tx - data.multicast.tx - data.broadcast.tx;
-    stats.mOverruns               = 0; // TODO: clarify if this can be queried from mgmt API (e.g. data.tx_dropped)
+    stats.mBeaconsSuccessCount    = data.sta_mgmt.beacons_rx;
+    stats.mBeaconsLostCount       = data.sta_mgmt.beacons_miss;
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -142,7 +142,8 @@ public:
         uint32_t mPacketMulticastTxCount{};
         uint32_t mPacketUnicastRxCount{};
         uint32_t mPacketUnicastTxCount{};
-        uint32_t mOverruns{};
+        uint32_t mBeaconsSuccessCount{};
+        uint32_t mBeaconsLostCount{};
     };
 
     struct WiFiNetwork


### PR DESCRIPTION
Added PHY statistics based on the Zephyr net_mgmt API (NET_REQUEST_STATS_GET_WIFI):
  * multicast RX/TX
  * unicast RX/TX
  * beacons lost/TX

Also added MapToMatterWiFiVersionCode function to align supplicant WiFi version code with Matter world.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>

