### PR TITLE
[nrf fromlist] [door-lock] Fix the crash when providing null-ed user index

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -197,7 +197,7 @@ void DoorLockServer::HandleLocalLockOperationError(chip::EndpointId endpointId, 
 
     HandleWrongCodeEntry(endpointId);
 
-    ChipLogProgress(Zcl, "Handling a local Lock Operation Error: [endpoint=%d, user=%d]", endpointId, userId.Value());
+    ChipLogProgress(Zcl, "Handling a local Lock Operation Error: [endpoint=%d]", endpointId);
 }
 
 bool DoorLockServer::HandleWrongCodeEntry(chip::EndpointId endpointId)


### PR DESCRIPTION

...to the HandleLocalLockOperationError method

We cannot assume that the valid user index is provided
in case of the invalid credential.

In fact, the spec in 5.2.5.4.4 says that UserIndex SHALL be null
if there is no user id that can be determined for the given
operation source.

Signed-off-by: Marcin Kajor <marcin.kajor@nordicsemi.no>

