### PR TITLE
[nrf noup] Fix the 'disconnected' status appearing after scan is issued

### DIFF
--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -190,6 +190,7 @@ CHIP_ERROR WiFiManager::Scan(const ByteSpan & ssid, ScanResultCallback resultCal
     mInternalScan       = internalScan;
     mScanResultCallback = resultCallback;
     mScanDoneCallback   = doneCallback;
+    mCachedWiFiState    = mWiFiState;
     mWiFiState          = WIFI_STATE_SCANNING;
 
     if (net_mgmt(NET_REQUEST_WIFI_SCAN, iface, NULL, 0))
@@ -350,39 +351,43 @@ void WiFiManager::ScanDoneHandler(uint8_t * data)
     const wifi_status * status      = reinterpret_cast<const wifi_status *>(data);
     WiFiRequestStatus requestStatus = static_cast<WiFiRequestStatus>(status->status);
 
-    if (Instance().mScanDoneCallback && !Instance().mInternalScan)
-    {
-        Instance().mScanDoneCallback(requestStatus);
-    }
-
     if (requestStatus == WiFiRequestStatus::FAILURE)
     {
-        ChipLogDetail(DeviceLayer, "Scan request failed (%d)", status->status);
+        ChipLogError(DeviceLayer, "Scan request failed (%d)", status->status);
     }
     else
     {
         ChipLogDetail(DeviceLayer, "Scan request done (%d)", status->status);
+    }
 
-        // Internal scan is supposed to be followed by connection request
-        if (Instance().mInternalScan)
+    if (Instance().mScanDoneCallback && !Instance().mInternalScan)
+    {
+        Instance().mScanDoneCallback(requestStatus);
+        // restore the connection state from before the scan request was issued
+        Instance().mWiFiState = Instance().mCachedWiFiState;
+        return;
+    }
+
+    // Internal scan is supposed to be followed by connection request
+    if (Instance().mInternalScan)
+    {
+        Instance().mWiFiState = WIFI_STATE_ASSOCIATING;
+        net_if * iface        = InetUtils::GetInterface();
+        VerifyOrReturn(nullptr != iface, CHIP_ERROR_INTERNAL);
+
+        if (net_mgmt(NET_REQUEST_WIFI_CONNECT, iface, &(Instance().mWiFiParams.mParams), sizeof(wifi_connect_req_params)))
         {
-            Instance().mWiFiState = WIFI_STATE_ASSOCIATING;
-            net_if * iface        = InetUtils::GetInterface();
-            VerifyOrReturn(nullptr != iface, CHIP_ERROR_INTERNAL);
-
-            if (net_mgmt(NET_REQUEST_WIFI_CONNECT, iface, &(Instance().mWiFiParams.mParams), sizeof(wifi_connect_req_params)))
+            ChipLogError(DeviceLayer, "Connection request failed");
+            if (Instance().mHandling.mOnConnectionFailed)
             {
-                ChipLogError(DeviceLayer, "Connection request failed");
-                if (Instance().mHandling.mOnConnectionFailed)
-                {
-                    Instance().mHandling.mOnConnectionFailed();
-                }
-                return;
+                Instance().mHandling.mOnConnectionFailed();
             }
-            ChipLogError(DeviceLayer, "Connection to %*s requested", Instance().mWiFiParams.mParams.ssid_length,
-                         Instance().mWiFiParams.mParams.ssid);
-            Instance().mInternalScan = false;
+            Instance().mWiFiState = WIFI_STATE_DISCONNECTED;
+            return;
         }
+        ChipLogDetail(DeviceLayer, "Connection to %*s requested", Instance().mWiFiParams.mParams.ssid_length,
+                      Instance().mWiFiParams.mParams.ssid);
+        Instance().mInternalScan = false;
     }
 }
 

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -204,6 +204,7 @@ private:
     ConnectionParams mWiFiParams{};
     ConnectionHandling mHandling;
     wifi_iface_state mWiFiState;
+    wifi_iface_state mCachedWiFiState;
     net_mgmt_event_callback mWiFiMgmtClbk{};
     ScanResultCallback mScanResultCallback{ nullptr };
     ScanDoneCallback mScanDoneCallback{ nullptr };


### PR DESCRIPTION
Restore the connection state which was set before requesting scan. Note that the connection was not really dropped, only the status reporting was broken.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>