### PR TITLE
Zephyr 01-03-2024 upmerge fixes

### DIFF
--- a/config/nrfconnect/app/enable-gnu-std.cmake
+++ b/config/nrfconnect/app/enable-gnu-std.cmake
@@ -1,6 +1,5 @@
 add_library(gnu17 INTERFACE)
 target_compile_options(gnu17
     INTERFACE 
-        $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>
-        -D_SYS__PTHREADTYPES_H_)
+        $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++17>)
 target_link_libraries(app PRIVATE gnu17)

--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -24,6 +24,10 @@ if CHIP
 # System configuration
 # ==============================================================================
 
+choice LIBC_IMPLEMENTATION
+    default NEWLIB_LIBC
+endchoice
+
 config ASSERT
     default y
 

--- a/src/platform/nrfconnect/SystemPlatformConfig.h
+++ b/src/platform/nrfconnect/SystemPlatformConfig.h
@@ -52,3 +52,6 @@ struct ChipDeviceEvent;
 #endif
 
 // ========== Platform-specific Configuration Overrides =========
+
+// Disable Zephyr Socket extensions module, as the Zephyr RTOS now implements recvmsg()
+#define CHIP_SYSTEM_CONFIG_USE_ZEPHYR_SOCKET_EXTENSIONS 0


### PR DESCRIPTION
Fixes:

* The recvmsg() is now implemented natively in Zephyr, so we are not supposed to define a custom one.
* D_SYS__PTHREADTYPES_H_ should not be forced (otherwise pthread definitions are not pulled in)
* NEWLIB_LIBC must be selected implicitly (it's no longer selected by wpa_supplicant)

