### PR TITLE
[nrf noup] [nrfconnect] migrate to new MCUmgr Kconfig options

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -131,12 +131,12 @@ config CHIP_DFU_OVER_BT_SMP
 	imply CHIP_SPI_NOR if BOARD_NRF7002DK_NRF5340_CPUAPP
 	imply BOOTLOADER_MCUBOOT
 	select MCUMGR
-	select MCUMGR_SMP_BT
-	select MCUMGR_CMD_IMG_MGMT
-	select MCUMGR_CMD_OS_MGMT
+	select MCUMGR_TRANSPORT_BT
+	select MCUMGR_GRP_IMG
+	select MCUMGR_GRP_OS
 	# Enable custom SMP request to erase settings partition.
-	select MCUMGR_GRP_ZEPHYR_BASIC
-	select MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
+	select MCUMGR_GRP_ZBASIC
+	select MCUMGR_GRP_ZBASIC_STORAGE_ERASE
 	help
 	  Enables Device Firmware Upgrade over Bluetooth LE with SMP and configures
 	  the set of options related to that feature.
@@ -144,10 +144,10 @@ config CHIP_DFU_OVER_BT_SMP
 if CHIP_DFU_OVER_BT_SMP
 
 # MCU Manager and SMP configuration
-config MCUMGR_SMP_BT_AUTHEN
+config MCUMGR_TRANSPORT_BT_AUTHEN
 	default n
 
-config MCUMGR_BUF_COUNT
+config MCUMGR_TRANSPORT_NETBUF_COUNT
 	default 6
 
 config MCUMGR_MGMT_NOTIFICATION_HOOKS
@@ -169,8 +169,8 @@ config BT_L2CAP_TX_MTU
 config BT_BUF_ACL_RX_SIZE
 	default 502
 
-# Increase MCUMGR_BUF_SIZE, as it must be big enough to fit MAX MTU + overhead and for single-image DFU default is 384 B
-config MCUMGR_BUF_SIZE
+# Increase MCUMGR_TRANSPORT_NETBUF_SIZE, as it must be big enough to fit MAX MTU + overhead and for single-image DFU default is 384 B
+config MCUMGR_TRANSPORT_NETBUF_SIZE
 	default 1024
 
 # Increase system workqueue size, as SMP is processed within it
@@ -180,10 +180,10 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 if SOC_SERIES_NRF53X
 
 # Enable custom SMP request to erase settings partition.
-config MCUMGR_GRP_ZEPHYR_BASIC
+config MCUMGR_GRP_ZBASIC
 	default y
 
-config MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
+config MCUMGR_GRP_ZBASIC_STORAGE_ERASE
 	default y
 
 endif # SOC_SERIES_NRF53X

--- a/config/zephyr/chip-module/Kconfig.features
+++ b/config/zephyr/chip-module/Kconfig.features
@@ -24,23 +24,23 @@ config MCUMGR
 	bool
 	default y
 
-config MCUMGR_CMD_IMG_MGMT
+config MCUMGR_GRP_IMG
 	bool
 	default y
 
-config MCUMGR_CMD_OS_MGMT
+config MCUMGR_GRP_OS
 	bool
 	default y
 
-config MCUMGR_SMP_BT
+config MCUMGR_TRANSPORT_BT
 	bool
 	default y
 
-config MCUMGR_SMP_BT_AUTHEN
+config MCUMGR_TRANSPORT_BT_AUTHEN
 	bool
 	default n
 
-config MCUMGR_BUF_COUNT
+config MCUMGR_TRANSPORT_NETBUF_COUNT
 	int
 	default 6
 
@@ -53,8 +53,8 @@ config BT_BUF_ACL_RX_SIZE
 	int
 	default 502
 
-# Increase MCUMGR_BUF_SIZE, as it must be big enough to fit MAX MTU + overhead and for single-image DFU default is 384 B
-config MCUMGR_BUF_SIZE
+# Increase MCUMGR_TRANSPORT_NETBUF_SIZE, as it must be big enough to fit MAX MTU + overhead and for single-image DFU default is 384 B
+config MCUMGR_TRANSPORT_NETBUF_SIZE
 	int
 	default 1024
 

