### PR TITLE
[nrf noup] [nrfconnect] Enable NVS lookup cache settings optimization

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -16,6 +16,10 @@
 
 rsource "../../zephyr/Kconfig"
 
+config CHIP
+	imply NVS_LOOKUP_CACHE
+	imply NVS_LOOKUP_CACHE_FOR_SETTINGS
+
 if CHIP
 
 # See config/zephyr/Kconfig for full definition

--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -212,9 +212,6 @@ endif # BOARD_NRF7002DK_NRF5340_CPUAPP
 config CHIP_EXTENDED_DISCOVERY
     default n
 
-config NVS_LOOKUP_CACHE
-    default y
-
 config NVS_LOOKUP_CACHE_SIZE
     default 512
 


### PR DESCRIPTION
By default, use the lookup cache hash function optimized for NVS used as the settings backend. This assumes that a user application uses Zephyr settings API and does not write to the NVS directly.

Corresponding change: https://github.com/nrfconnect/sdk-zephyr/pull/1263