### PR TITLE
[nrf noup] config: nrfconnect: Define _DEFAULT_SOURCE

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -91,6 +91,8 @@ set(GN_ROOT_TARGET ${CHIP_ROOT}/config/nrfconnect/chip-gn)
 
 # Prepare compiler flags
 
+list(APPEND CHIP_CFLAGS -D_DEFAULT_SOURCE)
+
 if (CONFIG_ARM)
     list(APPEND CHIP_CFLAGS_C
         --specs=nosys.specs
@@ -309,6 +311,7 @@ add_dependencies(chip-gn kernel)
 
 zephyr_interface_library_named(chip)
 target_compile_definitions(chip INTERFACE CHIP_HAVE_CONFIG_H)
+target_compile_definitions(chip INTERFACE _DEFAULT_SOURCE)
 target_include_directories(chip INTERFACE
     ${CHIP_ROOT}/src
     ${CHIP_ROOT}/src/include


### PR DESCRIPTION
This commit updates the chip-module build configurations to define `_DEFAULT_SOURCE` when compiling Matter because it uses non-standard functions that are only available when `_DEFAULT_SOURCE` is defined.

Note that this used to be not necessary only because of a quirk in the way Newlib handles the feature test macro, which resulted in Newlib defining `_DEFAULT_SOURCE` when compiling with `-std=gnu`.

For more details, refer to the issue zephyrproject-rtos/zephyr#52739.

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>