### PR TITLE
[nrf noup] Align heap configuration to Wi-Fi needs

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -55,8 +55,12 @@ config HEAP_MEM_POOL_SIZE
     default 80000 if CHIP_WIFI
 
 config CHIP_MALLOC_SYS_HEAP_SIZE
-    default 28672 if CHIP_WIFI
+    default 30720 if CHIP_WIFI
     default 8192 if NET_L2_OPENTHREAD
+
+# We use sys_heap based allocators, so make sure we don't reserve unused libc heap anyway
+config COMMON_LIBC_MALLOC_ARENA_SIZE
+    default -1
 
 config NVS_LOOKUP_CACHE_SIZE
     default 512


### PR DESCRIPTION
Force the default value of the libc heap to remain dynamic instead of propagating 30k of pre-reserved pool from wpa_supplicat. Also align the sys_heap pool to match the default Wi-Fi heap size.

This shall be pulled a part of https://github.com/nrfconnect/sdk-nrf/pull/13931.

