### PR TITLE
[nrf noup] Fix generate zap sript on windows

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -16,7 +16,7 @@
 #
 
 import argparse
-import fcntl
+import platform
 import json
 import os
 import shutil
@@ -29,6 +29,13 @@ from pathlib import Path
 from typing import Optional
 
 from zap_execution import ZapTool
+
+def isWindows():
+    return platform.system() == "Windows"
+
+# fcntl is not supported on widows platfrom due to lack of necessity of I/O control on file descriptor
+if not isWindows():
+    import fcntl
 
 
 @dataclass
@@ -287,16 +294,17 @@ class LockFileSerializer:
         self.lock_file = None
 
     def __enter__(self):
-        if not self.lock_file_path:
+        # fcntl is not supported on widows platfrom due to lack of necessity of I/O control on file descriptor
+        if not self.lock_file_path or isWindows():
             return
-
         self.lock_file = open(self.lock_file_path, 'wb')
         fcntl.lockf(self.lock_file, fcntl.LOCK_EX)
 
-    def __exit__(self, *args):
-        if not self.lock_file:
-            return
 
+    def __exit__(self, *args):
+        # fcntl is not supported on widows platfrom due to lack of necessity of I/O control on file descriptor
+        if not self.lock_file or isWindows():
+            return
         fcntl.lockf(self.lock_file, fcntl.LOCK_UN)
         self.lock_file.close()
         self.lock_file = None


### PR DESCRIPTION
Usage of generate.py script is not possible on windows due to fcntl package available onlu on unix pyhton packages using I/O control on descriptor file is not needed on windows.
This change enhance script to use fcntl on non-window system.
