### PR TITLE
[nrf noup] WPA supplicant advanced features disabled

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -260,6 +260,10 @@ config NRF700X_MAX_TX_TOKENS
 config NRF700X_MAX_TX_AGGREGATION
     default 1
 
+# it saves 25kB of FLASH
+config WPA_SUPP_ADVANCED_FEATURES
+    default n
+
 endif # CHIP_WIFI
 
 # ==============================================================================


### PR DESCRIPTION
This commit disables WPA_SUPP_ADVANCED_FEATURES. This change gives 25k free space of wifi app.