### PR TITLE
[nrf noup] [nrfconnect] Upmerge fixes

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
@@ -140,6 +140,9 @@ config FLASH_SIMULATOR_STATS
 config ENABLE_MGMT_PERUSER
     default y
 
+config ZCBOR
+    default y
+
 config BOOT_MGMT_CUSTOM_STORAGE_ERASE
     default y
 

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -168,7 +168,7 @@ CHIP_ERROR WiFiManager::Init()
 
         if (maddr && !net_if_ipv6_maddr_is_joined(maddr) && !net_ipv6_is_addr_mcast_link_all_nodes(&addr))
         {
-            net_if_ipv6_maddr_join(maddr);
+            net_if_ipv6_maddr_join(iface, maddr);
         }
 
         return CHIP_NO_ERROR;
@@ -224,12 +224,12 @@ CHIP_ERROR WiFiManager::Scan(const ByteSpan & ssid, ScanResultCallback resultCal
             workaroundDone = true;
             return CHIP_NO_ERROR;
         }
-        else 
+        else
         {
             // TODO The workaround has not worked, so reboot the device
             ChipLogError(DeviceLayer, "WiFi driver does not respond, resetting the device...");
             workaroundDone = false;
-            PlatformMgr().Shutdown();      
+            PlatformMgr().Shutdown();
         }
         return CHIP_ERROR_INTERNAL;
     }


### PR DESCRIPTION
Mcuboot requires zcbor, so enable it explicitly, otherwise the build fails with latest mcuboot.
Align with the upstream net_if API change.
