### PR TITLE
[nrf noup] Adapt Matter SDK to te WiFi FW patch on external flash

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -206,7 +206,14 @@ config BOOT_IMAGE_ACCESS_HOOKS
     default y if SOC_SERIES_NRF53X
 
 config UPDATEABLE_IMAGE_NUMBER
+    default 3 if NRF_WIFI_PATCHES_EXT_FLASH_STORE
     default 2 if SOC_SERIES_NRF53X
+
+config DFU_MULTI_IMAGE_MAX_IMAGE_COUNT
+    default 3 if NRF_WIFI_PATCHES_EXT_FLASH_STORE
+
+config NRF_WIFI_FW_PATCH_DFU
+    default y if NRF_WIFI_PATCHES_EXT_FLASH_STORE
 
 # ==============================================================================
 # OpenThread configuration


### PR DESCRIPTION
This commit sets the default kconfigs if the WiFi FW patch on external flash is enabled.

This is not the final solution, for now for testing purposes only.