### PR TITLE
[nrf noup] nrfconnect/telink: Adapt to zcbor 0.8.1

### DIFF
--- a/src/platform/nrfconnect/FactoryDataParser.c
+++ b/src/platform/nrfconnect/FactoryDataParser.c
@@ -92,7 +92,7 @@ bool FindUserDataEntry(struct FactoryData * factoryData, const char * entry, voi
         return false;
     }
 
-    ZCBOR_STATE_D(states, MAX_FACTORY_DATA_NESTING_LEVEL - 1, factoryData->user.data, factoryData->user.len, 1);
+    ZCBOR_STATE_D(states, MAX_FACTORY_DATA_NESTING_LEVEL - 1, factoryData->user.data, factoryData->user.len, 1, 0);
 
     bool res      = zcbor_map_start_decode(states);
     bool keyFound = false;
@@ -130,7 +130,7 @@ bool ParseFactoryData(uint8_t * buffer, uint16_t bufferSize, struct FactoryData 
     }
 
     memset(factoryData, 0, sizeof(*factoryData));
-    ZCBOR_STATE_D(states, MAX_FACTORY_DATA_NESTING_LEVEL, buffer, bufferSize, 1);
+    ZCBOR_STATE_D(states, MAX_FACTORY_DATA_NESTING_LEVEL, buffer, bufferSize, 1, 0);
 
     bool res = zcbor_map_start_decode(states);
     struct zcbor_string currentString;

--- a/src/platform/telink/FactoryDataParser.c
+++ b/src/platform/telink/FactoryDataParser.c
@@ -43,7 +43,7 @@ static inline bool uint16_decode(zcbor_state_t * states, uint16_t * value)
 bool ParseFactoryData(uint8_t * buffer, uint16_t bufferSize, struct FactoryData * factoryData)
 {
     memset(factoryData, 0, sizeof(*factoryData));
-    ZCBOR_STATE_D(states, MAX_FACTORY_DATA_NESTING_LEVEL, buffer, bufferSize, 1);
+    ZCBOR_STATE_D(states, MAX_FACTORY_DATA_NESTING_LEVEL, buffer, bufferSize, 1, 0);
 
     bool res = zcbor_map_start_decode(states);
     struct zcbor_string currentString;


### PR DESCRIPTION
New parameter to ZCBOR_STATE_D()