### PR TITLE
[door-lock] extend the OnFabricRemoved delegate with custom callback

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -1330,12 +1330,13 @@ bool DoorLockServer::OnFabricRemoved(chip::EndpointId endpointId, chip::FabricIn
         "[OnFabricRemoved] Handling a fabric removal from the door lock server [endpointId=%d,fabricIndex=%d]", endpointId,
         fabricIndex);
 
+    bool status{ true };
     // Iterate over all the users and clean up the deleted fabric
     if (!clearFabricFromUsers(endpointId, fabricIndex))
     {
         ChipLogError(Zcl, "[OnFabricRemoved] Unable to cleanup fabric from users - internal error [endpointId=%d,fabricIndex=%d]",
                      endpointId, fabricIndex);
-        return false;
+        status = false;
     }
 
     // Iterate over all the credentials and clean up the fabrics
@@ -1344,10 +1345,15 @@ bool DoorLockServer::OnFabricRemoved(chip::EndpointId endpointId, chip::FabricIn
         ChipLogError(Zcl,
                      "[OnFabricRemoved] Unable to cleanup fabric from credentials - internal error [endpointId=%d,fabricIndex=%d]",
                      endpointId, fabricIndex);
-        return false;
+        status = false;
     }
 
-    return true;
+    if (mOnFabricRemovedCustomCallback)
+    {
+        mOnFabricRemovedCustomCallback(endpointId, fabricIndex);
+    }
+
+    return status;
 }
 
 /**********************************************************

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -83,6 +83,8 @@ class DoorLockServer
 public:
     static DoorLockServer & Instance();
 
+    using OnFabricRemovedCustomCallback = void (*)(chip::EndpointId endpointId, chip::FabricIndex fabricIndex);
+
     void InitServer(chip::EndpointId endpointId);
 
     /**
@@ -186,6 +188,17 @@ public:
     {
         // appclusters, 5.2.2: USR feature has conformance [PIN | RID | FGP | FACE]
         return GetFeatures(endpointId).Has(DoorLockFeature::kUser) && SupportsAnyCredential(endpointId);
+    }
+
+    /**
+     * @brief Allows the application to register a custom callback which will be called after the default DoorLock
+     *        OnFabricRemoved implementation.
+     *
+     * @param callback callback to be registered
+     */
+    inline void SetOnFabricRemovedCustomCallback(OnFabricRemovedCustomCallback callback)
+    {
+        mOnFabricRemovedCustomCallback = callback;
     }
 
     bool OnFabricRemoved(chip::EndpointId endpointId, chip::FabricIndex fabricIndex);
@@ -557,6 +570,8 @@ private:
         const chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::DecodableType & commandData);
 
     std::array<EmberAfDoorLockEndpointContext, EMBER_AF_DOOR_LOCK_CLUSTER_SERVER_ENDPOINT_COUNT> mEndpointCtx;
+
+    OnFabricRemovedCustomCallback mOnFabricRemovedCustomCallback{ nullptr };
 
     static DoorLockServer instance;
 };


### PR DESCRIPTION
This change allows an application to register custom handling
used when the device leaves the fabric.
