### PR TITLE
[nrf noup] [nrfconnect] Introduce the WiFi connection recovery feature

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -172,6 +172,51 @@ config CHIP_FACTORY_RESET_ERASE_NVS
 	bool
 	default y if CHIP_FACTORY_DATA || CHIP_FACTORY_DATA_CUSTOM_BACKEND
 
+config CHIP_WIFI_CONNECTION_RECOVERY_MINIMUM_INTERVAL
+	int "Define the minimum connection recovery time interval in milliseconds"
+	depends on CHIP_WIFI
+	default 500
+	help
+	  Specifies the minimum connection recovery interval (in milliseconds).
+
+config CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL
+	int "Define the maximum connection recovery time interval in milliseconds"
+	depends on CHIP_WIFI
+	default 3600000 # 1 hour
+	help
+	  Specifies the maximum connection recovery interval (in milliseconds).
+
+config CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER
+	int "Define maximum amount of connection recovery occurrences"
+	depends on CHIP_WIFI
+	default 0
+	help
+	  Specifies the maximum connection recovery attempts. 
+	  If set to 0, no limitation is applied and the connect retry is performed endlessly.
+
+config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
+	int "Define the connection recovery jitter in milliseconds"
+	depends on CHIP_WIFI
+	default 2000
+	help
+	  Specifies the maximum connection recovery jitter interval (in milliseconds).
+	  Once the wait time reaches the maximum value a random jitter interval is
+	  added to it to avoid periodicity. The random jitter is selected
+	  within range [-JITTER; +JITTER]. The random jitter value is added only
+	  when connection recovery interval reaches the maximum value.
+
+config CHIP_WIFI_CONNECTION_RECOVERY_RESET_DELAY
+	int "Define the delay between resetting connection recovery interval"
+	depends on CHIP_WIFI
+	default 0
+	help
+	  Specifies the delay after a successful connection recovery.
+	  The 0 value means that the connection recovery interval will be cleared
+	  immediately after the connection recovery.
+	  A non-zero value delays the interval reset, which is helpful in the situation
+	  where a link quality to a WiFi access point is poor and device disconnects 
+	  frequently.
+
 endif
 
 config CHIP_LOG_SIZE_OPTIMIZATION

--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -172,51 +172,6 @@ config CHIP_FACTORY_RESET_ERASE_NVS
 	bool
 	default y if CHIP_FACTORY_DATA || CHIP_FACTORY_DATA_CUSTOM_BACKEND
 
-config CHIP_WIFI_CONNECTION_RECOVERY_MINIMUM_INTERVAL
-	int "Define the minimum connection recovery time interval in milliseconds"
-	depends on CHIP_WIFI
-	default 500
-	help
-	  Specifies the minimum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL
-	int "Define the maximum connection recovery time interval in milliseconds"
-	depends on CHIP_WIFI
-	default 3600000 # 1 hour
-	help
-	  Specifies the maximum connection recovery interval (in milliseconds).
-
-config CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER
-	int "Define maximum amount of connection recovery occurrences"
-	depends on CHIP_WIFI
-	default 0
-	help
-	  Specifies the maximum connection recovery attempts. 
-	  If set to 0, no limitation is applied and the connect retry is performed endlessly.
-
-config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
-	int "Define the connection recovery jitter in milliseconds"
-	depends on CHIP_WIFI
-	default 2000
-	help
-	  Specifies the maximum connection recovery jitter interval (in milliseconds).
-	  Once the wait time reaches the maximum value a random jitter interval is
-	  added to it to avoid periodicity. The random jitter is selected
-	  within range [-JITTER; +JITTER]. The random jitter value is added only
-	  when connection recovery interval reaches the maximum value.
-
-config CHIP_WIFI_CONNECTION_RECOVERY_RESET_DELAY
-	int "Define the delay between resetting connection recovery interval"
-	depends on CHIP_WIFI
-	default 0
-	help
-	  Specifies the delay after a successful connection recovery.
-	  The 0 value means that the connection recovery interval will be cleared
-	  immediately after the connection recovery.
-	  A non-zero value delays the interval reset, which is helpful in the situation
-	  where a link quality to a WiFi access point is poor and device disconnects 
-	  frequently.
-
 endif
 
 config CHIP_LOG_SIZE_OPTIMIZATION

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -138,4 +138,37 @@ endif # SOC_SERIES_NRF53X
 
 endif # CHIP_DFU_OVER_BT_SMP
 
