### PR TITLE
[nrf noup] Remove dependency to openssl from CHIP tool build for linux

### DIFF
--- a/.github/workflows/release_tools.yaml
+++ b/.github/workflows/release_tools.yaml
@@ -63,13 +63,13 @@ jobs:
             - name: Build x64 CHIP Tool with debug logs enabled
               timeout-minutes: 10
               run: |
-                  scripts/run_in_build_env.sh "gn gen out/chiptool_x64_debug --args='chip_mdns=\"platform\" symbol_level=0'"
+                  scripts/run_in_build_env.sh "gn gen out/chiptool_x64_debug --args='chip_mdns=\"platform\" chip_crypto=\"mbedtls\" symbol_level=0'"
                   scripts/run_in_build_env.sh "ninja -C out/chiptool_x64_debug chip-tool"
                   mv out/chiptool_x64_debug/chip-tool out/chiptool_x64_debug/chip-tool-debug
             - name: Build x64 CHIP Tool with debug logs disabled
               timeout-minutes: 10
               run: |
-                  scripts/run_in_build_env.sh "gn gen out/chiptool_x64_release --args='chip_mdns=\"platform\" chip_detail_logging=false symbol_level=0'"
+                  scripts/run_in_build_env.sh "gn gen out/chiptool_x64_release --args='chip_mdns=\"platform\" chip_detail_logging=false chip_crypto=\"mbedtls\" symbol_level=0'"
                   scripts/run_in_build_env.sh "ninja -C out/chiptool_x64_release chip-tool"
                   mv out/chiptool_x64_release/chip-tool out/chiptool_x64_release/chip-tool-release
             - name: Build arm64 CHIP Tool with debug logs enabled
@@ -81,7 +81,8 @@ jobs:
                       target_cxx=\"aarch64-linux-gnu-g++\"
                       target_ar=\"aarch64-linux-gnu-ar\"
                       target_cpu=\"arm64\"
-                      symbol_level=0'"
+                      symbol_level=0
+                      chip_crypto=\"mbedtls\"'"
                   scripts/run_in_build_env.sh "ninja -C out/chiptool_arm64_debug chip-tool"
                   mv out/chiptool_arm64_debug/chip-tool out/chiptool_arm64_debug/chip-tool-debug
             - name: Build arm64 CHIP Tool with debug logs disabled
@@ -94,13 +95,14 @@ jobs:
                       target_cxx=\"aarch64-linux-gnu-g++\"
                       target_ar=\"aarch64-linux-gnu-ar\"
                       target_cpu=\"arm64\"
-                      symbol_level=0'"
+                      symbol_level=0
+                      chip_crypto=\"mbedtls\"'"
                   scripts/run_in_build_env.sh "ninja -C out/chiptool_arm64_release chip-tool"
                   mv out/chiptool_arm64_release/chip-tool out/chiptool_arm64_release/chip-tool-release
             - name: Build x64 OTA Provider
               timeout-minutes: 10
               run: |
-                  scripts/run_in_build_env.sh "gn gen out/chipotaprovider_x64 --args='symbol_level=0' --root=examples/ota-provider-app/linux"
+                  scripts/run_in_build_env.sh "gn gen out/chipotaprovider_x64 --args='symbol_level=0 chip_crypto=\"mbedtls\"' --root=examples/ota-provider-app/linux"
                   scripts/run_in_build_env.sh "ninja -C out/chipotaprovider_x64 chip-ota-provider-app"
                   mv out/chipotaprovider_x64/chip-ota-provider-app /tmp/output_binaries/chip-ota-provider-app-linux_x64
             - name: Create zip files for CHIP Tool debug and release packages


### PR DESCRIPTION
Currently, the chip-tool that is released as a part of sdk-connectedhomeip has dependency to openssl.
The issue is that Ubuntu 20.04 and Ubuntu 22.04 use different versions of OpenSSL and the version built under 20.04 does not work under 22.04 (without some hacks to install the old openssl version) and vice verse.

- Removed the dependency to the dynamic library (OpenSSL) to build Chip-Tool with the mbedTLS.


