### PR TITLE
[nrf noup] Turn off wpa_supplicant debug output

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -226,6 +226,10 @@ choice WPA_SUPP_LOG_LEVEL_CHOICE
 	default WPA_SUPP_LOG_LEVEL_ERR
 endchoice
 
+# it saves us 20kB of FLASH
+config WPA_SUPP_NO_DEBUG
+    default y
+
 config NRF_WIFI_LOW_POWER
     default n
 


### PR DESCRIPTION
This saves ~20kB of FLASH.