### PR TITLE
[nrf fromlist][nrfconnect] Refactor of the factory data support

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -206,6 +206,11 @@ choice CHIP_FACTORY_DATA_CERT_SOURCE
 
 endchoice
 
+config CHIP_FACTORY_DATA_GENERATE_CD
+	bool "Generates Certification Declaration to the output build directory"
+	help
+	  Generates the new Certification Declaration and stores it to the output build directory.
+
 if CHIP_FACTORY_DATA_CERT_SOURCE_USER
 
 config CHIP_FACTORY_DATA_USER_CERTS_DAC_CERT
@@ -230,6 +235,7 @@ endif # CHIP_FACTORY_DATA_CERT_SOURCE_USER
 # Configs for SPAKE2+ generation
 config CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER
 	bool "Generate SPAKE2+ verifier"
+	default y
 	help
 	  Enables the generation of the SPAKE2+ verifier for the configured SPAKE2+
 	  passcode, iteration count and salt.


### PR DESCRIPTION
Refactored Factory Data Support:

- Added some useful tips to the Factory Data Guide.
- The SPAKE2+ verifier is now generated by default with each build.
- The Test Certification Declaration can now be generated separately and no longer requires the generation of the DAC and PAI certificates.
- The Rotating Device ID Unique ID can be used and generated only if the CONFIG_CHIP_ROTATING_DEVICE_ID is set to 'y'.
