### PR TITLE
[nrf noup] wifi: fixed the connection callback initialization

### DIFF
--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -222,12 +222,13 @@ void NrfWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callbac
                                               [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
                                               System::Clock::Seconds32{ kWiFiConnectNetworkTimeoutSeconds } };
 
+    VerifyOrExit(mpConnectCallback == nullptr, status = Status::kUnknownError);
+    mpConnectCallback = callback;
+
     VerifyOrExit(WiFiManager::StationStatus::CONNECTING != WiFiManager::Instance().GetStationStatus(),
                  status = Status::kOtherConnectionFailure);
     VerifyOrExit(networkId.data_equal(mStagingNetwork.GetSsidSpan()), status = Status::kNetworkIDNotFound);
-    VerifyOrExit(mpConnectCallback == nullptr, status = Status::kUnknownError);
 
-    mpConnectCallback = callback;
     WiFiManager::Instance().Connect(mStagingNetwork.GetSsidSpan(), mStagingNetwork.GetPassSpan(), handling);
 
 exit:


### PR DESCRIPTION
This fixes the misbehavior when attempting to establish a connection with the network that is not added to the networkcommissioning cluster.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>

