### PR TITLE
[nrf noup] Switch to statically allocated heap

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -75,6 +75,9 @@ config CHIP_DEBUG_SYMBOLS
 	help
 	  Build the application with debug symbols.
 
+config CHIP_MALLOC_SYS_HEAP
+	default y
+
 config CHIP_FACTORY_DATA
 	bool "Enable Factory Data support"
 	select ZCBOR

--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -85,11 +85,6 @@ config NEWLIB_LIBC_NANO
     bool
     default y
 
-# Warn a user if memory left for the heap is too small
-config NEWLIB_LIBC_MIN_REQUIRED_HEAP_SIZE
-    int
-    default 12288 # 12kB
-
 # Generic networking options
 config NET_SOCKETS_POSIX_NAMES
     bool

--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -215,7 +215,7 @@ config CHIP_MALLOC_SYS_HEAP_OVERRIDE
 
 config CHIP_MALLOC_SYS_HEAP_SIZE
 	int "Heap size used by memory allocator based on Zephyr sys_heap"
-	default 16384 # 16kB
+	default 10240 # 10kB
 	help
 	  This value controls how much of the device RAM is reserved for the heap
 	  used by the memory allocation functions based on sys_heap from Zephyr


### PR DESCRIPTION
Use malloc/free replacements based on statically allocated Zephyr's sys_heap to provide better control of RAM usage.
