### PR TITLE
[nrf noup] [nrfconnect] [zephyr] Disable synchronous printk

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -425,8 +425,10 @@ config LOG_DEFAULT_LEVEL
 config CHIP_LOG_SIZE_OPTIMIZATION
     default y
 
+# disable synchronous printk to avoid blocking IRQs which
+# may affect time sensitive components
 config PRINTK_SYNC
-    default y
+    default n
 
 endif # LOG
 

--- a/config/zephyr/chip-module/Kconfig.defaults
+++ b/config/zephyr/chip-module/Kconfig.defaults
@@ -40,9 +40,11 @@ config LOG_DEFAULT_LEVEL
 
 endif
 
+# disable synchronous printk to avoid blocking IRQs which
+# may affect time sensitive components
 config PRINTK_SYNC
 	bool
-	default y
+	default n
 
 config ASSERT
 	bool


### PR DESCRIPTION
Disable synchronous printk to avoid blocking IRQs which may affect time sensitive components (like 15.4 radio).

