### PR TITLE
[nrf noup] Set BLE connection to 1 for NUS

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -93,12 +93,6 @@ config BT_RX_STACK_SIZE
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	default 2048
 
-config BT_MAX_CONN
-	default 2
-
-config BT_MAX_PAIRED
-	default 2
-
 config BT_DEVICE_APPEARANCE
 	default 833
 


### PR DESCRIPTION
We decided to work with a single BLE connection when NUS is active.


