### PR TITLE
[nrf noup] [nrfconnect] Use default number of RTC channels

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.defaults
@@ -75,8 +75,5 @@ config EXCEPTION_STACK_TRACE
 config NRF_802154_SER_RADIO
     default y
 
-config NRF_RTC_TIMER_USER_CHAN_COUNT
-    default 2
-
 config NRF_802154_ENCRYPTION
     default y


### PR DESCRIPTION
The default number of RTC channels on nRF5340 was increased from 2 to 3 some time ago, but Matter applications are still built with 2 user channels. This causes that CSL transmitter does not work properly on Matter Thread Router devices.