### PR TITLE
[nrf noup] [shell] Add documentation for stat commands

### DIFF
--- a/docs/guides/nrfconnect_examples_cli.md
+++ b/docs/guides/nrfconnect_examples_cli.md
@@ -361,3 +361,32 @@ DNS resolve for 000000014A77CBB3-0000000000BC5C01 succeeded:
    IP address: fd08:b65e:db8e:f9c7:8052:1a8e:4dd4:e1f3
    Port: 5540
 ```
+
+### `stat` command group
+
+Handles a group of commands that are used to get and reset the peak usage of
+critical system resources used by Matter. These commands are only available
+when the `CONFIG_CHIP_STATISTICS=y` Kconfig option is set.
+
+#### `peak` subcommand
+
+Prints the peak usage of system resources.
+
+```shell
+uart:~$ matter stat peak
+Packet Buffers: 1
+Timers: 2
+TCP endpoints: 0
+UDP endpoints: 1
+Exchange contexts: 0
+Unsolicited message handlers: 5
+Platform events: 2
+```
+
+#### `reset` subcommand
+
+Resets the peak usage of system resources.
+
+```shell
+uart:~$ matter stat reset
+```

--- a/src/lib/shell/commands/Stat.cpp
+++ b/src/lib/shell/commands/Stat.cpp
@@ -29,7 +29,7 @@ namespace {
 
 Shell::Engine sSubShell;
 
-CHIP_ERROR StatTopHandler(int argc, char ** argv)
+CHIP_ERROR StatPeakHandler(int argc, char ** argv)
 {
     auto labels     = System::Stats::GetStrings();
     auto watermarks = System::Stats::GetHighWatermarks();
@@ -77,8 +77,8 @@ void RegisterStatCommands()
 {
     // Register subcommands of the `stat` commands.
     static const shell_command_t subCommands[] = {
-        { &StatTopHandler, "top", "Print top resource usage statistics. Usage: stat top" },
-        { &StatResetHandler, "reset", "Reset top resource usage statistics. Usage: stat reset" },
+        { &StatPeakHandler, "peak", "Print peak usage of system resources. Usage: stat peak" },
+        { &StatResetHandler, "reset", "Reset peak usage of system resources. Usage: stat reset" },
     };
 
     sSubShell.RegisterCommands(subCommands, ArraySize(subCommands));


### PR DESCRIPTION
1. Rename "top" command to "peak" as the latter better describes the purpose.
2. Add documentation for stat commands.