### PR TITLE
[nrf noup] Disable unnecessary assert information

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -50,6 +50,12 @@ config PRINTK_SYNC
 config ASSERT
     default y
 
+config ASSERT_NO_COND_INFO
+    default y
+
+config ASSERT_NO_MSG_INFO
+    default y
+
 config HW_STACK_PROTECTION
     default y
 


### PR DESCRIPTION
Limit assert information for Matter applications to file name and file number.

Seems to save around 20kB for nRF52840DK and nRF7002DK and 18k for nRF5340DK.