### PR TITLE
[nrf fromtree] Clear srp implementation

### DIFF
--- a/src/include/platform/ThreadStackManager.h
+++ b/src/include/platform/ThreadStackManager.h
@@ -121,6 +121,26 @@ public:
     CHIP_ERROR RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR InvalidateAllSrpServices(); ///< Mark all SRP services as invalid
     CHIP_ERROR RemoveInvalidSrpServices(); ///< Remove SRP services marked as invalid
+
+    /*
+     * @brief Utility function to clear all thread SRP host and services established between the SRP server and client.
+     * It is expected that a transaction is done between the SRP server and client so the clear request is applied on both ends
+     *
+     * A generic implementation is provided in `GenericThreadStackManagerImpl_OpenThread` with the SoC OT stack
+     */
+    CHIP_ERROR ClearAllSrpHostAndServices();
+
+    /*
+     * @brief Used to synchronize on the SRP server response confirming the clearing of the host and service entries
+     * Should be called in ClearAllSrpHostAndServices once the request is sent.
+     */
+    void WaitOnSrpClearAllComplete();
+
+    /*
+     * @brief Notify that the SRP server confirmed the clearing of the host and service entries
+     * Should be called in the SRP Client set callback in the removal confirmation.
+     */
+    void NotifySrpClearAllComplete();
     CHIP_ERROR SetupSrpHost(const char * aHostName);
     CHIP_ERROR ClearSrpHost(const char * aHostName);
     CHIP_ERROR SetSrpDnsCallbacks(DnsAsyncReturnCallback aInitCallback, DnsAsyncReturnCallback aErrorCallback, void * aContext);
@@ -288,6 +308,21 @@ inline CHIP_ERROR ThreadStackManager::InvalidateAllSrpServices()
 inline CHIP_ERROR ThreadStackManager::RemoveInvalidSrpServices()
 {
     return static_cast<ImplClass *>(this)->_RemoveInvalidSrpServices();
+}
+
+inline CHIP_ERROR ThreadStackManager::ClearAllSrpHostAndServices()
+{
+    return static_cast<ImplClass *>(this)->_ClearAllSrpHostAndServices();
+}
+
+inline void ThreadStackManager::WaitOnSrpClearAllComplete()
+{
+    return static_cast<ImplClass *>(this)->_WaitOnSrpClearAllComplete();
+}
+
+inline void ThreadStackManager::NotifySrpClearAllComplete()
+{
+    return static_cast<ImplClass *>(this)->_NotifySrpClearAllComplete();
 }
 
 inline CHIP_ERROR ThreadStackManager::SetupSrpHost(const char * aHostName)

--- a/src/platform/ESP32/ThreadStackManagerImpl.h
+++ b/src/platform/ESP32/ThreadStackManagerImpl.h
@@ -68,10 +68,21 @@ protected:
     void _OnCHIPoBLEAdvertisingStart();
     void _OnCHIPoBLEAdvertisingStop();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete();
+    void _NotifySrpClearAllComplete();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    // ===== Methods that override the GenericThreadStackMa
+
 private:
     friend ThreadStackManager & ::chip::DeviceLayer::ThreadStackMgr(void);
     friend ThreadStackManagerImpl & ::chip::DeviceLayer::ThreadStackMgrImpl(void);
     static ThreadStackManagerImpl sInstance;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    TaskHandle_t mSrpClearAllRequester = nullptr;
+#endif
+
     ThreadStackManagerImpl() = default;
 };
 

--- a/src/platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.h
+++ b/src/platform/FreeRTOS/GenericThreadStackManagerImpl_FreeRTOS.h
@@ -64,6 +64,10 @@ protected:
     bool _TryLockThreadStack(void);
     void _UnlockThreadStack(void);
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete();
+    void _NotifySrpClearAllComplete();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     // ===== Members available to the implementation subclass.
 
     SemaphoreHandle_t mThreadStackLock;
@@ -87,6 +91,10 @@ private:
 
 #if defined(CHIP_CONFIG_FREERTOS_USE_STATIC_SEMAPHORE) && CHIP_CONFIG_FREERTOS_USE_STATIC_SEMAPHORE
     StaticSemaphore_t mThreadStackLockMutex;
+#endif
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    TaskHandle_t mSrpClearAllRequester = nullptr;
 #endif
 };
 

