### PR TITLE
[nrf noup] [nrfconnect] Move handler for joining/leaving mcast group

### DIFF
--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -170,8 +170,7 @@ CHIP_ERROR IPv4Bind(int socket, const IPAddress & address, uint16_t port)
 } // anonymous namespace
 
 #if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-UDPEndPointImplSockets::MulticastGroupHandler UDPEndPointImplSockets::sJoinMulticastGroupHandler;
-UDPEndPointImplSockets::MulticastGroupHandler UDPEndPointImplSockets::sLeaveMulticastGroupHandler;
+UDPEndPointImplSockets::MulticastGroupHandler UDPEndPointImplSockets::sMulticastGroupHandler;
 #endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 
 CHIP_ERROR UDPEndPointImplSockets::BindImpl(IPAddressType addressType, const IPAddress & addr, uint16_t port, InterfaceId interface)
@@ -801,10 +800,9 @@ CHIP_ERROR UDPEndPointImplSockets::IPv4JoinLeaveMulticastGroupImpl(InterfaceId a
 CHIP_ERROR UDPEndPointImplSockets::IPv6JoinLeaveMulticastGroupImpl(InterfaceId aInterfaceId, const IPAddress & aAddress, bool join)
 {
 #if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
-    MulticastGroupHandler handler = join ? sJoinMulticastGroupHandler : sLeaveMulticastGroupHandler;
-    if (handler != nullptr)
+    if (sMulticastGroupHandler != nullptr)
     {
-        return handler(aInterfaceId, aAddress);
+        return sMulticastGroupHandler(aInterfaceId, aAddress, join);
     }
 #endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 

--- a/src/inet/UDPEndPointImplSockets.h
+++ b/src/inet/UDPEndPointImplSockets.h
@@ -63,13 +63,15 @@ private:
 
 #if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 public:
-    using MulticastGroupHandler = CHIP_ERROR (*)(InterfaceId, const IPAddress &);
-    static void SetJoinMulticastGroupHandler(MulticastGroupHandler handler) { sJoinMulticastGroupHandler = handler; }
-    static void SetLeaveMulticastGroupHandler(MulticastGroupHandler handler) { sLeaveMulticastGroupHandler = handler; }
+    using MulticastGroupHandler = CHIP_ERROR (*)(InterfaceId, const IPAddress &, bool /* join */);
+
+    static void SetMulticastGroupHandler(MulticastGroupHandler handler)
+    {
+        sMulticastGroupHandler = handler;
+    }
 
 private:
-    static MulticastGroupHandler sJoinMulticastGroupHandler;
-    static MulticastGroupHandler sLeaveMulticastGroupHandler;
+    static MulticastGroupHandler sMulticastGroupHandler;
 #endif // CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 };
 

--- a/src/platform/Zephyr/ThreadStackManagerImpl.cpp
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.cpp
@@ -46,24 +46,16 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 
     ReturnErrorOnFailure(GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(instance));
 
-    UDPEndPointImplSockets::SetJoinMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
+    UDPEndPointImplSockets::SetMulticastGroupHandler([](InterfaceId, const IPAddress & address, bool join) {
         const otIp6Address otAddress = ToOpenThreadIP6Address(address);
+        const auto handler           = join ? otIp6SubscribeMulticastAddress : otIp6UnsubscribeMulticastAddress;
+        otError error;
 
         ThreadStackMgr().LockThreadStack();
-        const auto otError = otIp6SubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
+        error = handler(openthread_get_default_instance(), &otAddress);
         ThreadStackMgr().UnlockThreadStack();
 
-        return MapOpenThreadError(otError);
-    });
-
-    UDPEndPointImplSockets::SetLeaveMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
-        const otIp6Address otAddress = ToOpenThreadIP6Address(address);
-
-        ThreadStackMgr().LockThreadStack();
-        const auto otError = otIp6UnsubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
-        ThreadStackMgr().UnlockThreadStack();
-
-        return MapOpenThreadError(otError);
+        return MapOpenThreadError(error);
     });
 
     return CHIP_NO_ERROR;

--- a/src/platform/Zephyr/ThreadStackManagerImpl.cpp
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.cpp
@@ -27,16 +27,13 @@
 #include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp>
 #include <platform/Zephyr/ThreadStackManagerImpl.h>
 
-#include <inet/UDPEndPointImpl.h>
 #include <lib/support/CodeUtils.h>
