### PR TITLE
[nrf noup] Repair wrong casting for CSL period setting

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1859,7 +1859,7 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::SetSEDIntervalMode(Connecti
 // * poll period for SED devices that poll the parent for data
 // * CSL period for SSED devices that listen for messages in scheduled time slots.
 #if CHIP_DEVICE_CONFIG_THREAD_SSED
-    // Get CSL period in units of 10 symbols, convert it to microseconds and divide by 1000 to get milliseconds.
+    // Get CSL period in units of us, divide by 1000 to get milliseconds.
     uint32_t curIntervalMS = otLinkGetCslPeriod(mOTInst) / 1000;
 #else
     uint32_t curIntervalMS = otLinkGetPollPeriod(mOTInst);
@@ -1868,8 +1868,8 @@ GenericThreadStackManagerImpl_OpenThread<ImplClass>::SetSEDIntervalMode(Connecti
     if (interval.count() != curIntervalMS)
     {
 #if CHIP_DEVICE_CONFIG_THREAD_SSED
-        // Set CSL period in units of 10 symbols, convert it to microseconds and divide by 1000 to get milliseconds.
-        otErr         = otLinkSetCslPeriod(mOTInst, static_cast<uint16_t>(static_cast<uint32_t>(interval.count() * 1000)));
+        // Get CSL period in units of us, divide by 1000 to get milliseconds.
+        otErr         = otLinkSetCslPeriod(mOTInst, interval.count() * 1000);
         curIntervalMS = otLinkGetCslPeriod(mOTInst) / 1000;
 #else
         otErr         = otLinkSetPollPeriod(mOTInst, interval.count());


### PR DESCRIPTION
After the API change, there should not be cast to uint16_t in the otLinkSetCslPeriod function anymore.


