### PR TITLE
[nrf noup] [mrp] Added config to allow overriding MRP params at runtime

### DIFF
--- a/src/messaging/ReliableMessageProtocolConfig.cpp
+++ b/src/messaging/ReliableMessageProtocolConfig.cpp
@@ -31,7 +31,7 @@ namespace chip {
 
 using namespace System::Clock::Literals;
 
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST || CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE
 static Optional<System::Clock::Timeout> idleRetransTimeoutOverride   = NullOptional;
 static Optional<System::Clock::Timeout> activeRetransTimeoutOverride = NullOptional;
 
@@ -72,7 +72,7 @@ Optional<ReliableMessageProtocolConfig> GetLocalMRPConfig()
     }
 #endif
 
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST  || CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE
     if (idleRetransTimeoutOverride.HasValue())
     {
         config.mIdleRetransTimeout = idleRetransTimeoutOverride.Value();

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -32,6 +32,20 @@
 namespace chip {
 
 /**
+ *  @def CHIP_CONFIG_RUNTIME_MRP_OVERRIDE
+ *
+ *  @brief
+ *    Enable overriding MRP params at runtime.
+ *
+ *  This config enables overriding MRP params at runtime which can be useful when the intervals may be various in different networks.
+ *  (e.g. different values of DTIM and beacon intervals in Wi-Fi network)
+ *
+ */
+#ifndef CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE
+#define CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE 0
+#endif
+
+/**
  *  @def CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
  *
  *  @brief
@@ -156,13 +170,13 @@ ReliableMessageProtocolConfig GetDefaultMRPConfig();
  */
 Optional<ReliableMessageProtocolConfig> GetLocalMRPConfig();
 
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST || CHIP_CONFIG_ALLOW_RUNTIME_MRP_OVERRIDE
 
 /**
  * @brief
  *
  * Overrides the local idle and active retransmission timeout parameters (which are usually set through compile
- * time defines). This is reserved for tests that need the ability to set these at runtime to make certain test scenarios possible.
+ * time defines).
  *
  */
 void OverrideLocalMRPConfig(System::Clock::Timeout idleRetransTimeout, System::Clock::Timeout activeRetransTimeout);

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -95,6 +95,8 @@ static_library("nrfconnect") {
       "wifi/WiFiManager.cpp",
       "wifi/WiFiManager.h",
     ]
+
+    public_deps += [ "${chip_root}/src/messaging:messaging_mrp_config" ]
   }
 
   if (chip_enable_nfc) {


### PR DESCRIPTION
Sometimes in different networks, it is needed to change MRP intervals at runtime. For example in low-power Wi-Fi networks when DTIM and beacon intervals may be various and depend on Access point settings.
The new config allows overriding MRP params at runtime by using the OverrideLocalMRPConfig() function, and clearing that override by using ClearLocalMRPConfigOverride().