--- a/examples/all-clusters-app/nrfconnect/CMakeLists.txt
+++ b/examples/all-clusters-app/nrfconnect/CMakeLists.txt
@@ -67,7 +67,7 @@ chip_configure_data_model(app
     ZAP_FILE ${ALL_CLUSTERS_COMMON_DIR}/all-clusters-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 

--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -357,7 +357,7 @@ void AppTask::FunctionHandler(const AppEvent & event)
             Instance().CancelTimer();
             Instance().mFunction = FunctionEvent::NoneSelected;
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
             GetDFUOverSMP().StartServer();
 #else
             LOG_INF("Software update is disabled");

--- a/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
@@ -26,7 +26,7 @@
 #include <platform/nrfconnect/FactoryDataProvider.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
 #include "DFUOverSMP.h"
 #endif
 

--- a/examples/all-clusters-minimal-app/nrfconnect/CMakeLists.txt
+++ b/examples/all-clusters-minimal-app/nrfconnect/CMakeLists.txt
@@ -65,7 +65,7 @@ chip_configure_data_model(app
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../all-clusters-common/all-clusters-minimal-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 

--- a/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/AppTask.cpp
@@ -278,7 +278,7 @@ void AppTask::FunctionHandler(const AppEvent & event)
         {
             Instance().CancelTimer();
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
             GetDFUOverSMP().StartServer();
 #else
             LOG_INF("Software update is disabled");

--- a/examples/all-clusters-minimal-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/include/AppTask.h
@@ -26,7 +26,7 @@
 #include <platform/nrfconnect/FactoryDataProvider.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
 #include "DFUOverSMP.h"
 #endif
 

--- a/examples/light-switch-app/nrfconnect/CMakeLists.txt
+++ b/examples/light-switch-app/nrfconnect/CMakeLists.txt
@@ -62,11 +62,11 @@ target_sources(app PRIVATE
                ${NRFCONNECT_COMMON}/util/LEDWidget.cpp)
 
 
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 
-if(CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/DFUOverSMP.cpp)
 endif()
 

--- a/examples/light-switch-app/nrfconnect/main/AppTask.cpp
+++ b/examples/light-switch-app/nrfconnect/main/AppTask.cpp
@@ -184,7 +184,7 @@ CHIP_ERROR AppTask::Init()
     k_timer_user_data_set(&sFunctionTimer, this);
 
     // Initialize DFU
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
     GetDFUOverSMP().Init();
     GetDFUOverSMP().ConfirmNewImage();
 #endif
@@ -291,7 +291,7 @@ void AppTask::ButtonReleaseHandler(const AppEvent & event)
                 Instance().CancelTimer(Timer::Function);
                 Instance().mFunction = FunctionEvent::NoneSelected;
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
                 GetDFUOverSMP().StartServer();
                 UpdateStatusLED();
 #else

--- a/examples/light-switch-app/nrfconnect/main/include/AppTask.h
+++ b/examples/light-switch-app/nrfconnect/main/include/AppTask.h
@@ -27,7 +27,7 @@
 #include <platform/nrfconnect/FactoryDataProvider.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
 #include "DFUOverSMP.h"
 #endif
 

--- a/examples/lighting-app/nrfconnect/CMakeLists.txt
+++ b/examples/lighting-app/nrfconnect/CMakeLists.txt
@@ -67,11 +67,11 @@ chip_configure_data_model(app
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lighting-common/lighting-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 
-if(CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/DFUOverSMP.cpp)
 endif()
 

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -197,7 +197,7 @@ CHIP_ERROR AppTask::Init()
     k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
     k_timer_user_data_set(&sFunctionTimer, this);
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
     // Initialize DFU over SMP
     GetDFUOverSMP().Init();
     GetDFUOverSMP().ConfirmNewImage();
@@ -473,7 +473,7 @@ void AppTask::FunctionHandler(const AppEvent & event)
             Instance().CancelTimer();
             Instance().mFunction = FunctionEvent::NoneSelected;
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
             GetDFUOverSMP().StartServer();
 #else
             LOG_INF("Software update is disabled");

--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -32,7 +32,7 @@
 #include "Rpc.h"
 #endif
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
 #include "DFUOverSMP.h"
 #endif
 

--- a/examples/lock-app/nrfconnect/CMakeLists.txt
+++ b/examples/lock-app/nrfconnect/CMakeLists.txt
@@ -64,10 +64,10 @@ chip_configure_data_model(app
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../lock-common/lock-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 
-if(CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/DFUOverSMP.cpp)
 endif()

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -175,7 +175,7 @@ CHIP_ERROR AppTask::Init()
     k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
     k_timer_user_data_set(&sFunctionTimer, this);
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
     // Initialize DFU over SMP
     GetDFUOverSMP().Init();
     GetDFUOverSMP().ConfirmNewImage();
@@ -424,7 +424,7 @@ void AppTask::FunctionHandler(const AppEvent & event)
             Instance().CancelTimer();
             Instance().mFunction = FunctionEvent::NoneSelected;
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
             GetDFUOverSMP().StartServer();
 #else
             LOG_INF("Software update is disabled");

--- a/examples/lock-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lock-app/nrfconnect/main/include/AppTask.h
@@ -29,7 +29,7 @@
 #include <platform/nrfconnect/FactoryDataProvider.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
 #include "DFUOverSMP.h"
 #endif
 

--- a/examples/platform/nrfconnect/util/DFUOverSMP.cpp
+++ b/examples/platform/nrfconnect/util/DFUOverSMP.cpp
@@ -17,7 +17,7 @@
 
 #include "DFUOverSMP.h"
 
-#if !defined(CONFIG_MCUMGR_SMP_BT) || !defined(CONFIG_MCUMGR_CMD_IMG_MGMT) || !defined(CONFIG_MCUMGR_CMD_OS_MGMT)
+#if !defined(CONFIG_MCUMGR_SMP_BT) || !defined(CONFIG_MCUMGR_GRP_IMG) || !defined(CONFIG_MCUMGR_CMD_OS_MGMT)
 #error "DFUOverSMP requires MCUMGR module configs enabled"
 #endif
 

--- a/examples/pump-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-app/nrfconnect/CMakeLists.txt
@@ -63,10 +63,10 @@ chip_configure_data_model(app
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../pump-common/pump-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 
-if(CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/DFUOverSMP.cpp)
 endif()

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -154,7 +154,7 @@ CHIP_ERROR AppTask::Init()
     k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
     k_timer_user_data_set(&sFunctionTimer, this);
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
     // Initialize DFU over SMP
     GetDFUOverSMP().Init();
     GetDFUOverSMP().ConfirmNewImage();
@@ -341,7 +341,7 @@ void AppTask::FunctionHandler(const AppEvent & event)
         {
             Instance().CancelTimer();
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
             GetDFUOverSMP().StartServer();
 #else
             LOG_INF("Software update is disabled");

--- a/examples/pump-app/nrfconnect/main/include/AppTask.h
+++ b/examples/pump-app/nrfconnect/main/include/AppTask.h
@@ -29,7 +29,7 @@
 #include <platform/nrfconnect/FactoryDataProvider.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
 #include "DFUOverSMP.h"
 #endif
 

--- a/examples/pump-controller-app/nrfconnect/CMakeLists.txt
+++ b/examples/pump-controller-app/nrfconnect/CMakeLists.txt
@@ -63,10 +63,10 @@ chip_configure_data_model(app
     ZAP_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../pump-controller-common/pump-controller-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 
-if(CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/DFUOverSMP.cpp)
 endif()

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -152,7 +152,7 @@ CHIP_ERROR AppTask::Init()
     k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
     k_timer_user_data_set(&sFunctionTimer, this);
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
     // Initialize DFU over SMP
     GetDFUOverSMP().Init();
     GetDFUOverSMP().ConfirmNewImage();
@@ -338,7 +338,7 @@ void AppTask::FunctionHandler(const AppEvent & event)
         {
             Instance().CancelTimer();
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
             GetDFUOverSMP().StartServer();
 #else
             LOG_INF("Software update is disabled");

--- a/examples/pump-controller-app/nrfconnect/main/include/AppTask.h
+++ b/examples/pump-controller-app/nrfconnect/main/include/AppTask.h
@@ -29,7 +29,7 @@
 #include <platform/nrfconnect/FactoryDataProvider.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
 #include "DFUOverSMP.h"
 #endif
 

--- a/examples/window-app/nrfconnect/CMakeLists.txt
+++ b/examples/window-app/nrfconnect/CMakeLists.txt
@@ -66,10 +66,10 @@ chip_configure_data_model(app
     ZAP_FILE ${WIN_APP_COMMON_DIR}/window-app.zap
 )
 
-if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_CHIP_OTA_REQUESTOR OR CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/OTAUtil.cpp)
 endif()
 
-if(CONFIG_MCUMGR_SMP_BT)
+if(CONFIG_MCUMGR_TRANSPORT_BT)
     target_sources(app PRIVATE ${NRFCONNECT_COMMON}/util/DFUOverSMP.cpp)
 endif()

--- a/examples/window-app/nrfconnect/main/AppTask.cpp
+++ b/examples/window-app/nrfconnect/main/AppTask.cpp
@@ -154,7 +154,7 @@ CHIP_ERROR AppTask::Init()
     k_timer_init(&sFunctionTimer, &AppTask::FunctionTimerTimeoutCallback, nullptr);
     k_timer_user_data_set(&sFunctionTimer, this);
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
     // Initialize DFU over SMP
     GetDFUOverSMP().Init();
     GetDFUOverSMP().ConfirmNewImage();
@@ -357,7 +357,7 @@ void AppTask::FunctionHandler(const AppEvent & event)
         {
             Instance().CancelTimer();
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
             GetDFUOverSMP().StartServer();
 #else
             LOG_INF("Software update is disabled");

--- a/examples/window-app/nrfconnect/main/include/AppTask.h
+++ b/examples/window-app/nrfconnect/main/include/AppTask.h
@@ -26,7 +26,7 @@
 #include <platform/nrfconnect/FactoryDataProvider.h>
 #endif
 
-#ifdef CONFIG_MCUMGR_SMP_BT
+#ifdef CONFIG_MCUMGR_TRANSPORT_BT
 #include "DFUOverSMP.h"
 #endif
 


### PR DESCRIPTION
Migrate to new MCUmgr Kconfig options using:
$ZEPHYR_BASE/scripts/utils/migrate_mcumgr_kconfigs.py
