### PR TITLE
Fixed using temporary buffer in GetWiFiInfo

### DIFF
--- a/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.cpp
+++ b/src/platform/nrfconnect/DiagnosticDataProviderImplNrf.cpp
@@ -45,9 +45,13 @@ DiagnosticDataProviderImplNrf & DiagnosticDataProviderImplNrf::GetDefaultInstanc
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBssId(ByteSpan & value)
 {
     WiFiManager::WiFiInfo info;
-    CHIP_ERROR err = WiFiManager::Instance().GetWiFiInfo(info);
-    value          = info.mBssId;
-    return err;
+    ReturnErrorOnFailure(WiFiManager::Instance().GetWiFiInfo(info));
+    ReturnErrorCodeIf(sizeof(info.mBssId) >= value.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    memcpy(value.data(), info.mBssId, sizeof(info.mBssId));
+    value.reduce_size(sizeof(info.mBssId));
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR
@@ -90,7 +94,7 @@ CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiRssi(int8_t & rssi)
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBeaconLostCount(uint32_t & beaconLostCount)
 {
     WiFiManager::NetworkStatistics stats;
-    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    CHIP_ERROR err  = WiFiManager::Instance().GetNetworkStatistics(stats);
     beaconLostCount = stats.mBeaconsLostCount;
     return err;
 }
@@ -99,14 +103,14 @@ CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiBeaconRxCount(uint32_t & beacon
 {
     WiFiManager::NetworkStatistics stats;
     CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
-    beaconRxCount = stats.mBeaconsSuccessCount;
+    beaconRxCount  = stats.mBeaconsSuccessCount;
     return err;
 }
 
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketMulticastRxCount(uint32_t & packetMulticastRxCount)
 {
     WiFiManager::NetworkStatistics stats;
-    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    CHIP_ERROR err         = WiFiManager::Instance().GetNetworkStatistics(stats);
     packetMulticastRxCount = stats.mPacketMulticastRxCount;
     return err;
 }
@@ -114,7 +118,7 @@ CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketMulticastRxCount(uint32_t
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketMulticastTxCount(uint32_t & packetMulticastTxCount)
 {
     WiFiManager::NetworkStatistics stats;
-    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    CHIP_ERROR err         = WiFiManager::Instance().GetNetworkStatistics(stats);
     packetMulticastTxCount = stats.mPacketMulticastTxCount;
     return err;
 }
@@ -122,7 +126,7 @@ CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketMulticastTxCount(uint32_t
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketUnicastRxCount(uint32_t & packetUnicastRxCount)
 {
     WiFiManager::NetworkStatistics stats;
-    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    CHIP_ERROR err       = WiFiManager::Instance().GetNetworkStatistics(stats);
     packetUnicastRxCount = stats.mPacketUnicastRxCount;
     return err;
 }
@@ -130,7 +134,7 @@ CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketUnicastRxCount(uint32_t &
 CHIP_ERROR DiagnosticDataProviderImplNrf::GetWiFiPacketUnicastTxCount(uint32_t & packetUnicastTxCount)
 {
     WiFiManager::NetworkStatistics stats;
-    CHIP_ERROR err = WiFiManager::Instance().GetNetworkStatistics(stats);
+    CHIP_ERROR err       = WiFiManager::Instance().GetNetworkStatistics(stats);
     packetUnicastTxCount = stats.mPacketUnicastTxCount;
     return err;
 }

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -288,16 +288,13 @@ CHIP_ERROR WiFiManager::GetWiFiInfo(WiFiInfo & info) const
 
     if (status.state >= WIFI_STATE_ASSOCIATED)
     {
-        uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
-        net_sprint_ll_addr_buf(reinterpret_cast<const uint8_t *>(status.bssid), WIFI_MAC_ADDR_LEN,
-                               reinterpret_cast<char *>(mac_string_buf), sizeof(mac_string_buf));
-        info.mBssId        = ByteSpan(mac_string_buf, sizeof(mac_string_buf));
         info.mSecurityType = MapToMatterSecurityType(status.security);
         info.mWiFiVersion  = MapToMatterWiFiVersionCode(status.link_mode);
         info.mRssi         = status.rssi;
         info.mChannel      = status.channel;
         info.mSsidLen      = status.ssid_len;
         memcpy(info.mSsid, status.ssid, status.ssid_len);
+        memcpy(info.mBssId, status.bssid, sizeof(status.bssid));
 
         return CHIP_NO_ERROR;
     }

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -127,7 +127,7 @@ public:
 
     struct WiFiInfo
     {
-        ByteSpan mBssId{};
+        uint8_t mBssId[DeviceLayer::Internal::kWiFiBSSIDLength];
         uint8_t mSecurityType{};
         uint8_t mWiFiVersion{};
         uint16_t mChannel{};


### PR DESCRIPTION
Cherry-picked fix to the GetWiFiInfo method from the Matter upstream.