+config CHIP_WIFI_CONNECTION_RECOVERY_MINIMUM_INTERVAL
+	int "Define the minimum connection recovery time interval in milliseconds"
+	depends on CHIP_WIFI
+	default 500
+	help
+	  Specifies the minimum connection recovery interval (in milliseconds).
+
+config CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL
+	int "Define the maximum connection recovery time interval in milliseconds"
+	depends on CHIP_WIFI
+	default 3600000 # 1 hour
+	help
+	  Specifies the maximum connection recovery interval (in milliseconds).
+
+config CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER
+	int "Define the maximum amount of connection recovery occurrences"
+	depends on CHIP_WIFI
+	default 0
+	help
+	  Specifies the maximum number of connection recovery attempts.
+	  If set to 0, no limitation is applied and attempts
+	  to recover the connection are performed indefinitely.
+
+config CHIP_WIFI_CONNECTION_RECOVERY_JITTER
+	int "Define the connection recovery jitter in milliseconds"
+	depends on CHIP_WIFI
+	default 2000
+	help
+	  Specifies the maximum connection recovery jitter interval (in milliseconds).
+	  Once the wait time reaches the current maximum value (defined by CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL),
+	  a random jitter interval is added to it to avoid periodicity. The random jitter is selected
+	  within range [-JITTER; +JITTER].
+
 endif # CHIP

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -147,6 +147,10 @@ CHIP_ERROR NrfWiFiDriver::CommitConfiguration()
 
 CHIP_ERROR NrfWiFiDriver::RevertConfiguration()
 {
+    // Abort Connection Recovery if it is in progress during reverting configuration.
+    // This is needed to stop recovery process after failsafe timer expiring.
+    WiFiManager::Instance().AbortConnectionRecovery();
+
     LoadFromStorage();
 
     if (WiFiManager::StationStatus::CONNECTING <= WiFiManager::Instance().GetStationStatus())

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -174,12 +174,12 @@ CHIP_ERROR WiFiManager::Scan(const ByteSpan & ssid, ScanResultCallback resultCal
     net_if * iface = InetUtils::GetInterface();
     VerifyOrReturnError(nullptr != iface, CHIP_ERROR_INTERNAL);
 
-    mInternalScan         = internalScan;
-    mScanResultCallback   = resultCallback;
-    mScanDoneCallback     = doneCallback;
-    mCachedWiFiState      = mWiFiState;
-    mWiFiState            = WIFI_STATE_SCANNING;
-    Instance().mSsidFound = false;
+    mInternalScan       = internalScan;
+    mScanResultCallback = resultCallback;
+    mScanDoneCallback   = doneCallback;
+    mCachedWiFiState    = mWiFiState;
+    mWiFiState          = WIFI_STATE_SCANNING;
+    mSsidFound          = false;
 
     if (net_mgmt(NET_REQUEST_WIFI_SCAN, iface, NULL, 0))
     {
@@ -216,8 +216,6 @@ CHIP_ERROR WiFiManager::Connect(const ByteSpan & ssid, const ByteSpan & credenti
     memcpy(mWantedNetwork.pass, credentials.data(), credentials.size());
     mWantedNetwork.ssidLen = ssid.size();
     mWantedNetwork.passLen = credentials.size();
-
-    Instance().mSsidFound = false;
 
     return Scan(ssid, nullptr, nullptr, true /* internal scan */);
 }
@@ -341,17 +339,19 @@ void WiFiManager::ScanResultHandler(Platform::UniquePtr<uint8_t> data)
 
 void WiFiManager::ScanDoneHandler(Platform::UniquePtr<uint8_t> data)
 {
-    CHIP_ERROR err = SystemLayer().ScheduleLambda([rawData = data.get()] {
+    CHIP_ERROR err = SystemLayer().ScheduleLambda([capturedData = data.get()] {
+        Platform::UniquePtr<uint8_t> safePtr(capturedData);
+        uint8_t * rawData               = safePtr.get();
         const wifi_status * status      = reinterpret_cast<const wifi_status *>(rawData);
         WiFiRequestStatus requestStatus = static_cast<WiFiRequestStatus>(status->status);
 
         if (requestStatus == WiFiRequestStatus::FAILURE)
         {
-            ChipLogError(DeviceLayer, "Scan request failed (%d)", status->status);
+            ChipLogError(DeviceLayer, "Wi-Fi scan finalization failure (%d)", status->status);
         }
         else
         {
-            ChipLogDetail(DeviceLayer, "Scan request done (%d)", status->status);
+            ChipLogProgress(DeviceLayer, "Wi-Fi scan done (%d)", status->status);
         }
 
         if (Instance().mScanDoneCallback && !Instance().mInternalScan)
@@ -362,15 +362,20 @@ void WiFiManager::ScanDoneHandler(Platform::UniquePtr<uint8_t> data)
             return;
         }
 
-        if (!Instance().mSsidFound)
-        {
-            DeviceLayer::SystemLayer().StartTimer(Instance().GetNextRecoveryTime(), Recover, nullptr);
-            return;
-        }
-
-        // Internal scan is supposed to be followed by connection request
+        // Internal scan is supposed to be followed by a connection request if the SSID has been found
         if (Instance().mInternalScan)
         {
+            if (!Instance().mSsidFound && !Instance().mRecoveryTimerAborted)
+            {
+                ChipLogProgress(DeviceLayer, "No requested SSID found");
+                auto currentTimeout = Instance().CalculateNextRecoveryTime();
+                ChipLogProgress(DeviceLayer, "Starting connection recover: re-scanning... (next attempt in %d ms)",
+                                currentTimeout.count());
+                Instance().mRecoveryTimerAborted = false;
+                DeviceLayer::SystemLayer().StartTimer(currentTimeout, Recover, nullptr);
+                return;
+            }
+
             Instance().mWiFiState = WIFI_STATE_ASSOCIATING;
             net_if * iface        = InetUtils::GetInterface();
             VerifyOrReturn(nullptr != iface, CHIP_ERROR_INTERNAL);
@@ -385,12 +390,10 @@ void WiFiManager::ScanDoneHandler(Platform::UniquePtr<uint8_t> data)
                 Instance().mWiFiState = WIFI_STATE_DISCONNECTED;
                 return;
             }
-            ChipLogDetail(DeviceLayer, "Connection to %*s requested", Instance().mWiFiParams.mParams.ssid_length,
-                          Instance().mWiFiParams.mParams.ssid);
+            ChipLogProgress(DeviceLayer, "Connection to %*s requested", Instance().mWiFiParams.mParams.ssid_length,
+                            Instance().mWiFiParams.mParams.ssid);
             Instance().mInternalScan = false;
         }
-
-        delete[] rawData;
     });
 
     if (CHIP_NO_ERROR == err)
@@ -421,29 +424,29 @@ void WiFiManager::SendRouterSolicitation(System::Layer * layer, void * param)
 
 void WiFiManager::ConnectHandler(Platform::UniquePtr<uint8_t> data)
 {
-    CHIP_ERROR err = SystemLayer().ScheduleLambda([rawData = data.get()] {
+    CHIP_ERROR err = SystemLayer().ScheduleLambda([capturedData = data.get()] {
+        Platform::UniquePtr<uint8_t> safePtr(capturedData);
+        uint8_t * rawData               = safePtr.get();
         const wifi_status * status      = reinterpret_cast<const wifi_status *>(rawData);
         WiFiRequestStatus requestStatus = static_cast<WiFiRequestStatus>(status->status);
 
         if (requestStatus == WiFiRequestStatus::FAILURE || requestStatus == WiFiRequestStatus::TERMINATED)
         {
-            ChipLogDetail(DeviceLayer, "Connection to WiFi network failed or was terminated by another request");
+            ChipLogProgress(DeviceLayer, "Connection to WiFi network failed or was terminated by another request");
             Instance().mWiFiState = WIFI_STATE_DISCONNECTED;
             if (Instance().mHandling.mOnConnectionFailed)
             {
                 Instance().mHandling.mOnConnectionFailed();
-                // Reset the connection recover interval to the minimum value after the defined delay
-                DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kConnectionRecoveryDelayToReset), ResetRecoveryTime, nullptr);
             }
         }
-        else
+        else // The connection has been established successfully.
         {
             // Workaround needed until sending Router Solicitation after connect will be done by the driver.
             DeviceLayer::SystemLayer().StartTimer(
                 System::Clock::Milliseconds32(chip::Crypto::GetRandU16() % kMaxInitialRouterSolicitationDelayMs),
                 SendRouterSolicitation, nullptr);
 
-            ChipLogDetail(DeviceLayer, "Connected to WiFi network");
+            ChipLogProgress(DeviceLayer, "Connected to WiFi network");
             Instance().mWiFiState = WIFI_STATE_COMPLETED;
             if (Instance().mHandling.mOnConnectionSuccess)
             {
@@ -451,10 +454,10 @@ void WiFiManager::ConnectHandler(Platform::UniquePtr<uint8_t> data)
             }
             Instance().PostConnectivityStatusChange(kConnectivity_Established);
         }
+        // Ensure fresh recovery for future connection requests.
+        Instance().ResetRecoveryTime();
         // cleanup the provisioning data as it is configured per each connect request
         Instance().ClearStationProvisioningData();
-
-        delete[] rawData;
     });
 
     if (CHIP_NO_ERROR == err)
@@ -467,9 +470,11 @@ void WiFiManager::ConnectHandler(Platform::UniquePtr<uint8_t> data)
 void WiFiManager::DisconnectHandler(Platform::UniquePtr<uint8_t>)
 {
     SystemLayer().ScheduleLambda([] {
-        ChipLogDetail(DeviceLayer, "WiFi station disconnected");
+        ChipLogProgress(DeviceLayer, "WiFi station disconnected");
         Instance().mWiFiState = WIFI_STATE_DISCONNECTED;
         Instance().PostConnectivityStatusChange(kConnectivity_Lost);
+        // Ensure fresh recovery for future connection requests.
+        Instance().ResetRecoveryTime();
     });
 }
 
@@ -486,55 +491,46 @@ void WiFiManager::PostConnectivityStatusChange(ConnectivityChange changeType)
     PlatformMgr().PostEventOrDie(&networkEvent);
 }
 
-System::Clock::Milliseconds32 WiFiManager::GetNextRecoveryTime()
+System::Clock::Milliseconds32 WiFiManager::CalculateNextRecoveryTime()
 {
-
-    if (mConnectionRecoveryTimeMs >= kConnectionRecoveryMaxIntervalMs)
+    if (mConnectionRecoveryTimeMs > kConnectionRecoveryMaxIntervalMs)
     {
-        // find the new random jitter value in range [-jitter, +jitter]
+        // Find the new random jitter value in range [-jitter, +jitter].
         int32_t jitter            = chip::Crypto::GetRandU32() % (2 * jitter + 1) - jitter;
         mConnectionRecoveryTimeMs = kConnectionRecoveryMaxIntervalMs + jitter;
+        return System::Clock::Milliseconds32(mConnectionRecoveryTimeMs);
     }
     else
     {
-        mConnectionRecoveryTimeMs = mConnectionRecoveryTimeMs * 2;
+        uint32_t currentRecoveryTimeout = mConnectionRecoveryTimeMs;
+        mConnectionRecoveryTimeMs       = mConnectionRecoveryTimeMs * 2;
+        return System::Clock::Milliseconds32(currentRecoveryTimeout);
     }
-    return System::Clock::Milliseconds32(mConnectionRecoveryTimeMs);
 }
 
 void WiFiManager::Recover(System::Layer *, void *)
 {
-    // If kConnectionRecoveryMaxOverallInterval has a non-zero value prevent re-scan endless.
+    // If kConnectionRecoveryMaxOverallInterval has a non-zero value prevent endless re-scan.
     if (0 != kConnectionRecoveryMaxRetries && (++Instance().mConnectionRecoveryCounter >= kConnectionRecoveryMaxRetries))
     {
         Instance().AbortConnectionRecovery();
+        return;
     }
 
-    // Prevent executing Scan if it has been aborted by the failsafe timer occurrence.
-    if (!Instance().mRecoveryTimerAborted)
-    {
-        ChipLogProgress(DeviceLayer, "Connection recover re-scanning... (next attempt in %d ms)",
-                        Instance().GetNextRecoveryTime().count());
-        Instance().Scan(Instance().mWantedNetwork.GetSsidSpan(), nullptr, nullptr, true /* internal scan */);
-    }
-    Instance().mRecoveryTimerAborted = false;
+    Instance().Scan(Instance().mWantedNetwork.GetSsidSpan(), nullptr, nullptr, true /* internal scan */);
 }
 
-void WiFiManager::ResetRecoveryTime(System::Layer *, void *)
+void WiFiManager::ResetRecoveryTime()
 {
-    if (WIFI_STATE_COMPLETED == Instance().mWiFiState)
-    {
-        Instance().mConnectionRecoveryTimeMs  = kConnectionRecoveryMinIntervalMs;
-        Instance().mConnectionRecoveryCounter = 0;
-    }
+    mConnectionRecoveryTimeMs  = kConnectionRecoveryMinIntervalMs;
+    mConnectionRecoveryCounter = 0;
 }
 
 void WiFiManager::AbortConnectionRecovery()
 {
     DeviceLayer::SystemLayer().CancelTimer(Recover, nullptr);
-    Instance().mConnectionRecoveryTimeMs  = kConnectionRecoveryMinIntervalMs;
-    Instance().mConnectionRecoveryCounter = 0;
-    Instance().mRecoveryTimerAborted      = true;
+    Instance().ResetRecoveryTime();
+    Instance().mRecoveryTimerAborted = true;
 }
 
 } // namespace DeviceLayer

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -74,12 +74,12 @@ public:
         return T2{};
     }
 
-    Map()                        = delete;
-    Map(const Map &)             = delete;
-    Map(Map &&)                  = delete;
+    Map()            = delete;
+    Map(const Map &) = delete;
+    Map(Map &&)      = delete;
     Map & operator=(const Map &) = delete;
-    Map & operator=(Map &&)      = delete;
-    ~Map()                       = default;
+    Map & operator=(Map &&) = delete;
+    ~Map()                  = default;
 
 private:
     Pair mMap[N];
@@ -172,7 +172,6 @@ public:
     static constexpr uint32_t kConnectionRecoveryMinIntervalMs     = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_MINIMUM_INTERVAL;
     static constexpr uint32_t kConnectionRecoveryMaxIntervalMs     = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL;
     static constexpr uint32_t kConnectionRecoveryJitterMs          = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_JITTER;
-    static constexpr uint32_t kConnectionRecoveryDelayToReset      = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_RESET_DELAY;
     static constexpr uint32_t kConnectionRecoveryMaxRetries        = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER;
 
     static_assert(kConnectionRecoveryMinIntervalMs < kConnectionRecoveryMaxIntervalMs);
@@ -225,8 +224,8 @@ private:
     // To avoid frequent recovery attempts when the signal to an access point is poor quality
     // The connection recovery interval will be cleared after the defined delay in kConnectionRecoveryDelayToReset.
     static void Recover(System::Layer * layer, void * param);
-    static void ResetRecoveryTime(System::Layer * layer, void * param);
-    System::Clock::Milliseconds32 GetNextRecoveryTime();
+    void ResetRecoveryTime();
+    System::Clock::Milliseconds32 CalculateNextRecoveryTime();
 
     ConnectionParams mWiFiParams{};
     ConnectionHandling mHandling;
@@ -241,7 +240,7 @@ private:
     bool mSsidFound{ false };
     uint32_t mConnectionRecoveryCounter{ 0 };
     uint32_t mConnectionRecoveryTimeMs{ kConnectionRecoveryMinIntervalMs };
-    bool mRecoveryTimerAborted = false;
+    bool mRecoveryTimerAborted{ false };
 
     static const Map<wifi_iface_state, StationStatus, 10> sStatusMap;
     static const Map<uint32_t, NetEventHandler, 4> sEventHandlerMap;


### PR DESCRIPTION
The WiFi connection recovery feature allows device re-scanning and re-connecting to the known WiFi network after the device's reboot and when the known SSID has not been found during the last scan. The connection recovery interval is doubled with
every occurrence to the defined maximum value and then its value depends on the maximum value +- the defined random jitter.

After restoring the connection, the Connection Recovery Interval is restored to the defined minimum value after elapsing of the defined delay to avoid frequent reconnections to a poor link quality network.
