### PR TITLE
[nrf noup] Enable minimal configuration of Shell

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -65,6 +65,9 @@ config FPU
 config SHELL
     default y
 
+config SHELL_MINIMAL
+    default y
+
 # Enable getting reboot reasons information
 config HWINFO
 	bool


### PR DESCRIPTION
Enable minimal shell configuration to save some ROM (~6.5k) and RAM .
