### PR TITLE
[nrf noup] Fixed the timeout when connecting to the WPA3 secured APs

### DIFF
--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -323,6 +323,7 @@ void WiFiManager::ScanResultHandler(uint8_t * data)
             Instance().mWiFiParams.mParams.security =
                 scanResult->security <= WIFI_SECURITY_TYPE_MAX ? scanResult->security : WIFI_SECURITY_TYPE_PSK;
             Instance().mWiFiParams.mParams.psk_length = Instance().mWantedNetwork.passLen;
+            Instance().mWiFiParams.mParams.mfp = (scanResult->mfp == WIFI_MFP_REQUIRED) ? WIFI_MFP_REQUIRED : WIFI_MFP_OPTIONAL;
 
             // If the security is none, WiFi driver expects the psk to be nullptr
             if (Instance().mWiFiParams.mParams.security == WIFI_SECURITY_TYPE_NONE)


### PR DESCRIPTION
Set the WiFi MFP (management frame protection) as at least optional. The current WiFi driver does not support this parameter within the scan result, so it must the hard coded for the time being (made it mandatory for secure associations, just in case).

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>