--- a/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.cpp
+++ b/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.cpp
@@ -54,6 +54,14 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
     VerifyOrExit(result == WICED_SUCCESS, err = CHIP_ERROR_INTERNAL);
     otSysInit(0, NULL);
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    mSrpClearAllSemaphore = wiced_rtos_create_mutex();
+    VerifyOrExit(mSrpClearAllSemaphore != nullptr, err = CHIP_ERROR_NO_MEMORY);
+
+    result = wiced_rtos_init_mutex(mSrpClearAllSemaphore);
+    VerifyOrExit(result == WICED_SUCCESS, err = CHIP_ERROR_INTERNAL);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     err = GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(NULL);
 
 exit:
@@ -94,6 +102,21 @@ void ThreadStackManagerImpl::_UnlockThreadStack()
     const wiced_result_t result = wiced_rtos_unlock_mutex(mMutex);
     VerifyOrReturn(result == WICED_SUCCESS || result == WICED_NOT_OWNED, ChipLogError(DeviceLayer, "%s %x", __func__, result));
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+void ThreadStackManagerImpl::_WaitOnSrpClearAllComplete()
+{
+    const wiced_result_t result = wiced_rtos_lock_mutex(mSrpClearAllSemaphore);
+    VerifyOrReturn(result == WICED_SUCCESS, ChipLogError(DeviceLayer, "%s %x", __func__, result));
+}
+
+void ThreadStackManagerImpl::_NotifySrpClearAllComplete()
+{
+    const wiced_result_t result = wiced_rtos_unlock_mutex(mSrpClearAllSemaphore);
+    VerifyOrReturn(result == WICED_SUCCESS || result == WICED_NOT_OWNED, ChipLogError(DeviceLayer, "%s %x", __func__, result));
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+// ===== Methods that override the GenericThreadStackMa
 
 void ThreadStackManagerImpl::ThreadTaskMain(void)
 {

--- a/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.h
+++ b/src/platform/Infineon/CYW30739/ThreadStackManagerImpl.h
@@ -58,6 +58,11 @@ protected:
     bool _TryLockThreadStack();
     void _UnlockThreadStack();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete();
+    void _NotifySrpClearAllComplete();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    // ===== Methods that override the GenericThreadStackMa
 private:
     // ===== Members for internal use by the following friends.
 
@@ -67,6 +72,9 @@ private:
     wiced_thread_t * mThread;
     EventFlags mEventFlags;
     wiced_mutex_t * mMutex;
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    wiced_mutex_t * mSrpClearAllSemaphore;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     static ThreadStackManagerImpl sInstance;
 
     // ===== Private members for use by this class only.

--- a/src/platform/Linux/ThreadStackManagerImpl.h
+++ b/src/platform/Linux/ThreadStackManagerImpl.h
@@ -57,6 +57,11 @@ public:
     bool _TryLockThreadStack() { return false; }            // Intentionally left blank
     void _UnlockThreadStack() {}                            // Intentionally left blank
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete() {}
+    void _NotifySrpClearAllComplete() {}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     bool _HaveRouteToAddress(const Inet::IPAddress & destAddr);
 
     void _OnPlatformEvent(const ChipDeviceEvent * event);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h
@@ -123,6 +123,7 @@ protected:
     CHIP_ERROR _RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR _InvalidateAllSrpServices();
     CHIP_ERROR _RemoveInvalidSrpServices();
+    CHIP_ERROR _ClearAllSrpHostAndServices();
 
     CHIP_ERROR _SetupSrpHost(const char * aHostName);
     CHIP_ERROR _ClearSrpHost(const char * aHostName);
@@ -204,6 +205,8 @@ private:
     };
 
     SrpClient mSrpClient;
+
+    bool mIsSrpClearAllRequested = false;
 
     static void OnSrpClientNotification(otError aError, const otSrpClientHostInfo * aHostInfo, const otSrpClientService * aServices,
                                         const otSrpClientService * aRemovedServices, void * aContext);

--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1979,6 +1979,12 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::OnSrpClientNotificatio
                 ThreadStackMgrImpl().mSrpClient.mIsInitialized = true;
                 ThreadStackMgrImpl().mSrpClient.mInitializedCallback(ThreadStackMgrImpl().mSrpClient.mCallbackContext,
                                                                      CHIP_NO_ERROR);
+
+                if (ThreadStackMgrImpl().mIsSrpClearAllRequested)
+                {
+                    ThreadStackMgrImpl().NotifySrpClearAllComplete();
+                    ThreadStackMgrImpl().mIsSrpClearAllRequested = false;
+                }
             }
         }
 
@@ -2287,6 +2293,35 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_RemoveInvalidSr
 exit:
     Impl()->UnlockThreadStack();
 
