### PR TITLE
[nrf noup] Introduce workaround to Wi-Fi connection recovery

### DIFF
--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -205,6 +205,7 @@ CHIP_ERROR WiFiManager::Scan(const ByteSpan & ssid, ScanResultCallback resultCal
     mCachedWiFiState    = mWiFiState;
     mWiFiState          = WIFI_STATE_SCANNING;
     mSsidFound          = false;
+    mRecoveryArmed    = true;
 
     if (net_mgmt(NET_REQUEST_WIFI_SCAN, iface, NULL, 0))
     {
@@ -266,6 +267,7 @@ CHIP_ERROR WiFiManager::Disconnect()
     }
     else
     {
+        mDisconnectRequested = true;
         ChipLogDetail(DeviceLayer, "Disconnect requested");
     }
 
@@ -390,15 +392,21 @@ void WiFiManager::ScanDoneHandler(Platform::UniquePtr<uint8_t> data)
         // Internal scan is supposed to be followed by a connection request if the SSID has been found
         if (Instance().mInternalScan)
         {
-            if (!Instance().mSsidFound && !Instance().mRecoveryTimerAborted)
+            if (Instance().mRecoveryArmed)
             {
-                ChipLogProgress(DeviceLayer, "No requested SSID found");
-                auto currentTimeout = Instance().CalculateNextRecoveryTime();
-                ChipLogProgress(DeviceLayer, "Starting connection recover: re-scanning... (next attempt in %d ms)",
-                                currentTimeout.count());
-                Instance().mRecoveryTimerAborted = false;
-                DeviceLayer::SystemLayer().StartTimer(currentTimeout, Recover, nullptr);
-                return;
+                if (!Instance().mSsidFound)
+                {
+                    ChipLogProgress(DeviceLayer, "No requested SSID found");
+                    auto currentTimeout = Instance().CalculateNextRecoveryTime();
+                    ChipLogProgress(DeviceLayer, "Starting connection recover: re-scanning... (next attempt in %d ms)",
+                                    currentTimeout.count());
+                    DeviceLayer::SystemLayer().StartTimer(currentTimeout, Recover, nullptr);
+                    return;
+                }
+                else
+                {
+                    Instance().AbortConnectionRecovery();
+                }
             }
 
             Instance().mWiFiState = WIFI_STATE_ASSOCIATING;
@@ -504,12 +512,36 @@ void WiFiManager::ConnectHandler(Platform::UniquePtr<uint8_t> data)
 
 void WiFiManager::DisconnectHandler(Platform::UniquePtr<uint8_t>)
 {
+    if (Instance().mDisconnectRequested)
+    {
+        Instance().mDisconnectRequested = false;
+
+        if (Instance().mRecoveryArmed)
+        {
+            Instance().AbortConnectionRecovery();
+        }
+    }
+    else
+    {
+        // Workaround: schedule the application level connection recovery in kSupplicantReconnectionTimeoutMs to give WPA supplicant
+        // some time to restore it.
+        if (!Instance().mRecoveryArmed)
+        {
+            Instance().mRecoveryArmed = true;
+            DeviceLayer::SystemLayer().StartTimer(
+                System::Clock::Milliseconds32(kSupplicantReconnectionTimeoutMs),
+                [](System::Layer * layer, void * param) {
+                    Instance().Disconnect();
+                    Recover(layer, param);
+                },
+                nullptr);
+        }
+    }
+
     SystemLayer().ScheduleLambda([] {
         ChipLogProgress(DeviceLayer, "WiFi station disconnected");
         Instance().mWiFiState = WIFI_STATE_DISCONNECTED;
         Instance().PostConnectivityStatusChange(kConnectivity_Lost);
-        // Ensure fresh recovery for future connection requests.
-        Instance().ResetRecoveryTime();
     });
 }
 
@@ -545,6 +577,13 @@ System::Clock::Milliseconds32 WiFiManager::CalculateNextRecoveryTime()
 
 void WiFiManager::Recover(System::Layer *, void *)
 {
+    // Prevent scheduling recovery if we are already connected to the network.
+    if (Instance().mWiFiState == WIFI_STATE_COMPLETED)
+    {
+        Instance().AbortConnectionRecovery();
+        return;
+    }
+
     // If kConnectionRecoveryMaxOverallInterval has a non-zero value prevent endless re-scan.
     if (0 != kConnectionRecoveryMaxRetries && (++Instance().mConnectionRecoveryCounter >= kConnectionRecoveryMaxRetries))
     {
@@ -565,7 +604,7 @@ void WiFiManager::AbortConnectionRecovery()
 {
     DeviceLayer::SystemLayer().CancelTimer(Recover, nullptr);
     Instance().ResetRecoveryTime();
-    Instance().mRecoveryTimerAborted = true;
+    Instance().mRecoveryArmed = false;
 }
 
 CHIP_ERROR WiFiManager::SetLowPowerMode(bool onoff)

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -173,6 +173,7 @@ public:
     static constexpr uint32_t kConnectionRecoveryMaxIntervalMs     = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL;
     static constexpr uint32_t kConnectionRecoveryJitterMs          = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_JITTER;
     static constexpr uint32_t kConnectionRecoveryMaxRetries        = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER;
+    static constexpr uint32_t kSupplicantReconnectionTimeoutMs     = 60000;
 
     static_assert(kConnectionRecoveryMinIntervalMs < kConnectionRecoveryMaxIntervalMs);
     static_assert(kConnectionRecoveryJitterMs <= kConnectionRecoveryMaxIntervalMs);
@@ -241,7 +242,8 @@ private:
     bool mSsidFound{ false };
     uint32_t mConnectionRecoveryCounter{ 0 };
     uint32_t mConnectionRecoveryTimeMs{ kConnectionRecoveryMinIntervalMs };
-    bool mRecoveryTimerAborted{ false };
+    bool mRecoveryArmed{ false };
+    bool mDisconnectRequested{ false };
 
     static const Map<wifi_iface_state, StationStatus, 10> sStatusMap;
     static const Map<uint32_t, NetEventHandler, 4> sEventHandlerMap;


### PR DESCRIPTION
It was observed that sometimes WPA supplicant may stuck in the reconnection process. This change introduces a workaround and fixes for existing recovery mechanism:

* Changed is-Recovery-Aborted approach to is-Recovery-started.
* Distinguished disconnects requested by the application from the disconnects coming from the supplicant.
* Added scheduling recovery procedure if supplicant was not able to re-connect to the network for given amount of time (60 s).


