### PR TITLE
[nrf noup] Fixed nrf7002 kconfig name again

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -21,7 +21,7 @@ if CHIP
 
 config CHIP_WIFI
 	bool "Enable nrfconnect Wi-Fi support"
-	default y if SHIELD_NRF7002EK_NRF7002 || BOARD_NRF7002DK_NRF5340_CPUAPP
+	default y if SHIELD_NRF7002EK || BOARD_NRF7002DK_NRF5340_CPUAPP
 	select WIFI_NRF700X
 	select WIFI
 	select WPA_SUPP


### PR DESCRIPTION
nRF7002 EK kconfig name changed once again, so we need to align our kconfigs to that.

