### PR TITLE
Fixed PlatformMgr().Shutdown() for NRF53

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.ipp
@@ -42,6 +42,10 @@
 #include <psa/crypto.h>
 #endif
 
+#if CONFIG_SOC_NRF5340_CPUAPP
+    #include <hal/nrf_reset.h>
+#endif
+
 #define DEFAULT_MIN_SLEEP_PERIOD (60 * 60 * 24 * 30) // Month [sec]
 
 namespace chip {
@@ -124,6 +128,10 @@ template <class ImplClass>
 void GenericPlatformManagerImpl_Zephyr<ImplClass>::_Shutdown(void)
 {
 #ifdef CONFIG_REBOOT
+    // Reset the network core first to avoid a hard fault because of the communication broken between cores.
+    #if CONFIG_SOC_NRF5340_CPUAPP
+    nrf_reset_network_force_off(NRF_RESET, false);
+    #endif
     sys_reboot(SYS_REBOOT_WARM);
 #else
     // NB: When this is implemented, |mInitialized| can be removed.


### PR DESCRIPTION
Linked to my case on the DevZone https://devzone.nordicsemi.com/f/nordic-q-a/108101/device-crash-when-doing-a-software-reset

When calling the function `PlatformMgr().Shutdown();` (intentionally, or through a factory reset) a Hard Fault happens because the communication is broken/not in sync anymore between the App and Net cores of the NRF5340. My fix proposes to first reset the network core then reset the application core.
