### PR TITLE
[nrf noup] FactoryDataProvider: align the fprotect memory block

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -95,7 +95,7 @@ config CHIP_MALLOC_SYS_HEAP
 config CHIP_FACTORY_DATA
 	bool "Enable Factory Data support"
 	select ZCBOR
-	select FPROTECT
+	imply FPROTECT
 	help
 	  Enables support for reading factory data from flash memory partition.
 	  It requires factory_data partition to exist in the partition manager 
@@ -127,6 +127,20 @@ config CHIP_FACTORY_DATA_VERSION
 	  After moving to the next version of the factory data set, change the default value. 
 	  This config is used to validate the version of a factory data set on a device-side 
 	  with the version of factory data saved in the Flash memory.
+
+config CHIP_FACTORY_DATA_WRITE_PROTECT
+	bool "Enable Factory Data write protection"
+	select FPROTECT
+	depends on CHIP_FACTORY_DATA
+	default y if CHIP_FACTORY_DATA
+	help
+		Enables the write protection of the Factory Data partition in the flash memory.
+		This is a recommended feature, but it requires the Settings partition size to be
+		a multiple of FPROTECT_BLOCK_SIZE and the Factory Data partition to be placed
+		right after the application partition in the address space (the Factory Data
+		partition offset must be equal to the last address of the application partition).
+		The second requirement is valid only when the FPROTECT_BLOCK_SIZE is bigger than
+		the flash memory page size.
 
 if CHIP_FACTORY_DATA_BUILD
 

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -21,10 +21,10 @@
 #include <platform/CommissionableDataProvider.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 
-#include <zephyr/drivers/flash.h>
 #include <fprotect.h>
 #include <pm_config.h>
 #include <system/SystemError.h>
+#include <zephyr/drivers/flash.h>
 
 #include "FactoryDataParser.h"
 
@@ -40,11 +40,43 @@ struct InternalFlashFactoryData
         return CHIP_NO_ERROR;
     }
 
+#ifdef CONFIG_CHIP_FACTORY_DATA_WRITE_PROTECT
+#define TO_STR_IMPL(x) #x
+#define TO_STR(x) TO_STR_IMPL(x)
+    // These two helpers allows to get the factory data memory block which shall be protected with fprotect, so that:
+    // 1) it is aligned to the multiple of CONFIG_FPROTECT_BLOCK_SIZE (which differs between nRF families)
+    // 2) it does not exceed the settings partition start address
+    // Note that this block can overlap with app partition but this is not a problem since we do not aim to modify
+    // the application code at runtime anyway.
+    constexpr size_t FactoryDataBlockBegin()
+    {
+        // calculate the nearest multiple of CONFIG_FPROTECT_BLOCK_SIZE smaller than PM_FACTORY_DATA_ADDRESS
+        return PM_FACTORY_DATA_ADDRESS & (-CONFIG_FPROTECT_BLOCK_SIZE);
+    }
+
+    constexpr size_t FactoryDataBlockSize()
+    {
+        // calculate the factory data end address rounded up to the nearest multiple of CONFIG_FPROTECT_BLOCK_SIZE
+        // and make sure we do not overlap with settings partition
+        constexpr size_t kFactoryDataBlockEnd =
+            (PM_FACTORY_DATA_ADDRESS + PM_FACTORY_DATA_SIZE + CONFIG_FPROTECT_BLOCK_SIZE - 1) & (-CONFIG_FPROTECT_BLOCK_SIZE);
+        static_assert(kFactoryDataBlockEnd <= PM_SETTINGS_STORAGE_ADDRESS,
+                      "FPROTECT memory block, which contains factory data"
+                      "partition overlaps with the settings partition."
+                      "Probably your settings partition size is not a multiple"
+                      "of the atomic FPROTECT block size of " TO_STR(CONFIG_FPROTECT_BLOCK_SIZE) "kB");
+        return kFactoryDataBlockEnd - FactoryDataBlockBegin();
+    }
+#undef TO_STR
+#undef TO_STR_IMPL
     CHIP_ERROR ProtectFactoryDataPartitionAgainstWrite()
     {
-        int ret = fprotect_area(PM_FACTORY_DATA_ADDRESS, PM_FACTORY_DATA_SIZE);
+        int ret = fprotect_area(FactoryDataBlockBegin(), FactoryDataBlockSize());
         return System::MapErrorZephyr(ret);
     }
+#else
+    CHIP_ERROR ProtectFactoryDataPartitionAgainstWrite() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+#endif
 };
 
 struct ExternalFlashFactoryData


### PR DESCRIPTION
Due to the smallest atomic SPU block (16k for nRF53) which can be protected we need to calculate proper offsets to include factory data partition.

