### PR TITLE
[nrf noup] Increased the default net_mgmt stack size

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -218,6 +218,9 @@ config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
 config SYSTEM_WORKQUEUE_STACK_SIZE
     default 2048
 
+config NET_MGMT_EVENT_STACK_SIZE
+    default 1024
+
 # align these numbers to match the OpenThread config
 config NET_IF_UNICAST_IPV6_ADDR_COUNT
     default 6


### PR DESCRIPTION
Once we were hit by the net_mgmt thread stack overflow while show casing the Matter over WiFi solution in WiFi RF congested environment. Increase the default stack size of net_mgmt from 768 to 1k.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>

