### PR TITLE
[nrf noup] wifi: avoid unwanted connect request

### DIFF
--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -397,6 +397,7 @@ void WiFiManager::ScanDoneHandler(Platform::UniquePtr<uint8_t> data)
                 ChipLogProgress(DeviceLayer, "Starting connection recover: re-scanning... (next attempt in %d ms)",
                                 currentTimeout.count());
                 DeviceLayer::SystemLayer().StartTimer(currentTimeout, Recover, nullptr);
+                return;
             }
 
             Instance().mWiFiState = WIFI_STATE_ASSOCIATING;


### PR DESCRIPTION
It's pointless to issue a connect request in case no valid SSID has been found.

I may cause the commissioning to fail when the SSID is not found at the first try, because without the `return` we go on and end up with the Connect() call that does not make sense and triggers a callback that deceptively informs Matter controller that the WiFiNetworkEnable commissioning step failed.