### PR TITLE
[nrf fromlist] Clear endpoint bitmask before reporting the PartList attribute

### DIFF
--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -829,7 +829,7 @@ CHIP_ERROR Engine::SetDirty(AttributePathParams & aAttributePath)
 
     bool intersectsInterestPath = false;
     InteractionModelEngine::GetInstance()->mReadHandlers.ForEachActiveObject(
-        [&aAttributePath, &intersectsInterestPath](ReadHandler * handler) {
+        [&aAttributePath, &intersectsInterestPath, this](ReadHandler * handler) {
             // We call SetDirty for both read interactions and subscribe interactions, since we may send inconsistent attribute data
             // between two chunks. SetDirty will be ignored automatically by read handlers which are waiting for a response to the
             // last message chunk for read interactions.
@@ -839,6 +839,8 @@ CHIP_ERROR Engine::SetDirty(AttributePathParams & aAttributePath)
                 {
                     if (object->mValue.Intersects(aAttributePath))
                     {
+                        // TODO: This is a workaround for Matter 1.1.0.1, remove it after upmerge to Matter 1.2
+                        this->InsertPathIntoDirtySet(aAttributePath);
                         handler->SetDirty(aAttributePath);
                         intersectsInterestPath = true;
                         break;
@@ -853,7 +855,6 @@ CHIP_ERROR Engine::SetDirty(AttributePathParams & aAttributePath)
     {
         return CHIP_NO_ERROR;
     }
-    ReturnErrorOnFailure(InsertPathIntoDirtySet(aAttributePath));
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -925,6 +925,7 @@ bool emberAfEndpointEnableDisable(EndpointId endpoint, bool enable)
         else
         {
             shutdownEndpoint(&(emAfEndpoints[index]));
+            emAfEndpoints[index].bitmask &= EMBER_AF_ENDPOINT_DISABLED;
         }
 
         EndpointId parentEndpointId = emberAfParentEndpointFromIndex(index);
@@ -943,11 +944,6 @@ bool emberAfEndpointEnableDisable(EndpointId endpoint, bool enable)
 
         MatterReportingAttributeChangeCallback(/* endpoint = */ 0, app::Clusters::Descriptor::Id,
                                                app::Clusters::Descriptor::Attributes::PartsList::Id);
-    }
-
-    if (!enable)
-    {
-        emAfEndpoints[index].bitmask &= EMBER_AF_ENDPOINT_DISABLED;
     }
 
     return true;


### PR DESCRIPTION
When we set a low value to the minimum subscription interval for subscription for the PartList attribute of the Description cluster, and then remove a dynamic endpoint the related bitmask may change after reporting it to a controller.
The controller receives the old number of endpoints and does not update it within the following subscriptions until the next change of the PartList attribute occurs.

To resolve the issue the endpoint bitmask should be cleared before reporting the PartList attribute of the Descriptor cluster to avoid race conditions.

[nrf] -> There is an old API and there is a bitmask operation instead of the method Clear!

