### PR TITLE
[nrf fromlist] [nrfconnect] Add a delay to last fabric remove action

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -304,4 +304,13 @@ choice CHIP_LAST_FABRIC_REMOVED_ACTION
 
 endchoice
 
+config CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY
+	int "After removing the last fabric wait defined time [in milliseconds] to perform an action"
+	depends on !CHIP_LAST_FABRIC_REMOVED_NONE
+	default 500
+	help
+	  After removing the last fabric the device will wait for the defined time and then perform
+	  an action chosen by the CHIP_LAST_FABRIC_REMOVED_ACTION option. This schedule will allow for
+	  avoiding race conditions before the device removes non-volatile data.
+
 endif # CHIP

--- a/docs/guides/nrfconnect_factory_data_configuration.md
+++ b/docs/guides/nrfconnect_factory_data_configuration.md
@@ -247,7 +247,7 @@ To use this script, complete the following steps:
     b. Add output file path:
 
     ```
-    -o <output_dir>
+    -o <path_to_output_json_file>
     ```
 
     c. Generate SPAKE2 verifier using one of the following methods:
@@ -357,7 +357,7 @@ $ python scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py \
 --passcode 20202021 \
 --product_finish "matte" \
 --product_color "black" \
---out "build.json"' \
+--out "build.json" \
 --schema "scripts/tools/nrfconnect/nrfconnect_factory_data.schema"
 ```
 

--- a/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-app/nrfconnect/main/include/AppTask.h
@@ -34,13 +34,10 @@
 
 struct k_timer;
 struct Identify;
-class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
-    friend class AppFabricTableDelegate;
-
     static AppTask & Instance(void)
     {
         static AppTask sAppTask;

--- a/examples/all-clusters-minimal-app/nrfconnect/main/include/AppTask.h
+++ b/examples/all-clusters-minimal-app/nrfconnect/main/include/AppTask.h
@@ -34,13 +34,10 @@
 
 struct k_timer;
 struct Identify;
-class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
-    friend class AppFabricTableDelegate;
-
     static AppTask & Instance(void)
     {
         static AppTask sAppTask;

--- a/examples/light-switch-app/nrfconnect/main/include/AppTask.h
+++ b/examples/light-switch-app/nrfconnect/main/include/AppTask.h
@@ -41,13 +41,10 @@
 
 struct k_timer;
 struct Identify;
-class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
-    friend class AppFabricTableDelegate;
-
     static AppTask & Instance()
     {
         static AppTask sAppTask;

--- a/examples/lighting-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lighting-app/nrfconnect/main/include/AppTask.h
@@ -42,13 +42,10 @@
 
 struct k_timer;
 struct Identify;
-class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
-    friend class AppFabricTableDelegate;
-
     static AppTask & Instance()
     {
         static AppTask sAppTask;

--- a/examples/lock-app/nrfconnect/main/include/AppTask.h
+++ b/examples/lock-app/nrfconnect/main/include/AppTask.h
@@ -41,13 +41,10 @@
 
 struct k_timer;
 struct Identify;
-class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
-    friend class AppFabricTableDelegate;
-
     static AppTask & Instance()
     {
         static AppTask sAppTask;

--- a/examples/platform/nrfconnect/util/include/FabricTableDelegate.h
+++ b/examples/platform/nrfconnect/util/include/FabricTableDelegate.h
@@ -40,14 +40,14 @@ public:
 #ifndef CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
         static AppFabricTableDelegate sAppFabricDelegate;
         chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAppFabricDelegate);
-        k_timer_init(&sFactoryResetTimer, &OnFabricRemovedTimerCallback, nullptr);
+        k_timer_init(&sFabricRemovedTimer, &OnFabricRemovedTimerCallback, nullptr);
 #endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
     }
 
 private:
     void OnFabricRemoved(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex)
     {
-        k_timer_start(&sFactoryResetTimer, K_MSEC(CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY), K_NO_WAIT);
+        k_timer_start(&sFabricRemovedTimer, K_MSEC(CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY), K_NO_WAIT);
     }
 
     static void OnFabricRemovedTimerCallback(k_timer * timer)
@@ -84,5 +84,5 @@ private:
 #endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
     }
 
-    inline static k_timer sFactoryResetTimer;
+    inline static k_timer sFabricRemovedTimer;
 };

--- a/examples/platform/nrfconnect/util/include/FabricTableDelegate.h
+++ b/examples/platform/nrfconnect/util/include/FabricTableDelegate.h
@@ -18,8 +18,6 @@
 
 #pragma once
 
-#include "AppTask.h"
-
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 #ifdef CONFIG_CHIP_WIFI
@@ -42,36 +40,49 @@ public:
 #ifndef CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
         static AppFabricTableDelegate sAppFabricDelegate;
         chip::Server::GetInstance().GetFabricTable().AddFabricDelegate(&sAppFabricDelegate);
+        k_timer_init(&sFactoryResetTimer, &OnFabricRemovedTimerCallback, nullptr);
 #endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
     }
 
 private:
     void OnFabricRemoved(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex)
     {
+        k_timer_start(&sFactoryResetTimer, K_MSEC(CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY), K_NO_WAIT);
+    }
+
+    static void OnFabricRemovedTimerCallback(k_timer * timer)
+    {
 #ifndef CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
         if (chip::Server::GetInstance().GetFabricTable().FabricCount() == 0)
         {
-#ifdef CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
-            chip::Server::GetInstance().ScheduleFactoryReset();
-#elif defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY) || defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START)
             chip::DeviceLayer::PlatformMgr().ScheduleWork([](intptr_t) {
-                /* Erase Matter data */
+#ifdef CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
+                chip::Server::GetInstance().ScheduleFactoryReset();
+#elif defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY) || defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START)
+                // Erase Matter data
                 chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().DoFactoryReset();
-                /* Erase Network credentials and disconnect */
+                // Erase Network credentials and disconnect
                 chip::DeviceLayer::ConnectivityMgr().ErasePersistentInfo();
 #ifdef CONFIG_CHIP_WIFI
                 chip::DeviceLayer::WiFiManager::Instance().Disconnect();
                 chip::DeviceLayer::ConnectivityMgr().ClearWiFiStationProvision();
 #endif
 #ifdef CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START
-                /* Start the New BLE advertising */
-                AppEvent event;
-                event.Handler = AppTask::StartBLEAdvertisementHandler;
-                AppTask::Instance().PostEvent(event);
+                // Start the New BLE advertising
+                if (!chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled())
+                {
+                    if (CHIP_NO_ERROR == chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow())
+                    {
+                        return;
+                    }
+                }
+                ChipLogError(FabricProvisioning, "Could not start Bluetooth LE advertising");
 #endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START
-            });
 #endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
+            });
         }
 #endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
     }
+
+    inline static k_timer sFactoryResetTimer;
 };

--- a/examples/pump-app/nrfconnect/main/include/AppTask.h
+++ b/examples/pump-app/nrfconnect/main/include/AppTask.h
@@ -36,13 +36,10 @@
 #endif
 
 struct k_timer;
-class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
-    friend class AppFabricTableDelegate;
-
     static AppTask & Instance(void)
     {
         static AppTask sAppTask;

--- a/examples/pump-controller-app/nrfconnect/main/include/AppTask.h
+++ b/examples/pump-controller-app/nrfconnect/main/include/AppTask.h
@@ -36,13 +36,10 @@
 #endif
 
 struct k_timer;
-class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
-    friend class AppFabricTableDelegate;
-
     static AppTask & Instance(void)
     {
         static AppTask sAppTask;

--- a/examples/window-app/nrfconnect/main/include/AppTask.h
+++ b/examples/window-app/nrfconnect/main/include/AppTask.h
@@ -38,13 +38,10 @@
 
 struct k_timer;
 struct Identify;
-class AppFabricTableDelegate;
 
 class AppTask
 {
 public:
-    friend class AppFabricTableDelegate;
-
     static AppTask & Instance(void)
     {
         static AppTask sAppTask;


### PR DESCRIPTION
In some cases, a last fabric removal action should be delayed to avoid race conditions and allow the device to finish all currently running tasks.

To control the delay use the
CONFIG_CHIP_LAST_FABRIC_REMOVED_SCHEDULE_TIME kconfig. By default, it has been set to 500 ms.


