### PR TITLE
[nrf noup] Fixed system workqueue stack overflow for Wi-Fi

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -227,7 +227,7 @@ config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
     default n
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
-    default 2048
+    default 2560
 
 config NET_MGMT_EVENT_STACK_SIZE
     default 4096


### PR DESCRIPTION
After failing to connect to the Wi-Fi network (e.g. due to bad password) the application falls into stack overflow.

Increased the stack size to handle the connection failure properly.


