### PR TITLE
[crypto] Add PSA SPAKE2+ implementation

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -160,7 +160,8 @@ else()
 endif()
 
 if (CONFIG_CHIP_CRYPTO_PSA)
-    matter_add_gn_arg_string("chip_crypto" "psa")
+    matter_add_gn_arg_string("chip_crypto"             "psa")
+    matter_add_gn_arg_bool  ("chip_crypto_psa_spake2p" TRUE)
 endif()
 
 if (BOARD STREQUAL "native_posix")

--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -51,6 +51,7 @@ buildconfig_header("crypto_buildconfig") {
   defines = [
     "CHIP_CRYPTO_MBEDTLS=${chip_crypto_mbedtls}",
     "CHIP_CRYPTO_PSA=${chip_crypto_psa}",
+    "CHIP_CRYPTO_PSA_SPAKE2P=${chip_crypto_psa_spake2p}",
     "CHIP_CRYPTO_OPENSSL=${chip_crypto_openssl}",
     "CHIP_CRYPTO_BORINGSSL=${chip_crypto_boringssl}",
     "CHIP_CRYPTO_PLATFORM=${chip_crypto_platform}",
@@ -152,6 +153,13 @@ static_library("crypto") {
     sources += [
       "RawKeySessionKeystore.cpp",
       "RawKeySessionKeystore.h",
+    ]
+  }
+
+  if (chip_crypto_psa_spake2p) {
+    sources += [
+      "PSASpake2p.cpp",
+      "PSASpake2p.h",
     ]
   }
 

--- a/src/crypto/PSASpake2p.cpp
+++ b/src/crypto/PSASpake2p.cpp
@@ -1,0 +1,203 @@
+/*
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "PSASpake2p.h"
+
+#include "CHIPCryptoPALPSA.h"
+
+#include <lib/support/CodeUtils.h>
+
+#include <psa/crypto.h>
+
+namespace chip {
+namespace Crypto {
+
+CHIP_ERROR PSASpake2p_P256_SHA256_HKDF_HMAC::Init(const uint8_t * context, size_t context_len)
+{
+    Clear();
+
+    VerifyOrReturnError(context_len <= sizeof(mContext), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    psa_pake_cipher_suite_t cs = PSA_PAKE_CIPHER_SUITE_INIT;
+    psa_pake_cs_set_algorithm(&cs, PSA_ALG_SPAKE2P);
+    psa_pake_cs_set_primitive(&cs, PSA_PAKE_PRIMITIVE(PSA_PAKE_PRIMITIVE_TYPE_ECC, PSA_ECC_FAMILY_SECP_R1, 256));
+    psa_pake_cs_set_hash(&cs, PSA_ALG_SHA_256);
+
+    psa_status_t status = psa_pake_setup(&mOperation, &cs);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    memcpy(mContext, context, context_len);
+    mContextLen = context_len;
+
+    return CHIP_NO_ERROR;
+}
+
+void PSASpake2p_P256_SHA256_HKDF_HMAC::Clear()
+{
+    IgnoreUnusedVariable(psa_pake_abort(&mOperation));
+    mOperation = psa_pake_operation_init();
+
+    IgnoreUnusedVariable(psa_destroy_key(mKey));
+    mKey = PSA_KEY_ID_NULL;
+}
+
+CHIP_ERROR PSASpake2p_P256_SHA256_HKDF_HMAC::BeginVerifier(const uint8_t * my_identity, size_t my_identity_len,
+                                                           const uint8_t * peer_identity, size_t peer_identity_len,
+                                                           const uint8_t * w0in, size_t w0in_len, const uint8_t * Lin,
+                                                           size_t Lin_len)
+{
+    VerifyOrReturnError(w0in_len <= kSpake2p_WS_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(Lin_len == kP256_Point_Length, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mRole               = PSA_PAKE_ROLE_SERVER;
+    psa_status_t status = psa_pake_set_role(&mOperation, PSA_PAKE_ROLE_SERVER);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    status = psa_pake_set_peer(&mOperation, peer_identity, peer_identity_len);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    status = psa_pake_set_user(&mOperation, my_identity, my_identity_len);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    uint8_t password[kSpake2p_WS_Length + kP256_Point_Length];
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+    memcpy(password + 0, w0in, w0in_len);
+    memcpy(password + w0in_len, Lin, Lin_len);
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DERIVE);
+    psa_set_key_algorithm(&attributes, PSA_ALG_SPAKE2P);
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_PASSWORD);
+
+    status = psa_import_key(&attributes, password, w0in_len + Lin_len, &mKey);
+    psa_reset_key_attributes(&attributes);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    status = psa_pake_set_password_key(&mOperation, mKey);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    status = psa_pake_input(&mOperation, PSA_PAKE_STEP_CONTEXT, mContext, mContextLen);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PSASpake2p_P256_SHA256_HKDF_HMAC::BeginProver(const uint8_t * my_identity, size_t my_identity_len,
+                                                         const uint8_t * peer_identity, size_t peer_identity_len,
+                                                         const uint8_t * w0in, size_t w0in_len, const uint8_t * w1in,
+                                                         size_t w1in_len)
+{
+    VerifyOrReturnError(w0in_len <= kSpake2p_WS_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(w1in_len <= kSpake2p_WS_Length, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mRole               = PSA_PAKE_ROLE_CLIENT;
+    psa_status_t status = psa_pake_set_role(&mOperation, PSA_PAKE_ROLE_CLIENT);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    status = psa_pake_set_user(&mOperation, my_identity, my_identity_len);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    status = psa_pake_set_peer(&mOperation, peer_identity, peer_identity_len);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    uint8_t password[kSpake2p_WS_Length * 2];
+    psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+
+    memcpy(password + 0, w0in, w0in_len);
+    memcpy(password + w0in_len, w1in, w1in_len);
+    psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DERIVE);
+    psa_set_key_algorithm(&attributes, PSA_ALG_SPAKE2P);
+    psa_set_key_type(&attributes, PSA_KEY_TYPE_PASSWORD);
+
+    status = psa_import_key(&attributes, password, w0in_len + w1in_len, &mKey);
+    psa_reset_key_attributes(&attributes);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    status = psa_pake_set_password_key(&mOperation, mKey);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    status = psa_pake_input(&mOperation, PSA_PAKE_STEP_CONTEXT, mContext, mContextLen);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PSASpake2p_P256_SHA256_HKDF_HMAC::ComputeRoundOne(const uint8_t * pab, size_t pab_len, uint8_t * out, size_t * out_len)
+{
+    VerifyOrReturnError(out_len != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    psa_status_t status;
+
+    if (mRole == PSA_PAKE_ROLE_SERVER)
+    {
+        status = psa_pake_input(&mOperation, PSA_PAKE_STEP_KEY_SHARE, pab, pab_len);
+        VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+    }
+
+    status = psa_pake_output(&mOperation, PSA_PAKE_STEP_KEY_SHARE, out, *out_len, out_len);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PSASpake2p_P256_SHA256_HKDF_HMAC::ComputeRoundTwo(const uint8_t * in, size_t in_len, uint8_t * out, size_t * out_len)
+{
+    VerifyOrReturnError(out_len != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    psa_status_t status;
+
+    if (mRole == PSA_PAKE_ROLE_CLIENT)
+    {
+        status = psa_pake_input(&mOperation, PSA_PAKE_STEP_KEY_SHARE, in, in_len);
+        VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+    }
+
+    status = psa_pake_output(&mOperation, PSA_PAKE_STEP_CONFIRM, out, *out_len, out_len);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PSASpake2p_P256_SHA256_HKDF_HMAC::KeyConfirm(const uint8_t * in, size_t in_len)
+{
+    psa_status_t status = psa_pake_input(&mOperation, PSA_PAKE_STEP_CONFIRM, in, in_len);
+    VerifyOrReturnError(status == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR PSASpake2p_P256_SHA256_HKDF_HMAC::GetKeys(uint8_t * out, size_t * out_len)
+{
+    VerifyOrReturnError(out != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(out_len != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    /*
+     * TODO: either:
+     * - use psa_pake_shared_secret() proposed in https://github.com/ARM-software/psa-api/issues/86
+     * - refactor Matter's GetKeys API to take an abstract shared secret instead of raw secret bytes.
+     */
+    oberon_spake2p_operation_t & oberonCtx = mOperation.MBEDTLS_PRIVATE(ctx).oberon_spake2p_ctx;
+
+    VerifyOrReturnError((oberonCtx.hash_len / 2) <= *out_len, CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    memcpy(out, oberonCtx.shared, oberonCtx.hash_len / 2);
+    *out_len = oberonCtx.hash_len / 2;
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace Crypto
+} // namespace chip

--- a/src/crypto/PSASpake2p.h
+++ b/src/crypto/PSASpake2p.h
@@ -1,0 +1,166 @@
+/*
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include "CHIPCryptoPAL.h"
+
+#include <psa/crypto.h>
+
+namespace chip {
+namespace Crypto {
+
+/**
+ * The below class implements the draft 01 version of the Spake2+ protocol as
+ * defined in https://www.ietf.org/id/draft-bar-cfrg-spake2plus-01.html.
+ *
+ * The following describes the protocol flows:
+ *
+ *     Commissioner                     Accessory
+ *     ------------                     ---------
+ *
+ *     Init
+ *     BeginProver
+ *     ComputeRoundOne  ------------->
+ *                                      Init
+ *                                      BeginVerifier
+ *                                  /-  ComputeRoundOne
+ *                      <-------------  ComputeRoundTwo
+ *     ComputeRoundTwo  ------------->
+ *     KeyConfirm                       KeyConfirm
+ *     GetKeys                          GetKeys
+ *
+ **/
+class PSASpake2p_P256_SHA256_HKDF_HMAC
+{
+public:
+    /**
+     * @brief Initialize Spake2+ with some context specific information.
+     *
+     * @param context     The context is arbitrary but should include information about the
+     *                    protocol being run, contain the transcript for negotiation, include
+     *                    the PKBDF parameters, etc.
+     * @param context_len The length of the context.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR Init(const uint8_t * context, size_t context_len);
+
+    /**
+     * @brief Free Spake2+ underlying objects.
+     **/
+    void Clear();
+
+    /**
+     * @brief Start the Spake2+ process as a verifier (i.e. an accessory being provisioned).
+     *
+     * @param my_identity       The verifier identity. May be NULL if identities are not established.
+     * @param my_identity_len   The verifier identity length.
+     * @param peer_identity     The peer identity. May be NULL if identities are not established.
+     * @param peer_identity_len The peer identity length.
+     * @param w0in              The input w0 (a parameter baked into the device or computed with ComputeW0).
+     * @param w0in_len          The input w0 length.
+     * @param Lin               The input L (a parameter baked into the device or computed with ComputeL).
+     * @param Lin_len           The input L length.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR BeginVerifier(const uint8_t * my_identity, size_t my_identity_len, const uint8_t * peer_identity,
+                             size_t peer_identity_len, const uint8_t * w0in, size_t w0in_len, const uint8_t * Lin, size_t Lin_len);
+
+    /**
+     * @brief Start the Spake2+ process as a prover (i.e. a commissioner).
+     *
+     * @param my_identity       The prover identity. May be NULL if identities are not established.
+     * @param my_identity_len   The prover identity length.
+     * @param peer_identity     The peer identity. May be NULL if identities are not established.
+     * @param peer_identity_len The peer identity length.
+     * @param w0in              The input w0 (an output from the PBKDF).
+     * @param w0in_len          The input w0 length.
+     * @param w1in              The input w1 (an output from the PBKDF).
+     * @param w1in_len          The input w1 length.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR BeginProver(const uint8_t * my_identity, size_t my_identity_len, const uint8_t * peer_identity,
+                           size_t peer_identity_len, const uint8_t * w0in, size_t w0in_len, const uint8_t * w1in, size_t w1in_len);
+
+    /**
+     * @brief Compute the first round of the protocol.
+     *
+     * @param pab      X value from commissioner.
+     * @param pab_len  X length.
+     * @param out     The output first round Spake2+ contribution.
+     * @param out_len The output first round Spake2+ contribution length.
+     *
+     * The out_len parameter is expected to point to an integer that holds
+     * the size of the buffer to put the first round Spake2+ contribution.
+     * After successful execution of this method, the variable is set to the
+     * actual size of the generated output.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR ComputeRoundOne(const uint8_t * pab, size_t pab_len, uint8_t * out, size_t * out_len);
+
+    /**
+     * @brief Compute the second round of the protocol.
+     *
+     * @param in      The peer first round Spake2+ contribution.
+     * @param in_len  The peer first round Spake2+ contribution length.
+     * @param out     The output second round Spake2+ contribution.
+     * @param out_len The output second round Spake2+ contribution length.
+     *
+     * The out_len parameter is expected to point to an integer that holds
+     * the size of the buffer to put the second round Spake2+ contribution.
+     * After successful execution of this method, the variable is set to the
+     * actual size of the generated output.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR ComputeRoundTwo(const uint8_t * in, size_t in_len, uint8_t * out, size_t * out_len);
+
+    /**
+     * @brief Confirm that each party computed the same keys.
+     *
+     * @param in     The peer second round Spake2+ contribution.
+     * @param in_len The peer second round Spake2+ contribution length.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR KeyConfirm(const uint8_t * in, size_t in_len);
+
+    /**
+     * @brief Return the shared secret.
+     *
+     * @param out     The output secret.
+     * @param out_len The output secret length.
+     *
+     * @return Returns a CHIP_ERROR on error, CHIP_NO_ERROR otherwise
+     **/
+    CHIP_ERROR GetKeys(uint8_t * out, size_t * out_len);
+
+private:
+    psa_pake_operation_t mOperation = PSA_PAKE_OPERATION_INIT;
+    psa_key_id_t mKey               = PSA_KEY_ID_NULL;
+
+    psa_pake_role_t mRole;
+    uint8_t mContext[kSHA256_Hash_Length];
+    size_t mContextLen;
+};
+
+} // namespace Crypto
+} // namespace chip

