### PR TITLE
[nrf noup] Align finding Python3 executable to NCS requirements.

### DIFF
--- a/config/nrfconnect/chip-module/generate_factory_data.cmake
+++ b/config/nrfconnect/chip-module/generate_factory_data.cmake
@@ -180,7 +180,7 @@ endfunction()
 #
 function(nrfconnect_generate_factory_data)
 
-find_package(Python REQUIRED)
+find_package(Python3 REQUIRED)
 
 # CHIP_ROOT must be provided as a reference set all localization of scripts
 if(NOT CHIP_ROOT)


### PR DESCRIPTION
We should try to find Python3 instead of Python within Cmake scripts.


