### PR TITLE
[nrf noup] Fix ram_report and rom_report

### DIFF
--- a/config/common/cmake/make_gn_args.py
+++ b/config/common/cmake/make_gn_args.py
@@ -28,7 +28,11 @@ GN_CFLAG_EXCLUDES = [
     '-fno-reorder-functions',
     '-ffunction-sections',
     '-fdata-sections',
-    '-g*',
+    '-g',
+    '-g0',
+    '-g1',
+    '-g2',
+    '-g3',
     '-O*',
     '-W*',
 ]


### PR DESCRIPTION
Stop filtering out gdwarf-4 when passing flags from Zephyr to Matter's GN build system. Older pyelftools versions are not able to parse DWARF5 format, so ram and rom report would not be generated.

Re-applying #165 on a new codebase.