### PR TITLE
[nrf fromlist] [app] Fix DeferredAttributePersister memory leak

### DIFF
--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -462,6 +462,13 @@ config CHIP_MALLOC_SYS_HEAP_WATERMARKS_SUPPORT
 	  Enables support for getting current heap high watermark and resetting 
 	  watermarks. 
 
+config CHIP_MALLOC_SYS_HEAP_DEBUG
+	bool "Log every allocated or freed memory block"
+	help
+	  Enables debug logs printed whenever a heap memory block is allocated or
+	  freed. The logs can be used to trace the source of memory leaks in the
+	  application.
+
 endif
 
 module = MATTER

--- a/src/app/DeferredAttributePersistenceProvider.cpp
+++ b/src/app/DeferredAttributePersistenceProvider.cpp
@@ -39,7 +39,7 @@ void DeferredAttribute::Flush(AttributePersistenceProvider & persister)
 {
     VerifyOrReturn(IsArmed());
     persister.WriteValue(mPath, ByteSpan(mValue.Get(), mValue.AllocatedSize()));
-    mValue.Release();
+    mValue.Free();
 }
 
 CHIP_ERROR DeferredAttributePersistenceProvider::WriteValue(const ConcreteAttributePath & aPath, const ByteSpan & aValue)

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -1141,8 +1141,8 @@ private:
             //
             callback->AdoptReadClient(std::move(readClient));
             callback.release();
-            attributePathParamsList.Release();
-            eventPathParamsList.Release();
+            IgnoreUnusedVariable(attributePathParamsList.Release());
+            IgnoreUnusedVariable(eventPathParamsList.Release());
             return err;
         });
     std::move(*bridge).DispatchAction(self);

--- a/src/lib/support/ScopedBuffer.h
+++ b/src/lib/support/ScopedBuffer.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <lib/support/CHIPMem.h>
+#include <lib/support/CodeUtils.h>
 
 #include <type_traits>
 #include <utility>
@@ -84,10 +85,11 @@ protected:
     const void * Ptr() const { return mBuffer; }
 
     /**
-     * Releases the undelying buffer. Buffer stops being managed and will not be
-     * auto-freed.
+     * Releases the underlying buffer.
+     *
+     * The buffer stops being managed and will not be auto-freed.
      */
-    void * Release()
+    CHECK_RETURN_VALUE void * Release()
     {
         void * buffer = mBuffer;
         mBuffer       = nullptr;
@@ -139,13 +141,18 @@ public:
 
     static_assert(std::is_trivially_destructible<T>::value, "Destructors won't get run");
 
-    inline T * Get() { return static_cast<T *>(Base::Ptr()); }
-    inline T & operator[](size_t index) { return Get()[index]; }
+    T * Get() { return static_cast<T *>(Base::Ptr()); }
+    T & operator[](size_t index) { return Get()[index]; }
 
-    inline const T * Get() const { return static_cast<const T *>(Base::Ptr()); }
-    inline const T & operator[](size_t index) const { return Get()[index]; }
+    const T * Get() const { return static_cast<const T *>(Base::Ptr()); }
+    const T & operator[](size_t index) const { return Get()[index]; }
 
-    inline T * Release() { return static_cast<T *>(Base::Release()); }
+    /**
+     * Releases the underlying buffer.
+     *
+     * The buffer stops being managed and will not be auto-freed.
+     */
+    CHECK_RETURN_VALUE T * Release() { return static_cast<T *>(Base::Release()); }
 
     ScopedMemoryBuffer & Calloc(size_t elementCount)
     {
@@ -222,7 +229,12 @@ public:
         ScopedMemoryBuffer<T>::Free();
     }
 
-    T * Release()
+    /**
+     * Releases the underlying buffer.
+     *
+     * The buffer stops being managed and will not be auto-freed.
+     */
+    CHECK_RETURN_VALUE T * Release()
     {
         T * buffer = ScopedMemoryBuffer<T>::Release();
         mCount     = 0;


### PR DESCRIPTION
ScopedMemoryBuffer's Release() method was used instead of Free(). Add CHECK_RETURN_VALUE annotation to the Release() method to prevent from making such a mistake in the future.

Also, add a mechanism to trace memory allocations.
