### PR TITLE
[nrf noup] Increased number of net sockets poll max

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -267,7 +267,7 @@ config NET_IF_MCAST_IPV6_ADDR_COUNT
     default 8
 
 config NET_SOCKETS_POLL_MAX
-    default 4
+    default 6
 
 config MBEDTLS_SSL_OUT_CONTENT_LEN
     default 900


### PR DESCRIPTION
Increased CONFIG_NET_SOCKETS_POLL_MAX from 4 to 6, as otherwise it resulted in bus fault during connection.


