### PR TITLE
[nrf noup] Disabled NFC thread callback

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -199,6 +199,11 @@ config CHIP_NFC_COMMISSIONING
     bool
     default y
 
+# Disable not needed NFC callback to save flash
+config NFC_THREAD_CALLBACK
+    bool
+    default n
+
 config CHIP_OTA_REQUESTOR
     bool
     default y


### PR DESCRIPTION
NFC lib introduced new callbacks that are not needed by the Matter samples and increase flash usage.