### PR TITLE
[nrf noup] Increased Wi-Fi max data size to fix commissioning fails

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -272,12 +272,6 @@ config NRF_WIFI_LOW_POWER
 config NRF700X_RX_NUM_BUFS
     default 16
 
-config NRF700X_TX_MAX_DATA_SIZE
-    default 1280
-
-config NRF700X_RX_MAX_DATA_SIZE
-    default 1280
-
 config NRF700X_MAX_TX_TOKENS
     default 10
 


### PR DESCRIPTION
Removed custom max data size configuration, which lead to failures during commissioning with 4th or 5th controller.


