### PR TITLE
[nrf noup] Increase the maximum number of prefixes

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -249,6 +249,11 @@ choice WPA_SUPP_LOG_LEVEL_CHOICE
 	default WPA_SUPP_LOG_LEVEL_ERR
 endchoice
 
+# increase the prefixes limit to match
+# maximum number of IPv6 addresses per interface
+config NET_IF_IPV6_PREFIX_COUNT
+    default 6
+
 # it saves us 20kB of FLASH
 config WPA_SUPP_NO_DEBUG
     default y


### PR DESCRIPTION
... to match the maximum number of IPv6 addresses per interface.

Zephyr ipv6_nbr implementation requires the given address to have a matching prefix set on the interface. Otherwise, the default router is used for sending neighbor advertisement and as a result, in case there are multiple routers in the network, the packet can be sent to the invalid interface (not the one which issued neighbor solicitation).

The detailed analysis of the issue can be found in KRKNWK-17318.
