### PR TITLE
[nrf noup] Fixed several Wi-Fi issues

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -227,7 +227,7 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
     default 2048
 
 config NET_MGMT_EVENT_STACK_SIZE
-    default 1024
+    default 4096
 
 # align these numbers to match the OpenThread config
 config NET_IF_UNICAST_IPV6_ADDR_COUNT
@@ -238,6 +238,9 @@ config NET_IF_MCAST_IPV6_ADDR_COUNT
 
 config NET_SOCKETS_POSIX_NAMES
     default n
+
+config NET_SOCKETS_POLL_MAX
+    default 4
 
 config MBEDTLS_SSL_OUT_CONTENT_LEN
     default 900

--- a/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
@@ -63,10 +63,6 @@ config BT_HCI_RAW_RESERVE
 config BT_BUF_CMD_TX_COUNT
     default 10
 
-# Enable support for Wi-Fi and Bluetooth LE coexistance
-config MPSL_CX
-    default y
-
 config ASSERT
     default y
 

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -453,6 +453,12 @@ void WiFiManager::ConnectHandler(Platform::UniquePtr<uint8_t> data)
                 Instance().mHandling.mOnConnectionSuccess();
             }
             Instance().PostConnectivityStatusChange(kConnectivity_Established);
+
+            // Workaround needed to re-initialize mDNS server after Wi-Fi interface is operative 
+            chip::DeviceLayer::ChipDeviceEvent event;
+            event.Type = chip::DeviceLayer::DeviceEventType::kDnssdPlatformInitialized;
+
+            CHIP_ERROR error = chip::DeviceLayer::PlatformMgr().PostEvent(&event);
         }
         // Ensure fresh recovery for future connection requests.
         Instance().ResetRecoveryTime();


### PR DESCRIPTION
* Disabled Wi-Fi/BLE coex as it was not stable and caused issues in CI tests
* Increased sockets poll and net mgmt stack to fix crash on the application boot due to no space to alloc all sockets
* Added generating kDnssdInitialized event after getting Wi-Fi
connected event to re-start mDNS server

