### PR TITLE
[nrf noup] use CMake command instead of bash in build script

### DIFF
--- a/config/common/cmake/chip_gn.cmake
+++ b/config/common/cmake/chip_gn.cmake
@@ -115,7 +115,7 @@ macro(matter_build target)
         BUILD_COMMAND           ${CMAKE_COMMAND} -E echo "Starting Matter library build in ${CMAKE_CURRENT_BINARY_DIR}"
         COMMAND                 ${Python3_EXECUTABLE} ${CHIP_ROOT}/config/common/cmake/make_gn_args.py @args.tmp > args.gn.tmp
         # Replace the config only if it has changed to avoid triggering unnecessary rebuilds
-        COMMAND                 bash -c "(! diff -q args.gn.tmp args.gn && mv args.gn.tmp args.gn) || true" 
+        COMMAND                 ${CMAKE_COMMAND} -E compare_files args.gn.tmp args.gn || ${CMAKE_COMMAND} -E rename args.gn.tmp args.gn 
         # Regenerate the ninja build system
         COMMAND                 ${GN_EXECUTABLE}
                                     --root=${CHIP_ROOT}


### PR DESCRIPTION
This commit fixes building on Windows PowerShell by removing usage of "bash" command.
