### PR TITLE
mgmt: mcumgr: Remove command registration functions

### DIFF
--- a/examples/platform/nrfconnect/util/DFUOverSMP.cpp
+++ b/examples/platform/nrfconnect/util/DFUOverSMP.cpp
@@ -68,9 +68,6 @@ void DFUOverSMP::Init()
         }
     };
 
-    os_mgmt_register_group();
-    img_mgmt_register_group();
-
     img_mgmt_set_upload_cb([](const img_mgmt_upload_req req, const img_mgmt_upload_action action) {
         ChipLogProgress(SoftwareUpdate, "DFU over SMP progress: %u/%u B of image %u", static_cast<unsigned>(req.off),
                         static_cast<unsigned>(action.size), static_cast<unsigned>(req.image));
@@ -111,7 +108,6 @@ void DFUOverSMP::ConfirmNewImage()
 void DFUOverSMP::StartServer()
 {
     VerifyOrReturn(!mIsStarted, ChipLogProgress(SoftwareUpdate, "DFU over SMP was already started"));
-    smp_bt_register();
 
     // Synchronize access to the advertising arbiter that normally runs on the CHIP thread.
     PlatformMgr().LockChipStack();


### PR DESCRIPTION
Commands are now registered automatically, this is no longer needed.

**DNM** until sdk-zephyr change is merged