### PR TITLE
[nrf noup] Disable nRF70 driver logs verbosity by default

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -255,6 +255,9 @@ config NET_IF_IPV6_PREFIX_COUNT
 config WPA_SUPP_NO_DEBUG
     default y
 
+config NRF700X_LOG_VERBOSE
+    default n
+
 config NRF_WIFI_LOW_POWER
     default n
 


### PR DESCRIPTION
This aims to keep memory footprint after this config is enabled by default in NCS.