--- a/src/crypto/crypto.gni
+++ b/src/crypto/crypto.gni
@@ -19,8 +19,15 @@ declare_args() {
 
   # Compile mbedtls externally. Only used if chip_crypto == "mbedtls"
   chip_external_mbedtls = false
+
+  # Use PSA Spake2+ implementation. Only used if chip_crypto == "psa"
+  chip_crypto_psa_spake2p = false
 }
 
 assert(
     !chip_external_mbedtls || chip_crypto == "mbedtls" || chip_crypto == "psa",
     "Use of external mbedtls requires the mbedtls or psa crypto impl")
+
+assert(
+    !chip_crypto_psa_spake2p || chip_crypto == "psa",
+    "Use of psa spake2+ requires the psa crypto impl")

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -27,6 +27,9 @@
 #pragma once
 
 #include <crypto/CHIPCryptoPAL.h>
+#if CHIP_CRYPTO_PSA_SPAKE2P
+#include <crypto/PSASpake2p.h>
+#endif
 #include <lib/support/Base64.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeDelegate.h>
@@ -210,6 +213,8 @@ private:
     // mNextExpectedMsg is set when we are expecting a message.
     Optional<Protocols::SecureChannel::MsgType> mNextExpectedMsg;
 
+#elif CHIP_CRYPTO_PSA_SPAKE2P
+    PSASpake2p_P256_SHA256_HKDF_HMAC mSpake2p;
     Spake2p_P256_SHA256_HKDF_HMAC mSpake2p;
 
     Spake2pVerifier mPASEVerifier;


### PR DESCRIPTION
Implement Matter's SPAKE2+ protocol using PSA crypto API. Use the PSA implementation in PASE session for nRF Connect platform.

**Note:** The implementation can't be used without changes in PSA crypto driver listed in NCSDK-23835.