### PR TITLE
[nrf fromtree] app: clusters: Add handling a local lock operation error

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -188,6 +188,18 @@ bool DoorLockServer::SetPrivacyModeButton(chip::EndpointId endpointId, bool isEn
     return SetAttribute(endpointId, Attributes::EnablePrivacyModeButton::Id, Attributes::EnablePrivacyModeButton::Set, isEnabled);
 }
 
+void DoorLockServer::HandleLocalLockOperationError(chip::EndpointId endpointId, LockOperationTypeEnum opType,
+                                                   OperationSourceEnum opSource, Nullable<uint16_t> userId)
+{
+    SendLockOperationEvent(endpointId, opType, opSource, OperationErrorEnum::kInvalidCredential, userId,
+                           Nullable<chip::FabricIndex>(), Nullable<chip::NodeId>(), Nullable<List<const LockOpCredentials>>(),
+                           false);
+
+    HandleWrongCodeEntry(endpointId);
+
+    ChipLogProgress(Zcl, "Handling a local Lock Operation Error: [endpoint=%d, user=%d]", endpointId, userId.Value());
+}
+
 bool DoorLockServer::HandleWrongCodeEntry(chip::EndpointId endpointId)
 {
     auto endpointContext = getContext(endpointId);

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -214,6 +214,20 @@ public:
      */
     void ResetWrongCodeEntryAttempts(chip::EndpointId endpointId);
 
+    /**
+     * @brief Handles a local lock operation error. This method allows handling a wrong attempt of providing
+     *        user credential entry that has been provided locally by the user. The method will emit the LockOperationEvent
+     *        to inform the controller that a local wrong attempt occurred, and also call HandleWrongEntry method to
+     *        increment wrong entry counter.
+     *
+     * @param endpointId
+     * @param opType Operation source to be registered in the LockOperationEvent.
+     * @param opSource source of the operation to be registered in the LockOperationEvent.
+     * @param userId Optional user id to be registered in the LockOperationEvent
+     */
+    void HandleLocalLockOperationError(chip::EndpointId endpointId, LockOperationTypeEnum opType, OperationSourceEnum opSource,
+                                       Nullable<uint16_t> userId);
+
 private:
     chip::FabricIndex getFabricIndex(const chip::app::CommandHandler * commandObj);
     chip::NodeId getNodeId(const chip::app::CommandHandler * commandObj);


### PR DESCRIPTION
In case we use a custom handling lock credential we need a mechanism that allows us to handle a lock operation error when the wrong credential has been provided.

Added handling local lock operation error to emit LockOperationEvent and call HandleWrongCodeEntry.


