### PR TITLE
[nrf noup] Disabled BLE 2M PHY due to interoperability issues

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -178,6 +178,10 @@ config BT_GATT_CACHING
     bool
     default n
 
+# Disable 2M PHY due to interoperability issues.
+config BT_CTLR_PHY_2M
+    default n
+
 # Enable NFC support
 
 config CHIP_NFC_COMMISSIONING

--- a/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.hci_rpmsg.defaults
@@ -58,6 +58,10 @@ config BT_CTLR_ASSERT_HANDLER
 config BT_HCI_RAW_RESERVE
     default 1
 
+# Disable 2M PHY due to interoperability issues.
+config BT_CTLR_PHY_2M
+    default n
+
 # Workaround: Unable to allocate command buffer when using K_NO_WAIT since
 # Host number of completed commands does not follow normal flow control.
 config BT_BUF_CMD_TX_COUNT

--- a/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.defaults
@@ -58,6 +58,10 @@ config BT_CTLR_ASSERT_HANDLER
 config BT_HCI_RAW_RESERVE
     default 1
 
+# Disable 2M PHY due to interoperability issues.
+config BT_CTLR_PHY_2M
+    default n
+
 # Workaround: Unable to allocate command buffer when using K_NO_WAIT since
 # Host number of completed commands does not follow normal flow control.
 config BT_BUF_CMD_TX_COUNT


### PR DESCRIPTION
There were some interoperability issues discovered due to BLE PHY dynamic changes from 1M to 2M. The 2M was disabled to ensure the interoperability with some of the BT controllers.