-#include <platform/OpenThread/OpenThreadUtils.h>
 #include <platform/ThreadStackManager.h>
 
 namespace chip {
 namespace DeviceLayer {
 
 using namespace ::chip::DeviceLayer::Internal;
-using namespace ::chip::Inet;
 
 ThreadStackManagerImpl ThreadStackManagerImpl::sInstance;
 
@@ -45,18 +42,6 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
     otInstance * const instance = openthread_get_default_instance();
 
     ReturnErrorOnFailure(GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(instance));
-
-    UDPEndPointImplSockets::SetMulticastGroupHandler([](InterfaceId, const IPAddress & address, bool join) {
-        const otIp6Address otAddress = ToOpenThreadIP6Address(address);
-        const auto handler           = join ? otIp6SubscribeMulticastAddress : otIp6UnsubscribeMulticastAddress;
-        otError error;
-
-        ThreadStackMgr().LockThreadStack();
-        error = handler(openthread_get_default_instance(), &otAddress);
-        ThreadStackMgr().UnlockThreadStack();
-
-        return MapOpenThreadError(error);
-    });
 
     return CHIP_NO_ERROR;
 }

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -28,6 +28,8 @@ static_library("nrfconnect") {
     "../Zephyr/ConfigurationManagerImpl.cpp",
     "../Zephyr/DiagnosticDataProviderImpl.cpp",
     "../Zephyr/DiagnosticDataProviderImpl.h",
+    "../Zephyr/InetUtils.cpp",
+    "../Zephyr/InetUtils.h",
     "../Zephyr/KeyValueStoreManagerImpl.cpp",
     "../Zephyr/Logging.cpp",
     "../Zephyr/PlatformManagerImpl.cpp",
@@ -96,8 +98,6 @@ static_library("nrfconnect") {
 
   if (chip_enable_wifi) {
     sources += [
-      "../Zephyr/InetUtils.cpp",
-      "../Zephyr/InetUtils.h",
       "OTAImageProcessorImplWiFi.h",
       "wifi/ConnectivityManagerImplWiFi.cpp",
       "wifi/ConnectivityManagerImplWiFi.h",

--- a/src/platform/nrfconnect/ConnectivityManagerImpl.cpp
+++ b/src/platform/nrfconnect/ConnectivityManagerImpl.cpp
@@ -17,11 +17,12 @@
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
-#include <platform/ConnectivityManager.h>
-#include <platform/internal/BLEManager.h>
-
+#include <inet/UDPEndPointImplSockets.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/ConnectivityManager.h>
+#include <platform/internal/BLEManager.h>
+#include <platform/Zephyr/InetUtils.h>
 
 #include <platform/internal/GenericConnectivityManagerImpl_UDP.ipp>
 
@@ -35,14 +36,56 @@
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/internal/GenericConnectivityManagerImpl_Thread.ipp>
+#include <platform/OpenThread/OpenThreadUtils.h>
 #endif
 
-using namespace ::chip;
-using namespace ::chip::TLV;
+using namespace ::chip::Inet;
 using namespace ::chip::DeviceLayer::Internal;
 
 namespace chip {
 namespace DeviceLayer {
+
+namespace {
+CHIP_ERROR JoinLeaveMulticastGroup(net_if * iface, const Inet::IPAddress & address, bool join)
+{
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    if (net_if_l2(iface) == &NET_L2_GET_NAME(OPENTHREAD))
+    {
+        const otIp6Address otAddress = ToOpenThreadIP6Address(address);
+        const auto handler           = join ? otIp6SubscribeMulticastAddress : otIp6UnsubscribeMulticastAddress;
+        otError error;
+
+        ThreadStackMgr().LockThreadStack();
+        error = handler(openthread_get_default_instance(), &otAddress);
+        ThreadStackMgr().UnlockThreadStack();
+
+        return MapOpenThreadError(error);
+    }
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    // The following code should also be valid for other interface types, such as Ethernet,
+    // but they are not officially supported, so for now enable it for Wi-Fi only.
+    const in6_addr in6Addr = InetUtils::ToZephyrAddr(address);
+
+    if (join)
+    {
+        net_if_mcast_addr * maddr = net_if_ipv6_maddr_add(iface, &in6Addr);
+
+        if (maddr && !net_if_ipv6_maddr_is_joined(maddr))
+        {
+            net_if_ipv6_maddr_join(iface, maddr);
+        }
+    }
+    else
+    {
+        VerifyOrReturnError(net_if_ipv6_maddr_rm(iface, &in6Addr), CHIP_ERROR_INVALID_ADDRESS);
+    }
+#endif
+
+    return CHIP_NO_ERROR;
+}
+} // namespace
 
 ConnectivityManagerImpl ConnectivityManagerImpl::sInstance;
 
@@ -54,6 +97,25 @@ CHIP_ERROR ConnectivityManagerImpl::_Init()
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     ReturnErrorOnFailure(InitWiFi());
 #endif
+
+    UDPEndPointImplSockets::SetMulticastGroupHandler([](InterfaceId interfaceId, const IPAddress & address, bool join) {
+        if (interfaceId.IsPresent())
+        {
+            net_if * iface = InetUtils::GetInterface(interfaceId);
+            VerifyOrReturnError(iface != nullptr, INET_ERROR_UNKNOWN_INTERFACE);
+
+            return JoinLeaveMulticastGroup(iface, address, join);
+        }
+
+        // If the interface is not specified, join or leave the multicast group on all interfaces.
+        for (int i = 1; net_if * iface = net_if_get_by_index(i); i++)
+        {
+            ReturnErrorOnFailure(JoinLeaveMulticastGroup(iface, address, join));
+        }
+
+        return CHIP_NO_ERROR;
+    });
+
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -23,8 +23,6 @@
 #include "WiFiManager.h"
 
 #include <crypto/RandUtils.h>
-#include <inet/InetInterface.h>
-#include <inet/UDPEndPointImplSockets.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/Zephyr/InetUtils.h>
@@ -161,30 +159,6 @@ CHIP_ERROR WiFiManager::Init()
     mNetIf = InetUtils::GetWiFiInterface();
     VerifyOrReturnError(mNetIf != nullptr, INET_ERROR_UNKNOWN_INTERFACE);
 
-    // TODO: consider moving these to ConnectivityManagerImpl to be prepared for handling multiple interfaces on a single device.
-    Inet::UDPEndPointImplSockets::SetMulticastGroupHandler(
-        [](Inet::InterfaceId interfaceId, const Inet::IPAddress & address, bool join) {
-            const in6_addr addr = InetUtils::ToZephyrAddr(address);
-            net_if * iface      = InetUtils::GetInterface(interfaceId);
-            VerifyOrReturnError(iface != nullptr, INET_ERROR_UNKNOWN_INTERFACE);
-
-            if (join)
-            {
-                net_if_mcast_addr * maddr = net_if_ipv6_maddr_add(iface, &addr);
-
-                if (maddr && !net_if_ipv6_maddr_is_joined(maddr) && !net_ipv6_is_addr_mcast_link_all_nodes(&addr))
-                {
-                    net_if_ipv6_maddr_join(iface, maddr);
-                }
-            }
-            else
-            {
-                VerifyOrReturnError(net_ipv6_is_addr_mcast_link_all_nodes(&addr) || net_if_ipv6_maddr_rm(iface, &addr),
-                                    CHIP_ERROR_INVALID_ADDRESS);
-            }
-
-            return CHIP_NO_ERROR;
-        });
 
     net_mgmt_init_event_callback(&mWiFiMgmtClbk, WifiMgmtEventHandler, kWifiManagementEvents);
     net_mgmt_add_event_callback(&mWiFiMgmtClbk);

--- a/src/platform/telink/ThreadStackManagerImpl.cpp
+++ b/src/platform/telink/ThreadStackManagerImpl.cpp
@@ -48,24 +48,16 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 
     ReturnErrorOnFailure(GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(instance));
 
-    UDPEndPointImplSockets::SetJoinMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
+    UDPEndPointImplSockets::SetMulticastGroupHandler([](InterfaceId, const IPAddress & address, bool join) {
         const otIp6Address otAddress = ToOpenThreadIP6Address(address);
+        const auto handler           = join ? otIp6SubscribeMulticastAddress : otIp6UnsubscribeMulticastAddress;
+        otError error;
 
         ThreadStackMgr().LockThreadStack();
-        const auto otError = otIp6SubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
+        error = handler(openthread_get_default_instance(), &otAddress);
         ThreadStackMgr().UnlockThreadStack();
 
-        return MapOpenThreadError(otError);
-    });
-
-    UDPEndPointImplSockets::SetLeaveMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
-        const otIp6Address otAddress = ToOpenThreadIP6Address(address);
-
-        ThreadStackMgr().LockThreadStack();
-        const auto otError = otIp6UnsubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
-        ThreadStackMgr().UnlockThreadStack();
-
-        return MapOpenThreadError(otError);
+        return MapOpenThreadError(error);
     });
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
Move the platform handler for joining and leaving a multicast group to ConnectivityManagerImpl to support Matter stack on a system with multiple network interfaces (Thread + Wi-Fi). Previously, both Thread and WiFi would try to register their handler but only one of them would win.