### PR TITLE
[nrf fromtree] [nrfconnect] Removed overwriting mbedTLS configs handled by OT (#30577)

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -335,9 +335,6 @@ config MBEDTLS_ENABLE_HEAP
 config MBEDTLS_HEAP_SIZE
     default 8192
 
-config MBEDTLS_TLS_LIBRARY
-    default y
-
 config NRF_SECURITY_ADVANCED
     default y
 
@@ -354,9 +351,6 @@ config MBEDTLS_CTR_DRBG_C
     default y
 
 config MBEDTLS_CIPHER_MODE_CTR
-    default y
-
-config MBEDTLS_ECJPAKE_C
     default y
 
 config MBEDTLS_SHA256_C


### PR DESCRIPTION


Removed overwriting mbedTLS configs handled by OpenThread Kconfig:
* MBEDTLS_TLS_LIBRARY
* MBEDTLS_ECJPAKE_C

Are handled in sdk-nrf repository in `subsys/net/openthread/Kconfig` They should not be overwritten by Matter config.


(cherry picked from  https://github.com/project-chip/connectedhomeip/commit/4922ea669a2397bf19a666d3ada9e6e06adc7529)