### PR TITLE
[nrf noup] Support disabling Wi-Fi LPM during the OTA DFU

### DIFF
--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -94,6 +94,7 @@ static_library("nrfconnect") {
       "wifi/NrfWiFiDriver.h",
       "wifi/WiFiManager.cpp",
       "wifi/WiFiManager.h",
+      "OTAImageProcessorImplWiFi.h",
     ]
   }
 

--- a/src/platform/nrfconnect/OTAImageProcessorImplWiFi.h
+++ b/src/platform/nrfconnect/OTAImageProcessorImplWiFi.h
@@ -1,0 +1,63 @@
+/*
+ *    Copyright (c) 2023 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "OTAImageProcessorImpl.h"
+#include "wifi/WiFiManager.h"
+
+namespace chip {
+
+namespace DeviceLayer {
+
+class OTAImageProcessorImplWiFi : public OTAImageProcessorImpl
+{
+public:
+    explicit OTAImageProcessorImplWiFi(ExternalFlashManager * flashHandler = nullptr) : OTAImageProcessorImpl(flashHandler) {}
+
+    CHIP_ERROR PrepareDownload() override
+    {
+        CHIP_ERROR err = WiFiManager::Instance().SetLowPowerMode(false);
+        if (err == CHIP_NO_ERROR)
+        {
+            return OTAImageProcessorImpl::PrepareDownload();
+        }
+        return err;
+    };
+
+    CHIP_ERROR Abort() override
+    {
+        CHIP_ERROR err = OTAImageProcessorImpl::Abort();
+        if (err == CHIP_NO_ERROR)
+        {
+            return WiFiManager::Instance().SetLowPowerMode(true);
+        }
+        return err;
+    };
+
+    CHIP_ERROR Apply() override
+    {
+        CHIP_ERROR err = OTAImageProcessorImpl::Apply();
+        if (err == CHIP_NO_ERROR)
+        {
+            return WiFiManager::Instance().SetLowPowerMode(true);
+        }
+        return err;
+    };
+};
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -564,5 +564,34 @@ void WiFiManager::AbortConnectionRecovery()
     Instance().mRecoveryTimerAborted = true;
 }
 
+CHIP_ERROR WiFiManager::SetLowPowerMode(bool onoff)
+{
+    net_if * iface = InetUtils::GetInterface();
+    VerifyOrReturnError(nullptr != iface, CHIP_ERROR_INTERNAL);
+
+    wifi_ps_config currentConfig{};
+    if (net_mgmt(NET_REQUEST_WIFI_PS_CONFIG, iface, &currentConfig, sizeof(currentConfig)))
+    {
+        ChipLogError(DeviceLayer, "Get current low power mode config request failed");
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    if ((currentConfig.enabled == WIFI_PS_ENABLED && onoff == false) ||
+        (currentConfig.enabled == WIFI_PS_DISABLED && onoff == true))
+    {
+        wifi_ps_params params{ .enabled = onoff ? WIFI_PS_ENABLED : WIFI_PS_DISABLED };
+        if (net_mgmt(NET_REQUEST_WIFI_PS, iface, &params, sizeof(params)))
+        {
+            ChipLogError(DeviceLayer, "Set low power mode request failed");
+            return CHIP_ERROR_INTERNAL;
+        }
+        ChipLogProgress(DeviceLayer, "Successfully set low power mode [%d]", onoff);
+        return CHIP_NO_ERROR;
+    }
+
+    ChipLogDetail(DeviceLayer, "Low power mode is already in requested state [%d]", onoff);
+    return CHIP_NO_ERROR;
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -192,6 +192,7 @@ public:
     CHIP_ERROR GetWiFiInfo(WiFiInfo & info) const;
     CHIP_ERROR GetNetworkStatistics(NetworkStatistics & stats) const;
     void AbortConnectionRecovery();
+    CHIP_ERROR SetLowPowerMode(bool onoff);
 
 private:
     using NetEventHandler = void (*)(Platform::UniquePtr<uint8_t>);


### PR DESCRIPTION
Added subclass of OTAImageProcessorImpl whcih implements Wi-Fi specific optimization for LPM which should be disabled during OTA due to the high throughput requirements. This allows applications to use the OTAImageProcessorImplWiFi to do the job.

