### PR TITLE
[nrf noup] Changed WPA SUPP logs level to error

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -37,7 +37,7 @@ config CHIP_APP_LOG_LEVEL
     default 4 # debug
 
 config LOG_DEFAULT_LEVEL
-    default 2 # warning
+    default 1 # error
 
 config CHIP_LOG_SIZE_OPTIMIZATION
     default y
@@ -215,6 +215,10 @@ config IEEE802154_NRF5_RX_STACK_SIZE
 endif
 
 if CHIP_WIFI
+
+choice WPA_SUPP_LOG_LEVEL_CHOICE
+	default WPA_SUPP_LOG_LEVEL_ERR
+endchoice
 
 config NRF_WIFI_LOW_POWER
     default n


### PR DESCRIPTION
* Changed default log level to error
* Changed WPA supplicant log levet to error. This is a workaround and it will be removed once default log levels fix to Zephyr will be merged.