### PR TITLE
[nrf noup] moved bt_fixed_passkey config to the features set

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -99,6 +99,13 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
 config BT_DEVICE_APPEARANCE
 	default 833
 
+if !LOG
+
+config BT_FIXED_PASSKEY
+	default y
+
+endif
+
 config CHIP_NUS_MAX_COMMAND_LEN
 	int "Maximum length of single command in Bytes"
 	default 10

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -3290,8 +3290,8 @@ bool DoorLockServer::HandleRemoteLockOperation(chip::app::CommandHandler * comma
 
     EndpointId endpoint       = commandPath.mEndpointId;
     OperationErrorEnum reason = OperationErrorEnum::kUnspecified;
-    Nullable<uint16_t> pinUserIdx; // Will get set to non-null if we find a user for the PIN.
-    Optional<uint16_t> pinCredIdx; // Will get set to a value if the PIN is one we know about.
+    Nullable<uint16_t> pinUserIdx;                                  // Will get set to non-null if we find a user for the PIN.
+    Optional<uint16_t> pinCredIdx{ Optional<uint16_t>::Missing() }; // Will get set to a value if the PIN is one we know about.
     bool success   = false;
     bool sendEvent = true;
 


### PR DESCRIPTION
BT_FIXED_PASSKEY cannot be added to prj_release.conf file because it causes a CMAKE warning. The config has been moved to the Kconfig.feature file.


