### PR TITLE
[nrf noup] Fix the unused variable error

### DIFF
--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -454,11 +454,15 @@ void WiFiManager::ConnectHandler(Platform::UniquePtr<uint8_t> data)
             }
             Instance().PostConnectivityStatusChange(kConnectivity_Established);
 
-            // Workaround needed to re-initialize mDNS server after Wi-Fi interface is operative 
+            // Workaround needed to re-initialize mDNS server after Wi-Fi interface is operative
             chip::DeviceLayer::ChipDeviceEvent event;
             event.Type = chip::DeviceLayer::DeviceEventType::kDnssdPlatformInitialized;
 
             CHIP_ERROR error = chip::DeviceLayer::PlatformMgr().PostEvent(&event);
+            if (error != CHIP_NO_ERROR)
+            {
+                ChipLogError(DeviceLayer, "Cannot post event [error: %s]", ErrorStr(error));
+            }
         }
         // Ensure fresh recovery for future connection requests.
         Instance().ResetRecoveryTime();


### PR DESCRIPTION
This is warning propagated to an error in the CI.

