### PR TITLE
[nrf noup] Fix ram_report and rom_report

### DIFF
--- a/config/nrfconnect/chip-module/make_gn_args.py
+++ b/config/nrfconnect/chip-module/make_gn_args.py
@@ -29,7 +29,11 @@ GN_CFLAG_EXCLUDES = [
     '-fno-reorder-functions',
     '-ffunction-sections',
     '-fdata-sections',
-    '-g*',
+    '-g',
+    '-g0',
+    '-g1',
+    '-g2',
+    '-g3',
     '-O*',
     '-W*',
 ]


### PR DESCRIPTION
Stop filtering out gdwarf-4 when passing flags from Zephyr to Matter's GN build system. Older pyelftools versions are not able to parse DWARF5 format, so ram and rom report would not be generated.