### PR TITLE
[nrf noup] [zephyr] Fix CHIPDevicePlatformEvent.h include dependencies

### DIFF
--- a/src/platform/Zephyr/CHIPDevicePlatformEvent.h
+++ b/src/platform/Zephyr/CHIPDevicePlatformEvent.h
@@ -23,7 +23,7 @@
 
 #pragma once
 
-#include <platform/CHIPDeviceEvent.h>
+#include <system/SystemPacketBuffer.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 


### PR DESCRIPTION
Currently the CHIPDevicePlatformEvent depends on the SystemPacketBuffer which is included in the
CHIPDeviceEvent.h too late.

The problem is silently worked around in the application when the <platform/PlatformManager.h> include is preceded by other headers that pull in SystemPacketBuffer.h, but we need a proper fix.
