### PR TITLE
[nrf noup] config: ncs: Fix Wi-Fi maximum transmit tokens

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -279,7 +279,7 @@ config NRF700X_RX_MAX_DATA_SIZE
     default 1280
 
 config NRF700X_MAX_TX_TOKENS
-    default 8
+    default 10
 
 config NRF700X_MAX_TX_AGGREGATION
     default 1


### PR DESCRIPTION
    Wi-Fi samples use 10 as tokens, i.e., no spare tokens at all (5 * 2 =
    10), but Matter samples use 8 which gives ( 5 * 1 + 3), so, 3 spare
    tokens which changes the traffic profile.
    
    So, match with Wi-Fi as that combination is well tested.
