### PR TITLE
[nrf noup] wifi: Fix 5GHz association

### DIFF
--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -352,6 +352,7 @@ void WiFiManager::ScanResultHandler(Platform::UniquePtr<uint8_t> data)
             Instance().mWiFiParams.mParams.timeout = Instance().mHandling.mConnectionTimeout.count();
             Instance().mWiFiParams.mParams.channel = WIFI_CHANNEL_ANY;
             Instance().mWiFiParams.mRssi           = scanResult->rssi;
+            Instance().mWiFiParams.mParams.band    = WIFI_FREQ_BAND_UNKNOWN;
             Instance().mSsidFound                  = true;
         }
     }


### PR DESCRIPTION
Wi-Fi stack recently introduced a check for valid band value and the default value of 0 (memset) means only 2.4GHz, so, 5GHz Wi-Fi associations will fail.

Fix the default to Unknown to scan all supported bands.

Fixes KRKNWK-18035.
