### PR TITLE
[nrf noup] Select Experimental for persistent subscriptions

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -297,6 +297,10 @@ config CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY
 	  and remove it. After the first boot of the device the DAC private key will be moved
 	  to the PSA ITS secure storage and will not be available in the factory data anymore.
 	  It will be overwritten in the factory data set by zeros.
-	
+
+config CHIP_PERSISTENT_SUBSCRIPTIONS
+	default n
+	# selecting experimental for this feature since there is an issue with multiple controllers.
+	select EXPERIMENTAL
 
 endif # CHIP


### PR DESCRIPTION
Currently, there is an issue with persistent subscriptions when multiple controllers create subscriptions.


