### PR TITLE
[nrf noup] Remove Android Chip Tool build from release workflow

### DIFF
--- a/.github/workflows/release_tools.yaml
+++ b/.github/workflows/release_tools.yaml
@@ -34,10 +34,9 @@ jobs:
 
         env:
             DEBIAN_FRONTEND: noninteractive
-            JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
 
         container:
-            image: connectedhomeip/chip-build-android:0.6.18
+            image: connectedhomeip/chip-build:0.6.18
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
                 - "/tmp/output_binaries:/tmp/output_binaries"
@@ -48,7 +47,7 @@ jobs:
               with:
                   ref: "${{ github.event.inputs.commit }}"
             - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform android linux
+              run: scripts/checkout_submodules.py --shallow --platform linux
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -109,26 +108,6 @@ jobs:
               run: |
                   python3 -m zipfile -c /tmp/output_binaries/chip-tool-linux_x64.zip out/chiptool_x64_debug/chip-tool-debug out/chiptool_x64_release/chip-tool-release
                   python3 -m zipfile -c /tmp/output_binaries/chip-tool-linux_aarch64.zip out/chiptool_arm64_debug/chip-tool-debug out/chiptool_arm64_release/chip-tool-release
-            - name: Build arm Android CHIPTool
-              timeout-minutes: 30
-              env:
-                TARGET_CPU: arm
-              run: |
-                  scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target android-arm-chip-tool build"
-                  cp out/android-arm-chip-tool/outputs/apk/debug/app-debug.apk /tmp/output_binaries/chip-tool-android_armv7l.apk
-            - name: Build arm64 Android CHIPTool
-              timeout-minutes: 30
-              env:
-                TARGET_CPU: arm64
-              run: |
-                  git clean -fdx src/android/CHIPTool
-                  scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target android-arm64-chip-tool build"
-                  cp out/android-arm64-chip-tool/outputs/apk/debug/app-debug.apk /tmp/output_binaries/chip-tool-android_aarch64.apk
-            - name: Upload artifacts
-              uses: actions/upload-artifact@v2
-              with:
-                  name: chip
-                  path: /tmp/output_binaries/*
             - name: Upload release packages
               uses: softprops/action-gh-release@v1
               if: github.event.inputs.publishRelease == 'true'


### PR DESCRIPTION
Android Chip Tool is no longer maintained so it must be removed from the release workflow.


