### PR TITLE
[nrf fromlist] [nrfconnect] Import spake2p.py as a module

### DIFF
--- a/config/nrfconnect/chip-module/generate_factory_data.cmake
+++ b/config/nrfconnect/chip-module/generate_factory_data.cmake
@@ -88,12 +88,7 @@ string(APPEND script_args "--include_passcode\n")
 string(APPEND script_args "--overwrite\n")
 
 # check if spake2 verifier should be generated using script
-if(CONFIG_CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER)
-    # request script to generate a new spake2_verifier
-    # by adding an argument to script_args
-    find_program(spake_exe NAMES spake2p REQUIRED)
-    string(APPEND script_args "--spake2p_path ${spake_exe}\n")   
-else()
+if(NOT CONFIG_CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER)
     # Spake2 verifier should be provided using kConfig
     string(APPEND script_args "--spake2_verifier \"${CONFIG_CHIP_DEVICE_SPAKE2_TEST_VERIFIER}\"\n")
 endif()

--- a/scripts/setup/requirements.nrfconnect.txt
+++ b/scripts/setup/requirements.nrfconnect.txt
@@ -1,3 +1,4 @@
 jsonschema>=4.4.0
 cbor2>=5.4.3
 wget>=3.2
+ecdsa>=0.18.0

--- a/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
+++ b/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
@@ -46,6 +46,9 @@ PUB_KEY_PREFIX = b'\x04'
 INVALID_PASSCODES = [00000000, 11111111, 22222222, 33333333, 44444444,
                      55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321]
 
+sys.path.insert(0, os.path.join(MATTER_ROOT, 'scripts', 'tools', 'spake2p'))
+from spake2p import generate_verifier  # noqa: E402 isort:skip
+
 
 def get_raw_private_key_der(der_file: str, password: str):
     """ Split given der file to get separated key pair consisting of public and private keys.
@@ -176,27 +179,6 @@ def gen_test_certs(chip_cert_exe: str,
     return attestation_certs(new_certificates["DAC_CERT"] + ".der",
                              new_certificates["DAC_KEY"] + ".der",
                              new_certificates["PAI_CERT"] + ".der")
-
-
-def gen_spake2p_verifier(passcode: int, it: int, salt: bytes) -> str:
-    """ Generate Spake2+ verifier using SPAKE2+ Python Tool
-
-    Args:
-        passcode (int): Pairing passcode using in Spake2+
-        it (int): Iteration counter for Spake2+ verifier generation
-        salt (str): Salt used to generate Spake2+ verifier
-
-    Returns:
-        verifier encoded in Base64
-    """
-
-    cmd = [
-        os.path.join(MATTER_ROOT, 'scripts/tools/spake2p/spake2p.py'), 'gen-verifier',
-        '--passcode', str(passcode),
-        '--salt', base64.b64encode(salt).decode('ascii'),
-        '--iteration-count', str(it),
-    ]
-    return subprocess.check_output(cmd)
 
 
 class FactoryDataGenerator:
@@ -351,7 +333,7 @@ class FactoryDataGenerator:
 
     def _generate_spake2_verifier(self):
         """ If verifier has not been provided in arguments list it should be generated via external script """
-        return base64.b64decode(gen_spake2p_verifier(self._args.passcode, self._args.spake2_it, self._args.spake2_salt))
+        return generate_verifier(self._args.passcode, self._args.spake2_salt, self._args.spake2_it)
 
     def _generate_rotating_device_uid(self):
         """ If rotating device unique ID has not been provided it should be generated """


### PR DESCRIPTION
In the factory data generation script, import spake2p.py as a module instead of starting a new process. This fixes running the script on windows. Also, update the requirements.
