### PR TITLE
[nrf noup] Fixed boot reason for nRF52

### DIFF
--- a/src/platform/nrfconnect/Reboot.cpp
+++ b/src/platform/nrfconnect/Reboot.cpp
@@ -56,13 +56,7 @@ void Reboot(SoftwareRebootReason reason)
 {
     const RetainedReason retainedReason = EncodeReason(reason);
 
-    // The parameter passed to sys_reboot() is retained in GPREGRET (general-purpose
-    // retention register) on nRF52 SOC family, but nRF53 ignores the parameter, so
-    // set it manually.
-
-#ifdef CONFIG_SOC_SERIES_NRF53X
     nrf_power_gpregret_set(NRF_POWER, retainedReason);
-#endif
 
     sys_reboot(retainedReason);
 }


### PR DESCRIPTION
Recently the mechanism of nRF52 reboot type retention which is used in Matter has been deprecated in Zephyr and can be only bring back by a dedicated KConfig. Another solution (chosen) is to explicitly store boot reason in the retention registers for both nRF52 and nRF53.

Reference Zephyr PR:
https://github.com/nrfconnect/sdk-zephyr/commit/f79a08d6c0fed793a1b86af70dcb941dd67e63d9

Another solution could be to leave the Reboot and enable the `NRF_STORE_REBOOT_TYPE_GPREGRET` KConfig but the behavior will be the same. Anyway, I think we should migrate to the suggested retention mechanism (please see KRKNWK-17601).
