### PR TITLE
[nrf noup] Increase stability of Wi-Fi LPM operations

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -275,7 +275,7 @@ config NRF700X_RX_MAX_DATA_SIZE
     default 1280
 
 config NRF700X_MAX_TX_TOKENS
-    default 8
+    default 10
 
 config NRF700X_MAX_TX_AGGREGATION
     default 1

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -307,7 +307,7 @@ endchoice
 config CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY
 	int "After removing the last fabric wait defined time [in milliseconds] to perform an action"
 	depends on !CHIP_LAST_FABRIC_REMOVED_NONE
-	default 500
+	default 1000
 	help
 	  After removing the last fabric the device will wait for the defined time and then perform
 	  an action chosen by the CHIP_LAST_FABRIC_REMOVED_ACTION option. This schedule will allow for


### PR DESCRIPTION
This commit increases the number of TX Tokens to the previous value of 10 to prevent RPU stalls.

Additionally, it was observed that a 500ms delay before executing a factory reset is too small for certain situations on Wi-Fi. This commit also increases this delay to 1s.

I run 200 commissionings with few controlling commands on 2GHz and 5GHz Wi-Fi networks, and with included changes I have not observed permanent data stall or failing `unpair` command. Without it, I observed both.