### PR TITLE
Wifi ble coex

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -108,8 +108,18 @@ config BT_PERIPHERAL_PREF_MIN_INT
 config BT_PERIPHERAL_PREF_MAX_INT
     default 36
 
+# Increase BT timeout to 5 s to improve connection reliability and avoid fast drop outs.
+config BT_PERIPHERAL_PREF_TIMEOUT
+    default 500
+
 config BT_GAP_AUTO_UPDATE_CONN_PARAMS
     default y
+
+# Decrease connection parameters update time, as some Matter controllers request
+# enabling IP networking faster than BT connection parameters are updated, what may result
+# in commissioning instabilities.
+config BT_CONN_PARAM_UPDATE_TIMEOUT
+    default 1000
 
 config BT_GATT_DYNAMIC_DB
     default y

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -83,8 +83,8 @@ config CHIP_DFU_OVER_BT_SMP
 	select MCUMGR_CMD_IMG_MGMT
 	select MCUMGR_CMD_OS_MGMT
 	# Enable custom SMP request to erase settings partition.
-	select MCUMGR_GRP_ZEPHYR_BASIC if SOC_SERIES_NRF53X
-	select MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE if SOC_SERIES_NRF53X
+	select MCUMGR_GRP_ZEPHYR_BASIC
+	select MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
 	help
 		Enables Device Firmware Upgrade over Bluetoot LE with SMP
 		and configures set of options related to that feature.

--- a/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
@@ -63,6 +63,10 @@ config BT_HCI_RAW_RESERVE
 config BT_BUF_CMD_TX_COUNT
     default 10
 
+# Enable support for Wi-Fi and Bluetooth LE coexistance
+config MPSL_CX
+    default y
+
 config ASSERT
     default y
 


### PR DESCRIPTION
Pulled commits to improve Bluetooth LE connection configuration, enable Wi-Fi/BLE coex and enable erasing settings partition using MCUMGR command during DFU over Bluetooth LE SMP.