### PR TITLE
[nrf noup] Fixed SYS_INIT callback API

### DIFF
--- a/src/lib/shell/MainLoopZephyr.cpp
+++ b/src/lib/shell/MainLoopZephyr.cpp
@@ -29,7 +29,7 @@ static int cmd_matter(const struct shell * shell, size_t argc, char ** argv)
     return (Engine::Root().ExecCommand(argc - 1, argv + 1) == CHIP_NO_ERROR) ? 0 : -ENOEXEC;
 }
 
-static int RegisterCommands(const struct device * dev)
+static int RegisterCommands()
 {
     Engine::Root().RegisterDefaultCommands();
     return 0;

--- a/src/platform/Zephyr/SysHeapMalloc.cpp
+++ b/src/platform/Zephyr/SysHeapMalloc.cpp
@@ -67,7 +67,7 @@ LockGuard::~LockGuard()
     }
 }
 
-int initHeap(const device *)
+int initHeap()
 {
     sys_heap_init(&sHeap, sHeapMemory, sizeof(sHeapMemory));
     return 0;


### PR DESCRIPTION
The SYS_INIT() callback API changed in Zephyr and Matter code alignments were needed.

