### PR TITLE
[nrf noup] Lock thread stack before factory reset

### DIFF
--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -40,6 +40,10 @@
 #include <zephyr/settings/settings.h>
 #endif
 
+#ifdef CONFIG_NET_L2_OPENTHREAD
+#include <platform/ThreadStackManager.h>
+#endif 
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -176,6 +180,11 @@ void ConfigurationManagerImpl::RunConfigUnitTest(void)
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     ChipLogProgress(DeviceLayer, "Performing factory reset");
+
+// Lock the Thread stack to avoid unwanted interaction with settings NVS during factory reset.
+#ifdef CONFIG_NET_L2_OPENTHREAD
+    ThreadStackMgr().LockThreadStack();
+#endif
 
 #ifdef CONFIG_CHIP_FACTORY_RESET_ERASE_NVS
     void * storage = nullptr;


### PR DESCRIPTION
This commit fix a problem with thread activity interrupting factory reset. This activity used to led to “Factory reset fail: -6”. Writing to cleared nvm flash pages caused the problem.

