### PR TITLE
[nrf noup] Added support for multi-variant application OTA DFU

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -222,6 +222,7 @@ chip_gn_arg_bool  ("chip_detail_logging"                    CONFIG_MATTER_LOG_LE
 chip_gn_arg_bool  ("chip_automation_logging"                "false")
 chip_gn_arg_bool  ("chip_malloc_sys_heap"                   CONFIG_CHIP_MALLOC_SYS_HEAP)
 chip_gn_arg_bool  ("chip_enable_wifi"                       CONFIG_WIFI_NRF700X)
+chip_gn_arg_bool  ("chip_multi_variant_ota"                 CONFIG_THREAD_WIFI_SWITCHING)
 
 if (CONFIG_CHIP_FACTORY_DATA)
     chip_gn_arg_bool  ("chip_use_transitional_commissionable_data_provider"  "false")

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -109,6 +109,12 @@ static_library("nrfconnect") {
       "OTAImageProcessorImpl.cpp",
       "OTAImageProcessorImpl.h",
     ]
+      if (chip_multi_variant_ota) {
+        sources += [
+          "OTAMultiImageDownloader.cpp",
+          "OTAMultiImageDownloader.h",
+        ]
+      }
   }
 
   if (chip_malloc_sys_heap) {

--- a/src/platform/nrfconnect/OTAMultiImageDownloader.cpp
+++ b/src/platform/nrfconnect/OTAMultiImageDownloader.cpp
@@ -1,0 +1,181 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "OTAMultiImageDownloader.h"
+#include <dfu/dfu_target.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <pm_config.h>
+
+namespace chip {
+namespace DeviceLayer {
+
+size_t OTAMultiImageDownloaders::sCurrentId;
+
+std::array<OTAMultiImageDownloader, OTAMultiImageDownloaders::CurrentImageID::LIMIT> OTAMultiImageDownloaders::sImageHandlers{
+    { OTAMultiImageDownloader{ 0, PM_APP_1_CORE_APP_DOWNLOAD_OFFSET, PM_APP_1_CORE_APP_DOWNLOAD_SIZE, PM_APP_1_CORE_APP_ADDRESS,
+                               PM_APP_1_CORE_APP_SIZE },
+      OTAMultiImageDownloader{ 1, PM_APP_1_CORE_NET_DOWNLOAD_OFFSET, PM_APP_1_CORE_NET_DOWNLOAD_SIZE, PM_APP_1_CORE_NET_ADDRESS,
+                               PM_APP_1_CORE_NET_SIZE },
+      OTAMultiImageDownloader{ 2, PM_APP_2_CORE_APP_DOWNLOAD_OFFSET, PM_APP_2_CORE_APP_DOWNLOAD_SIZE, PM_APP_2_CORE_APP_ADDRESS,
+                               PM_APP_2_CORE_APP_SIZE },
+      OTAMultiImageDownloader{ 3, PM_APP_2_CORE_NET_DOWNLOAD_OFFSET, PM_APP_2_CORE_NET_DOWNLOAD_SIZE, PM_APP_2_CORE_NET_ADDRESS,
+                               PM_APP_2_CORE_NET_SIZE } }
+};
+
+static const device * sExtFlash = DEVICE_DT_GET(DT_CHOSEN(nordic_pm_ext_flash));
+
+int OTAMultiImageDownloader::Init(const device * flash, ssize_t size)
+{
+    if (!device_is_ready(flash))
+    {
+        ChipLogError(SoftwareUpdate, "Flash device is not ready!");
+        return -EFAULT;
+    }
+    return Init(flash, mOffset, size);
+}
+
+int OTAMultiImageDownloader::Init(const device * flash, size_t offset, size_t size)
+{
+    mBuffer = (uint8_t *) Platform::MemoryAlloc(kBufferSize);
+    return stream_flash_init(&mStream, flash, mBuffer, kBufferSize, offset, size, nullptr);
+}
+
+int OTAMultiImageDownloader::Apply(const device * flash)
+{
+    // Reinit stream with different flash partition
+    int err = Init(flash, mTargetOffset, mTargetImgSize);
+    if (err != 0)
+    {
+        ChipLogError(SoftwareUpdate, "Cannot reinitialize flash stream");
+        return -EBUSY;
+    }
+
+    Platform::ScopedMemoryBuffer<uint8_t> buffer;
+    if (!buffer.Alloc(kBufferSize))
+    {
+        return -ENOMEM;
+    }
+
+    for (size_t offset = 0; offset < mImgSize; offset += kBufferSize)
+    {
+        err = flash_read(flash, mOffset + offset, buffer.Get(), kBufferSize);
+        if (err != 0)
+        {
+            ChipLogError(SoftwareUpdate, "Failed to read data chunk from flash");
+            return -EIO;
+        }
+        err = Write(buffer.Get(), kBufferSize);
+        if (err != 0)
+        {
+            ChipLogError(SoftwareUpdate, "Failed to write data chunk to flash");
+            return -EIO;
+        }
+    }
+    return Finalize();
+}
+
+int OTAMultiImageDownloader::Write(const uint8_t * chunk, size_t chunkSize)
+{
+    return stream_flash_buffered_write(&mStream, chunk, chunkSize, false);
+}
+
+int OTAMultiImageDownloader::Finalize()
+{
+    int err = stream_flash_buffered_write(&mStream, nullptr, 0, true);
+    Platform::MemoryFree(mBuffer);
+    return err;
+}
+
+// Implementation of stateless OTAMultiImageDownloaders class
+
+int OTAMultiImageDownloaders::Open(int id, size_t size)
+{
+    int dfuTargetId = id < 2 ? id : id - 2; // dfu_target only accepts fixed 0 and 1 slots in the secondary partition
+    if (DfuTargetActionNeeded(id))
+    {
+
+        int err = dfu_target_init(DFU_TARGET_IMAGE_TYPE_MCUBOOT, dfuTargetId, size, nullptr);
+        if (err)
+        {
+            ChipLogError(SoftwareUpdate, "Cannot initialize DFU target: %d", err);
+            return err;
+        }
+    }
+
+    OTAMultiImageDownloaders::SetCurrentImageId(id);
+    return OTAMultiImageDownloaders::GetCurrentImage()->Init(sExtFlash, size);
+}
+
+int OTAMultiImageDownloaders::Write(const uint8_t * chunk, size_t chunk_size)
+{
+    if (DfuTargetActionNeeded(OTAMultiImageDownloaders::CurrentImageId()))
+    {
+        int err = dfu_target_write(chunk, chunk_size);
+        if (err < 0)
+        {
+            ChipLogError(SoftwareUpdate, "Cannot write DFU target: %d", err);
+            return err;
+        }
+    }
+
+    return OTAMultiImageDownloaders::GetCurrentImage()->Write(chunk, chunk_size);
+}
+
+int OTAMultiImageDownloaders::Close(bool success)
+{
+    if (DfuTargetActionNeeded(OTAMultiImageDownloaders::CurrentImageId()))
+    {
+        int err = success ? dfu_target_done(success) : dfu_target_reset();
+        if (err)
+        {
+            ChipLogError(SoftwareUpdate, "Cannot close DFU target: %d", err);
+            return err;
+        }
+    }
+
+    return OTAMultiImageDownloaders::GetCurrentImage()->Finalize();
+}
+
+int OTAMultiImageDownloaders::Apply()
+{
+    int err{ -ENXIO };
+    for (auto image : sImageHandlers)
+    {
+        err = image.Apply(sExtFlash);
+        if (err)
+        {
+            return err;
+        }
+    }
+    return err;
+}
+
+int OTAMultiImageDownloaders::DfuTargetActionNeeded(int id)
+{
+    if (CONFIG_APPLICATION_IDX == RunningVariant::THREAD && CONFIG_APPLICATION_OTHER_IDX == RunningVariant::WIFI)
+    {
+        return (id == CurrentImageID::APP_1_CORE_APP || id == CurrentImageID::APP_1_CORE_NET);
+    }
+    else if (CONFIG_APPLICATION_IDX == RunningVariant::WIFI && CONFIG_APPLICATION_OTHER_IDX == RunningVariant::THREAD)
+    {
+        return (id == CurrentImageID::APP_2_CORE_APP || id == CurrentImageID::APP_2_CORE_NET);
+    }
+    return false;
+}
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/OTAMultiImageDownloader.h
+++ b/src/platform/nrfconnect/OTAMultiImageDownloader.h
@@ -1,0 +1,97 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <zephyr/storage/stream_flash.h>
+
+#include <array>
+
+namespace chip {
+namespace DeviceLayer {
+
+/* A helper class to facilitate the multi variant application OTA DFU
+   (Thread/WiFi switchable)  with the stream_flash backend */
+class OTAMultiImageDownloader
+{
+public:
+    OTAMultiImageDownloader(int imageId, size_t offset, size_t size, size_t targetOffset, size_t targetSize) :
+        mImgId(imageId), mOffset(offset), mImgSize(size), mTargetOffset(targetOffset), mTargetImgSize(targetSize)
+    {}
+
+    int Init(const device * flash, ssize_t size);
+    int Write(const uint8_t * chunk, size_t chunkSize);
+    int Finalize();
+    int Apply(const device * flash);
+    int GetImageId() { return mImgId; }
+
+private:
+    int Init(const device * flash, size_t offset, size_t size);
+
+    int mImgId;
+    const size_t mOffset;
+    const size_t mImgSize;
+    const size_t mTargetOffset;
+    const size_t mTargetImgSize;
+    uint8_t * mBuffer;
+    stream_flash_ctx mStream;
+
+    static constexpr size_t kBufferSize = CONFIG_CHIP_OTA_REQUESTOR_BUFFER_SIZE;
+};
+
+/* Wrapper for a collection of OTAMultiImageDownloader static objects */
+class OTAMultiImageDownloaders
+{
+public:
+    static OTAMultiImageDownloader * GetCurrentImage()
+    {
+        if (sCurrentId > sImageHandlers.size())
+        {
+            return nullptr;
+        }
+        return &sImageHandlers[sCurrentId];
+    }
+
+    static int Open(int id, size_t size);
+    static int Write(const uint8_t * chunk, size_t chunk_size);
+    static int Close(bool success);
+    static int Apply();
+    static int DfuTargetActionNeeded(int id);
+    static void SetCurrentImageId(size_t id) { sCurrentId = id; }
+    static size_t CurrentImageId() { return sCurrentId; }
+
+private:
+    enum CurrentImageID : int
+    {
+        NONE = -1,
+        APP_1_CORE_APP,
+        APP_1_CORE_NET,
+        APP_2_CORE_APP,
+        APP_2_CORE_NET,
+        LIMIT
+    };
+
+    enum RunningVariant : int
+    {
+        THREAD = 1,
+        WIFI
+    };
+
+    static size_t sCurrentId;
+    static std::array<OTAMultiImageDownloader, CurrentImageID::LIMIT> sImageHandlers;
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/args.gni
+++ b/src/platform/nrfconnect/args.gni
@@ -17,4 +17,6 @@ declare_args() {
 
   # Enable factory data support
   chip_enable_factory_data = false
+  # Enable multi-variant application DFU support
+  chip_multi_variant_ota = false
 }


### PR DESCRIPTION
* Implemented dedicated flash write handlers for a Thread/WiFi switchable app.
* A script for generating multi variant OTA image has been added in sdk-nrf.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>
