### PR TITLE
[nrf noup] Fixed dependencies for CHIP_DFU_OVER_BT_SMP kconfig

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -131,6 +131,9 @@ config CHIP_DFU_OVER_BT_SMP
 	imply BOOTLOADER_MCUBOOT
 	select MCUMGR
 	select MCUMGR_TRANSPORT_BT
+	select IMG_MANAGER
+	select STREAM_FLASH
+	select ZCBOR
 	select MCUMGR_GRP_IMG
 	select MCUMGR_GRP_OS
 	# Enable custom SMP request to erase settings partition.


### PR DESCRIPTION
Some Kconfigs selected by the CHIP_DFU_OVER_BT_SMP have unmet dependencies.


