### PR TITLE
[nrf noup] Fixed hard fault once advertising mdns records

### DIFF
--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -215,7 +215,7 @@ config CHIP_MALLOC_SYS_HEAP_OVERRIDE
 
 config CHIP_MALLOC_SYS_HEAP_SIZE
 	int "Heap size used by memory allocator based on Zephyr sys_heap"
-	default 10240 # 10kB
+	default 12288 # 12kB
 	help
 	  This value controls how much of the device RAM is reserved for the heap
 	  used by the memory allocation functions based on sys_heap from Zephyr

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -874,6 +874,7 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
     }
 
     UniquePtr<ListenIterator> allInterfaces = GetAddressPolicy()->GetListenEndpoints();
+    VerifyOrDieWithMsg(allInterfaces != nullptr, Discovery, "Failed to allocate memory for endpoints.");
 
     chip::Inet::InterfaceId interfaceId;
     chip::Inet::IPAddressType addressType;
@@ -881,6 +882,7 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
     while (allInterfaces->Next(&interfaceId, &addressType))
     {
         UniquePtr<IpAddressIterator> allIps = GetAddressPolicy()->GetIpAddressesForEndpoint(interfaceId, addressType);
+        VerifyOrDieWithMsg(allIps != nullptr, Discovery, "Failed to allocate memory for ip addresses.");
 
         Inet::IPAddress ipAddress;
         while (allIps->Next(ipAddress))


### PR DESCRIPTION
In mDNS code there isn't a check that would verify if memory was allocated successfully. In case heap is too small the application will fall into hard fault due to usage of non-allocated memory.
