### PR TITLE
[nrf noup] Disabled Wi-Fi logs to save flash

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -262,6 +262,10 @@ config WPA_SUPP_NO_DEBUG
 config NRF700X_LOG_VERBOSE
     default n
 
+choice WIFI_NRF700X_LOG_LEVEL_CHOICE
+    default WIFI_NRF700X_LOG_LEVEL_OFF
+endchoice
+
 config NRF_WIFI_LOW_POWER
     default n
 


### PR DESCRIPTION
Recently some new Wi-Fi logs were enabled by default. These need to be disabled to decrease memory footprint.


