### PR TITLE
[nrf fromlist] Added calculating unique id lenght based on kconfig

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -157,6 +157,13 @@ config CHIP_FACTORY_DATA_WRITE_PROTECT
 		The second requirement is valid only when the FPROTECT_BLOCK_SIZE is bigger than
 		the flash memory page size.
 
+config CHIP_FACTORY_DATA_ROTATING_DEVICE_UID_MAX_LEN
+	int "Maximum length of rotating device ID unique ID in bytes"
+	default 16
+	depends on CHIP_FACTORY_DATA
+	help
+	  Maximum acceptable length of rotating device ID unique ID in bytes.
+
 if CHIP_FACTORY_DATA_BUILD
 
 # Factory data definitions

--- a/src/platform/nrfconnect/CHIPDevicePlatformConfig.h
+++ b/src/platform/nrfconnect/CHIPDevicePlatformConfig.h
@@ -255,3 +255,15 @@
 #ifdef CONFIG_CHIP_EXTENDED_DISCOVERY
 #define CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY 1
 #endif // CONFIG_CHIP_EXTENDED_DISCOVERY
+
+#ifndef CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH
+#if CONFIG_CHIP_FACTORY_DATA
+// UID will be copied from the externally programmed factory data, so we don't know the actual length and we need to assume some max
+// boundary.
+#define CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH CONFIG_CHIP_FACTORY_DATA_ROTATING_DEVICE_UID_MAX_LEN
+#else
+// UID will be copied from hex encoded Kconfig option, so we may calculate its length in bytes by subtracting null terminator and
+// dividing size by 2.
+#define CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH ((sizeof(CONFIG_CHIP_DEVICE_ROTATING_DEVICE_UID) - 1) / 2)
+#endif // CONFIG_CHIP_FACTORY_DATA
+#endif // CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID_LENGTH

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -323,6 +323,8 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetRotatingDeviceIdUniqueId(Mu
 
     memcpy(uniqueIdSpan.data(), mFactoryData.rd_uid.data, mFactoryData.rd_uid.len);
 
+    uniqueIdSpan.reduce_size(mFactoryData.rd_uid.len);
+
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
The unique id length is fixed to 16 B, while it should be equal to the current length of related string passed through kconfig