+    return error;
+}
+
+/*
+ * @brief This is a utility function to remove all Thread client srp host and services
+ * established between the device and the srp server (in most cases the OTBR).
+ * The calling task is blocked until OnSrpClientNotification which confims the client received the request.
+ * The blocking mechanism is defined by the platform implementation of `WaitOnSrpClearAllComplete` and `NotifySrpClearAllComplete`
+ *
+ * Note: This function is meant to be used during the factory reset sequence.
+ *
+ */
+template <class ImplClass>
+CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ClearAllSrpHostAndServices()
+{
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    Impl()->LockThreadStack();
+    if (!mIsSrpClearAllRequested)
+    {
+        error =
+            MapOpenThreadError(otSrpClientRemoveHostAndServices(mOTInst, true /*aRemoveKeyLease*/, true /*aSendUnregToServer*/));
+        mIsSrpClearAllRequested = true;
+        Impl()->UnlockThreadStack();
+        Impl()->WaitOnSrpClearAllComplete();
+    }
+    else
+    {
+        Impl()->UnlockThreadStack();
+    }
     return error;
 }
 

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -617,6 +617,16 @@ CHIP_ERROR ThreadStackManagerImpl::_RemoveInvalidSrpServices()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ThreadStackManagerImpl::_ClearAllSrpHostAndServices()
+{
+    for (auto it = mSrpClientServices.begin(); it != mSrpClientServices.end();)
+    {
+        ReturnErrorOnFailure(_RemoveSrpService(it->mInstanceName, it->mName));
+        it = mSrpClientServices.erase(it);
+    }
+    return CHIP_NO_ERROR;
+}
+
 void ThreadStackManagerImpl::_ThreadIpAddressCb(int index, char * ipAddr, thread_ipaddr_type_e ipAddrType, void * userData)
 {
     int threadErr = THREAD_ERROR_NONE;

--- a/src/platform/Tizen/ThreadStackManagerImpl.h
+++ b/src/platform/Tizen/ThreadStackManagerImpl.h
@@ -57,6 +57,11 @@ public:
     bool _TryLockThreadStack() { return false; }            // Intentionally left blank
     void _UnlockThreadStack() {}                            // Intentionally left blank
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete() {}
+    void _NotifySrpClearAllComplete() {}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     bool _HaveRouteToAddress(const Inet::IPAddress & destAddr);
 
     void _OnPlatformEvent(const ChipDeviceEvent * event);
@@ -117,6 +122,7 @@ public:
     CHIP_ERROR _RemoveSrpService(const char * aInstanceName, const char * aName);
     CHIP_ERROR _InvalidateAllSrpServices();
     CHIP_ERROR _RemoveInvalidSrpServices();
+    CHIP_ERROR _ClearAllSrpHostAndServices();
     CHIP_ERROR _SetupSrpHost(const char * aHostName);
     CHIP_ERROR _ClearSrpHost(const char * aHostName);
     CHIP_ERROR _SetSrpDnsCallbacks(DnsAsyncReturnCallback aInitCallback, DnsAsyncReturnCallback aErrorCallback, void * aContext);

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -42,7 +42,7 @@
 
 #ifdef CONFIG_NET_L2_OPENTHREAD
 #include <platform/ThreadStackManager.h>
-#endif 
+#endif
 
 namespace chip {
 namespace DeviceLayer {
@@ -180,6 +180,10 @@ void ConfigurationManagerImpl::RunConfigUnitTest(void)
 void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     ChipLogProgress(DeviceLayer, "Performing factory reset");
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    ThreadStackMgr().ClearAllSrpHostAndServices();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
 // Lock the Thread stack to avoid unwanted interaction with settings NVS during factory reset.
 #ifdef CONFIG_NET_L2_OPENTHREAD

--- a/src/platform/Zephyr/ThreadStackManagerImpl.cpp
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.cpp
@@ -43,6 +43,10 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 
     ReturnErrorOnFailure(GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(instance));
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    k_sem_init(&mSrpClearAllSemaphore, 0, 1);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     return CHIP_NO_ERROR;
 }
 
@@ -61,6 +65,18 @@ void ThreadStackManagerImpl::_UnlockThreadStack()
 {
     openthread_api_mutex_unlock(openthread_get_default_context());
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+void ThreadStackManagerImpl::_WaitOnSrpClearAllComplete()
+{
+    k_sem_take(&mSrpClearAllSemaphore, K_SECONDS(2));
+}
+
+void ThreadStackManagerImpl::_NotifySrpClearAllComplete()
+{
+    k_sem_give(&mSrpClearAllSemaphore);
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Zephyr/ThreadStackManagerImpl.h
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.h
@@ -71,6 +71,10 @@ protected:
     bool _TryLockThreadStack();
     void _UnlockThreadStack();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete();
+    void _NotifySrpClearAllComplete();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     // ===== Methods that override the GenericThreadStackManagerImpl_OpenThread abstract interface.
 
     void _ProcessThreadActivity() {}
@@ -82,6 +86,10 @@ private:
 
     friend ThreadStackManager & ::chip::DeviceLayer::ThreadStackMgr(void);
     friend ThreadStackManagerImpl & ::chip::DeviceLayer::ThreadStackMgrImpl(void);
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    k_sem mSrpClearAllSemaphore;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
     static ThreadStackManagerImpl sInstance;
 

--- a/src/platform/silabs/ThreadStackManagerImpl.h
+++ b/src/platform/silabs/ThreadStackManagerImpl.h
@@ -77,7 +77,6 @@ private:
     // ===== Methods that implement the ThreadStackManager abstract interface.
 
     CHIP_ERROR _InitThreadStack(void);
-
     // ===== Members for internal use by the following friends.
 
     friend ThreadStackManager & ::chip::DeviceLayer::ThreadStackMgr(void);

--- a/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
+++ b/src/platform/silabs/efr32/ConfigurationManagerImpl.cpp
@@ -277,7 +277,6 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
-
     ChipLogProgress(DeviceLayer, "Clearing Thread provision");
     ThreadStackMgr().ErasePersistentInfo();
 

--- a/src/platform/telink/ThreadStackManagerImpl.cpp
+++ b/src/platform/telink/ThreadStackManagerImpl.cpp
@@ -60,6 +60,10 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
         return MapOpenThreadError(error);
     });
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    k_sem_init(&mSrpClearAllSemaphore, 0, 1);
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     return CHIP_NO_ERROR;
 }
 
@@ -78,6 +82,18 @@ void ThreadStackManagerImpl::_UnlockThreadStack()
 {
     openthread_api_mutex_unlock(openthread_get_default_context());
 }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+void ThreadStackManagerImpl::_WaitOnSrpClearAllComplete()
+{
+    k_sem_take(&mSrpClearAllSemaphore, K_SECONDS(2));
+}
+
+void ThreadStackManagerImpl::_NotifySrpClearAllComplete()
+{
+    k_sem_give(&mSrpClearAllSemaphore);
+}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
 CHIP_ERROR
 ThreadStackManagerImpl::_AttachToThreadNetwork(const Thread::OperationalDataset & dataset,

--- a/src/platform/telink/ThreadStackManagerImpl.h
+++ b/src/platform/telink/ThreadStackManagerImpl.h
@@ -74,6 +74,10 @@ protected:
     bool _TryLockThreadStack();
     void _UnlockThreadStack();
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete();
+    void _NotifySrpClearAllComplete();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
     // ===== Methods that override the GenericThreadStackManagerImpl_OpenThread abstract interface.
 
     void _ProcessThreadActivity() {}
@@ -94,6 +98,10 @@ private:
     // ===== Private members for use by this class only.
     bool mRadioBlocked;
     bool mReadyToAttach;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    k_sem mSrpClearAllSemaphore;
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
 
     NetworkCommissioning::ThreadDriver::ScanCallback * mpScanCallback;
 };

--- a/src/platform/webos/ThreadStackManagerImpl.h
+++ b/src/platform/webos/ThreadStackManagerImpl.h
@@ -50,6 +50,11 @@ public:
     bool _TryLockThreadStack() { return false; }            // Intentionally left blank
     void _UnlockThreadStack() {}                            // Intentionally left blank
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    void _WaitOnSrpClearAllComplete() {}
+    void _NotifySrpClearAllComplete() {}
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
     bool _HaveRouteToAddress(const Inet::IPAddress & destAddr);
 
     void _OnPlatformEvent(const ChipDeviceEvent * event);


### PR DESCRIPTION
This commit implements the host srp clear, using a cherry-picked upstream solution.

Cherry-picked commit 6350333 content:

“This PR brings https://github.com/project-chip/connectedhomeip/pull/31606 feature to The GenericThreadStackManagerImpl.
The functionality remains the same (with the addition of deleting the client key lease also).

However, this requires each platform that uses it, to provide a synchronization mechanism.

I created the Templates _WaitOnSrpClearAllComplete and _NotifySrpClearAllComplete and I provided an implementation for all platforms using the GenericThreadStackManagerImpl. (It is left unimplemented for others)

The synchronization mechanism I chose for Zephyr platforms (nordic/telink) and Infineon might not be optional so suggestions are welcome.

The functionality was only tested on the Silabs platform and is currently only used on it also. I am confident it works for all FreeRTOS-based platforms.

I suggest all other thread platform owners take some time to test and use ClearAllSrpHostAndServices during their factory-reset sequence.”