### PR TITLE
[nrf noup] Make Wi-Fi manager use Wi-Fi interface only

### DIFF
--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -207,8 +207,8 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
-    const net_if * const iface = InetUtils::GetInterface();
-    VerifyOrReturnError(iface != nullptr && iface->if_dev != nullptr, CHIP_ERROR_INTERNAL);
+    const net_if * const iface = InetUtils::GetWiFiInterface();
+    VerifyOrReturnError(iface != nullptr, CHIP_ERROR_INTERNAL);
 
     const auto linkAddrStruct = iface->if_dev->link_addr;
     memcpy(buf, linkAddrStruct.addr, linkAddrStruct.len);

--- a/src/platform/Zephyr/InetUtils.cpp
+++ b/src/platform/Zephyr/InetUtils.cpp
@@ -17,11 +17,13 @@
 
 #include "InetUtils.h"
 
+#include <zephyr/net/net_if.h>
+
 namespace chip {
 namespace DeviceLayer {
 namespace InetUtils {
 
-in6_addr ToZephyrAddr(const chip::Inet::IPAddress & address)
+in6_addr ToZephyrAddr(const Inet::IPAddress & address)
 {
     in6_addr zephyrAddr;
 
@@ -31,9 +33,14 @@ in6_addr ToZephyrAddr(const chip::Inet::IPAddress & address)
     return zephyrAddr;
 }
 
-net_if * GetInterface(chip::Inet::InterfaceId ifaceId)
+net_if * GetInterface(Inet::InterfaceId ifaceId)
 {
     return ifaceId.IsPresent() ? net_if_get_by_index(ifaceId.GetPlatformInterface()) : net_if_get_default();
+}
+
+net_if * GetWiFiInterface()
+{
+    return net_if_get_first_wifi();
 }
 
 } // namespace InetUtils

--- a/src/platform/Zephyr/InetUtils.h
+++ b/src/platform/Zephyr/InetUtils.h
@@ -24,8 +24,9 @@ namespace chip {
 namespace DeviceLayer {
 namespace InetUtils {
 
-in6_addr ToZephyrAddr(const chip::Inet::IPAddress & address);
-net_if * GetInterface(chip::Inet::InterfaceId ifaceId = chip::Inet::InterfaceId::Null());
+in6_addr ToZephyrAddr(const Inet::IPAddress & address);
+net_if * GetInterface(Inet::InterfaceId ifaceId);
+net_if * GetWiFiInterface();
 
 } // namespace InetUtils
 } // namespace DeviceLayer

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -220,6 +220,7 @@ private:
     void ResetRecoveryTime();
     System::Clock::Milliseconds32 CalculateNextRecoveryTime();
 
+    net_if * mNetIf{ nullptr };
     ConnectionParams mWiFiParams{};
     ConnectionHandling mHandling;
     wifi_iface_state mWiFiState;


### PR DESCRIPTION
Find the Wi-Fi interface at the Wi-Fi manager initialization and use that interface instead of the default interface when calling Wi-Fi management functions.
