### PR TITLE
[nrf noup] Provide configs for Matter NUS feature

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -73,6 +73,58 @@ config SPI_NOR_FLASH_LAYOUT_PAGE_SIZE
 
 endif # CHIP_SPI_NOR
 
+config CHIP_NUS
+	bool "Enable Nordic UART service for Matter purposes"
+	select BT_NUS
+	select BT_SMP
+	select BT_NUS_AUTHEN
+	select BT_SETTINGS
+	help
+	  Enables Nordic UART service (NUS) for Matter samples.
+	  Using NUS service you can control a Matter sample using pre-defined BLE commands 
+	  and do defined operations. The CHIP NUS service can be useful to keep communication
+	  with a smart home device when a connection within Matter network is lost.
+
+if CHIP_NUS
+
+config BT_RX_STACK_SIZE
+	default 1536
+
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	default 2048
+
+config BT_MAX_CONN
+	default 2
+
+config BT_MAX_PAIRED
+	default 2
+
+config BT_DEVICE_APPEARANCE
+	default 833
+
+config CHIP_NUS_MAX_COMMAND_LEN
+	int "Maximum length of single command in Bytes"
+	default 10
+	help
+	  Maximum length of single command. This command will be send via Bluetooth LE to
+	  a paired smart home device.
+
+config CHIP_NUS_FIXED_PASSKEY
+	int "Define the default passkey for NUS"
+	depends on BT_FIXED_PASSKEY
+	default 123456
+	help
+	  Define the default password for pairing with the Bluetooth LE device.
+
+config CHIP_NUS_MAX_COMMANDS
+	int "Define maximum NUS commands amount"
+	default 2
+	help
+	  Define the maximum number of NUS commands to declare by user.
+
+endif
+
+
 config CHIP_DFU_OVER_BT_SMP
 	bool "Enable DFU over Bluetooth LE SMP feature set"
 	imply CHIP_QSPI_NOR if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840

--- a/src/platform/Zephyr/BLEAdvertisingArbiter.cpp
+++ b/src/platform/Zephyr/BLEAdvertisingArbiter.cpp
@@ -38,6 +38,8 @@ const BLEAdvertisingArbiter::Request & ToRequest(const sys_snode_t * node)
 // Notify application about stopped advertising if the callback has been provided
 void NotifyAdvertisingStopped(const sys_snode_t * node)
 {
+    VerifyOrReturn(node);
+    
     const Request & request = ToRequest(node);
 
     if (request.onStopped != nullptr)


### PR DESCRIPTION
Matter NUS feature allows to add of BLE Nordic UART Service and register commands which allow controlling the Matter device via BLE.

This can be useful when the device loses connection with a Matter Controller but it should be controlled in another way for e.g. a Door Lock.

