### PR TITLE
Clean-up default KConfigs

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -228,7 +228,8 @@ config CHIP_FACTORY_DATA_USER_CERTS_PAI_CERT
 	string "Path to the PAI certificate (DER format)"
 	help
 	  Provides the absolute path to the PAI certificate in the DER format.
-endif
+
+endif # CHIP_FACTORY_DATA_CERT_SOURCE_USER
 
 # Configs for SPAKE2+ generation
 config CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER
@@ -243,14 +244,12 @@ config CHIP_DEVICE_GENERATE_ROTATING_DEVICE_UID
 	help
 	  Enables the generation of a random Rotating device ID unique ID.
 
-endif #CHIP_FACTORY_DATA_BUILD
+endif # CHIP_FACTORY_DATA_BUILD
 
 # See config/zephyr/Kconfig for full definition
 config CHIP_FACTORY_RESET_ERASE_NVS
 	bool
-	default y if CHIP_FACTORY_DATA || CHIP_FACTORY_DATA_CUSTOM_BACKEND
-
-endif
+	default y
 
 config CHIP_LOG_SIZE_OPTIMIZATION
 	bool "Disable some detailed logs to decrease flash usage"
@@ -268,3 +267,5 @@ config CHIP_IPV4
 	  If disabled, it allows to build nRF Connect SDK application
 	  with IPv4 support independently of the Matter stack still
 	  running over IPv6.
+
+endif # CHIP

--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -65,6 +65,15 @@ config FPU
 config SHELL
     default y
 
+# Enable getting reboot reasons information
+config HWINFO
+	bool
+	default y
+
+config HWINFO_SHELL
+	bool
+	default n
+
 config PTHREAD_IPC
     bool
     default n
@@ -212,6 +221,10 @@ config NET_L2_OPENTHREAD
     default y if !WIFI_NRF700X
 
 if NET_L2_OPENTHREAD
+
+# Disable OpenThread shell
+config OPENTHREAD_SHELL
+    default n
 
 # Disable certain parts of Zephyr IPv6 stack
 config NET_IPV6_NBR_CACHE

--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -162,6 +162,10 @@ config BT_DEVICE_NAME_GATT_WRITABLE
     bool
     default n
 
+config BT_GATT_CACHING
+    bool
+    default n
+
 # Enable NFC support
 
 config CHIP_NFC_COMMISSIONING


### PR DESCRIPTION
This PR includes three commits:

- Disabled BLE GATT Cache (getting 3k in Release build)
- Disabled Shell for OpenThread and HWINFO, leaving just Matter Shell (getting almost 47k in Debug build)
- Enabled erasing NVS by default during factory reset  