### PR TITLE
[nrf noup] Update Mbed TLS config file defines

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -67,9 +67,8 @@ if (CONFIG_NRF_SECURITY)
         zephyr_include_directories($<TARGET_PROPERTY:platform_cc3xx,INTERFACE_INCLUDE_DIRECTORIES>)
     endif()
     matter_add_flags(-DMBEDTLS_CONFIG_FILE=<nrf-config.h>)
-    if(CONFIG_CHIP_CRYPTO_PSA)
-        matter_add_flags(-DMBEDTLS_USER_CONFIG_FILE=<nrf-config-user.h>)
-    endif()
+    matter_add_flags(-DMBEDTLS_PSA_CRYPTO_CONFIG_FILE=<nrf-psa-crypto-want-config.h>)
+    matter_add_flags(-DMBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE=<nrf-psa-crypto-config.h>)
 elseif(CONFIG_MBEDTLS)
     zephyr_include_directories($<TARGET_PROPERTY:mbedTLS,INTERFACE_INCLUDE_DIRECTORIES>)
     zephyr_compile_definitions($<TARGET_PROPERTY:mbedTLS,INTERFACE_COMPILE_DEFINITIONS>)
@@ -89,7 +88,7 @@ matter_add_cxxflags(${ZEPHYR_GNU_CPP_STD})
 # Set up custom OpenThread configuration
 
 if (CONFIG_CHIP_OPENTHREAD_CONFIG)
-    get_filename_component(CHIP_OPENTHREAD_CONFIG 
+    get_filename_component(CHIP_OPENTHREAD_CONFIG
         ${CONFIG_CHIP_OPENTHREAD_CONFIG}
         REALPATH
         BASE_DIR ${CMAKE_SOURCE_DIR}

--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -341,6 +341,9 @@ config MBEDTLS_SHA256_C
 config MBEDTLS_PK_C
     default y
 
+config MBEDTLS_PKCS5_C
+    default y
+
 config MBEDTLS_PK_WRITE_C
     default y
 


### PR DESCRIPTION
MBEDTLS_USER_CONFIG_FILE has been replaced with MBEDTLS_PSA_CRYPTO_CONFIG_FILE and MBEDTLS_PSA_CRYPTO_USER_CONFIG_FILE. This commit updates Matter's CMakeLists to reflect this.


Needed for upmerge https://github.com/nrfconnect/sdk-nrf/pull/13662