### PR TITLE
Revert "[nrf fromlist][nrfconnect] Add checking of Wi-Fi supplicant and Interface"

### DIFF
--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -144,33 +144,6 @@ const Map<uint32_t, WiFiManager::NetEventHandler, 5> WiFiManager::sEventHandlerM
     { NET_EVENT_WIFI_DISCONNECT_COMPLETE, WiFiManager::DisconnectHandler },
 });
 
-void WiFiManager::WiFiSupplicantEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface)
-{
-    switch (mgmtEvent)
-    {
-    case NET_EVENT_WPA_SUPP_READY:
-        Instance().mSupplicantReady = true;
-        break;
-    case NET_EVENT_WPA_SUPP_NOT_READY:
-        Instance().mSupplicantReady = false;
-        break;
-    case NET_EVENT_WPA_SUPP_IFACE_ADDED:
-        Instance().mInterfaceUp = true;
-        break;
-    case NET_EVENT_WPA_SUPP_IFACE_REMOVED:
-        Instance().mInterfaceUp = false;
-        break;
-    default:
-        break;
-    }
-
-    if (Instance().mSupplicantReady && Instance().mInterfaceUp)
-    {
-        // In this case the Supplicant and Interface is fully ready.
-        DeviceLayer::SystemLayer().CancelTimer(SupplicantInitTimeout, nullptr);
-    }
-}
-
 void WiFiManager::WifiMgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface)
 {
     if (iface == Instance().mNetIf)
@@ -197,16 +170,11 @@ CHIP_ERROR WiFiManager::Init()
 
     net_mgmt_init_event_callback(&mWiFiMgmtClbk, WifiMgmtEventHandler, kWifiManagementEvents);
     net_mgmt_init_event_callback(&mIPv6MgmtClbk, IPv6MgmtEventHandler, kIPv6ManagementEvents);
-    net_mgmt_init_event_callback(&mSuppMgmtClbk, WiFiSupplicantEventHandler, kSupplicantEvents);
 
     net_mgmt_add_event_callback(&mWiFiMgmtClbk);
     net_mgmt_add_event_callback(&mIPv6MgmtClbk);
-    net_mgmt_add_event_callback(&mSuppMgmtClbk);
 
-    // Set the timer and wait for the WiFi supplicant and interface ready.
-    DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(kSupplicantReadyTimeoutMs), SupplicantInitTimeout, nullptr);
-
-    ChipLogDetail(DeviceLayer, "WiFiManager initialization requested");
+    ChipLogDetail(DeviceLayer, "WiFiManager has been initialized");
 
     return CHIP_NO_ERROR;
 }
@@ -618,14 +586,6 @@ CHIP_ERROR WiFiManager::SetLowPowerMode(bool onoff)
 
     ChipLogDetail(DeviceLayer, "Low power mode is already in requested state [%d]", onoff);
     return CHIP_NO_ERROR;
-}
-
-void WiFiManager::SupplicantInitTimeout(System::Layer * layer, void * param)
-{
-    ChipLogError(DeviceLayer, "Wi-Fi supplicant and interface have not been initialized!");
-    // Wi-Fi driver must be initialized within the given timeout, when it is still not ready, do not to allow any further
-    // operations.
-    VerifyOrDie(Instance().mSupplicantReady && Instance().mInterfaceUp);
 }
 
 } // namespace DeviceLayer

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -33,7 +33,6 @@
 
 extern "C" {
 #include <src/utils/common.h>
-#include <supp_events.h>
 #include <wpa_supplicant/wpa_supplicant_i.h>
 }
 
@@ -174,7 +173,6 @@ public:
     static constexpr uint32_t kConnectionRecoveryMaxIntervalMs     = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_MAXIMUM_INTERVAL;
     static constexpr uint32_t kConnectionRecoveryJitterMs          = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_JITTER;
     static constexpr uint32_t kConnectionRecoveryMaxRetries        = CONFIG_CHIP_WIFI_CONNECTION_RECOVERY_MAX_RETRIES_NUMBER;
-    static constexpr uint32_t kSupplicantReadyTimeoutMs            = 500;
 
     CHIP_ERROR Init();
     CHIP_ERROR Scan(const ByteSpan & ssid, ScanResultCallback resultCallback, ScanDoneCallback doneCallback,
@@ -202,13 +200,9 @@ private:
 
     constexpr static uint32_t kIPv6ManagementEvents = NET_EVENT_IPV6_ADDR_ADD | NET_EVENT_IPV6_ADDR_DEL;
 
-    constexpr static uint32_t kSupplicantEvents = NET_EVENT_WPA_SUPP_READY | NET_EVENT_WPA_SUPP_CMD_NOT_READY |
-        NET_EVENT_WPA_SUPP_IFACE_ADDED | NET_EVENT_WPA_SUPP_IFACE_REMOVED;
-
     // Event handling
     static void WifiMgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface);
     static void IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface);
-    static void WiFiSupplicantEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface);
     static void ScanResultHandler(Platform::UniquePtr<uint8_t> data);
     static void ScanDoneHandler(Platform::UniquePtr<uint8_t> data);
     static void ConnectHandler(Platform::UniquePtr<uint8_t> data);
@@ -227,13 +221,9 @@ private:
     // To avoid frequent recovery attempts when the signal to an access point is poor quality
     // The connection recovery interval will be cleared after the defined delay in kConnectionRecoveryDelayToReset.
     static void Recover(System::Layer * layer, void * param);
-    static void SupplicantInitTimeout(System::Layer * layer, void * param);
     void ResetRecoveryTime();
     System::Clock::Milliseconds32 CalculateNextRecoveryTime();
 
-    bool mSupplicantReady{ false };
-    bool mInterfaceUp{ false };
-    bool mSupplicantInitTimeoutElapsed{ false };
     net_if * mNetIf{ nullptr };
     ConnectionParams mWiFiParams{};
     ConnectionHandling mHandling;
@@ -241,7 +231,6 @@ private:
     wifi_iface_state mCachedWiFiState;
     net_mgmt_event_callback mWiFiMgmtClbk{};
     net_mgmt_event_callback mIPv6MgmtClbk{};
-    net_mgmt_event_callback mSuppMgmtClbk{};
     ScanResultCallback mScanResultCallback{ nullptr };
     ScanDoneCallback mScanDoneCallback{ nullptr };
     WiFiNetwork mWantedNetwork{};


### PR DESCRIPTION
The previous commit has been merged too fast and caused regression on nightly tests.
We decided to not check the interfaces.

This reverts commit 324ff7699e65c2120af6a6c665b6ccf63cda71d9.


