### PR TITLE
[nrf noup] fix various issues with Network Commissioning cluster on Wi-Fi

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -519,8 +519,6 @@ void Instance::OnFinished(Status status, CharSpan debugText, ThreadScanResponseI
     }
 
     mLastNetworkingStatusValue.SetNonNull(status);
-    mLastConnectErrorValue.SetNull();
-    mLastNetworkIDLen = 0;
 
     TLV::TLVWriter * writer;
     TLV::TLVType listContainerType;
@@ -633,8 +631,6 @@ void Instance::OnFinished(Status status, CharSpan debugText, WiFiScanResponseIte
     }
 
     mLastNetworkingStatusValue.SetNonNull(status);
-    mLastConnectErrorValue.SetNull();
-    mLastNetworkIDLen = 0;
 
     TLV::TLVWriter * writer;
     TLV::TLVType listContainerType;

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -103,8 +103,7 @@ CHIP_ERROR NrfWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
 
     if (mStagingNetwork.IsConfigured())
     {
-        WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
-                                                  [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
+        WiFiManager::ConnectionHandling handling{ [](int connStatus) { Instance().OnNetworkStatusChanged(connStatus); },
                                                   System::Clock::Seconds32{ kWiFiConnectNetworkTimeoutSeconds } };
         ReturnErrorOnFailure(
             WiFiManager::Instance().Connect(mStagingNetwork.GetSsidSpan(), mStagingNetwork.GetPassSpan(), handling));
@@ -113,8 +112,10 @@ CHIP_ERROR NrfWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     return CHIP_NO_ERROR;
 }
 
-void NrfWiFiDriver::OnNetworkStatusChanged(Status status)
+void NrfWiFiDriver::OnNetworkStatusChanged(int connStatus)
 {
+    Status status = connStatus ? Status::kUnknownError : Status::kSuccess;
+
     if (status == Status::kSuccess)
     {
         ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Enabled);
@@ -127,7 +128,8 @@ void NrfWiFiDriver::OnNetworkStatusChanged(Status status)
         if (CHIP_NO_ERROR == WiFiManager::Instance().GetWiFiInfo(wifiInfo))
         {
             mpNetworkStatusChangeCallback->OnNetworkingStatusChange(status,
-                MakeOptional(ByteSpan(wifiInfo.mSsid, wifiInfo.mSsidLen)), NullOptional);
+                MakeOptional(ByteSpan(wifiInfo.mSsid, wifiInfo.mSsidLen)),
+                connStatus ? MakeOptional(connStatus) : NullOptional);
         }
     }
 
@@ -170,8 +172,7 @@ CHIP_ERROR NrfWiFiDriver::RevertConfiguration()
 
     if (mStagingNetwork.IsConfigured())
     {
-        WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
-                                                  [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
+        WiFiManager::ConnectionHandling handling{ [](int connStatus) { Instance().OnNetworkStatusChanged(connStatus); },
                                                   System::Clock::Seconds32{ kWiFiConnectNetworkTimeoutSeconds } };
         ReturnErrorOnFailure(
             WiFiManager::Instance().Connect(mStagingNetwork.GetSsidSpan(), mStagingNetwork.GetPassSpan(), handling));
@@ -224,8 +225,7 @@ Status NrfWiFiDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, MutableC
 void NrfWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callback)
 {
     Status status = Status::kSuccess;
-    WiFiManager::ConnectionHandling handling{ [] { Instance().OnNetworkStatusChanged(Status::kSuccess); },
-                                              [] { Instance().OnNetworkStatusChanged(Status::kUnknownError); },
+    WiFiManager::ConnectionHandling handling{ [](int connStatus) { Instance().OnNetworkStatusChanged(connStatus); },
                                               System::Clock::Seconds32{ kWiFiConnectNetworkTimeoutSeconds } };
 
     VerifyOrExit(mpConnectCallback == nullptr, status = Status::kUnknownError);
@@ -255,10 +255,10 @@ void NrfWiFiDriver::LoadFromStorage()
     mStagingNetwork = network;
 }
 
-void NrfWiFiDriver::OnScanWiFiNetworkDone(WiFiManager::WiFiRequestStatus status)
+void NrfWiFiDriver::OnScanWiFiNetworkDone(const wifi_status & status)
 {
     VerifyOrReturn(mScanCallback != nullptr);
-    mScanCallback->OnFinished(status == WiFiManager::WiFiRequestStatus::SUCCESS ? Status::kSuccess : Status::kUnknownError,
+    mScanCallback->OnFinished(status.status ? Status::kUnknownError : Status::kSuccess,
                               CharSpan(), &mScanResponseIterator);
     mScanCallback = nullptr;
 }
@@ -273,7 +273,7 @@ void NrfWiFiDriver::ScanNetworks(ByteSpan ssid, WiFiDriver::ScanCallback * callb
     mScanCallback    = callback;
     CHIP_ERROR error = WiFiManager::Instance().Scan(
         ssid, [](const WiFiScanResponse & response) { Instance().OnScanWiFiNetworkResult(response); },
-        [](WiFiManager::WiFiRequestStatus status) { Instance().OnScanWiFiNetworkDone(status); });
+        [](const wifi_status & status) { Instance().OnScanWiFiNetworkDone(status); });
 
     if (error != CHIP_NO_ERROR)
     {

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.cpp
@@ -122,7 +122,13 @@ void NrfWiFiDriver::OnNetworkStatusChanged(Status status)
 
     if (mpNetworkStatusChangeCallback)
     {
-        mpNetworkStatusChangeCallback->OnNetworkingStatusChange(status, NullOptional, NullOptional);
+        WiFiManager::WiFiInfo wifiInfo;
+
+        if (CHIP_NO_ERROR == WiFiManager::Instance().GetWiFiInfo(wifiInfo))
+        {
+            mpNetworkStatusChangeCallback->OnNetworkingStatusChange(status,
+                MakeOptional(ByteSpan(wifiInfo.mSsid, wifiInfo.mSsidLen)), NullOptional);
+        }
     }
 
     if (mpConnectCallback)

--- a/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
+++ b/src/platform/nrfconnect/wifi/NrfWiFiDriver.h
@@ -93,9 +93,9 @@ public:
         return sInstance;
     }
 
-    void OnNetworkStatusChanged(Status status);
+    void OnNetworkStatusChanged(int status);
     void OnScanWiFiNetworkResult(const WiFiScanResponse & result);
-    void OnScanWiFiNetworkDone(WiFiManager::WiFiRequestStatus status);
+    void OnScanWiFiNetworkDone(const wifi_status & status);
 
 private:
     void LoadFromStorage();

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -88,16 +88,9 @@ private:
 class WiFiManager
 {
 public:
-    enum WiFiRequestStatus : int
-    {
-        SUCCESS    = 0,
-        FAILURE    = 1,
-        TERMINATED = 2
-    };
-
     using ScanResultCallback = void (*)(const NetworkCommissioning::WiFiScanResponse &);
-    using ScanDoneCallback   = void (*)(WiFiRequestStatus);
-    using ConnectionCallback = void (*)();
+    using ScanDoneCallback   = void (*)(const wifi_status &);
+    using ConnectionCallback = void (*)(int);
 
     enum class StationStatus : uint8_t
     {
@@ -120,8 +113,7 @@ public:
 
     struct ConnectionHandling
     {
-        ConnectionCallback mOnConnectionSuccess{};
-        ConnectionCallback mOnConnectionFailed{};
+        ConnectionCallback mOnConnectionDone{};
         System::Clock::Seconds32 mConnectionTimeout{};
     };
 


### PR DESCRIPTION
This PR fixes few issues with Network Commissioning cluster on Wi-Fi platform.

Please review commit by commit.

**[nrf noup] Fix handling of LastNetworkID in Wi-Fi driver**
This commit ensures that `LastNetworkID` attribute is not null, not only after `ConnectNetwork` command is issued, but also in case the connection is established after resboot or after connection is lost.

`[1709852472.587357][369591:369593] CHIP:TOO:   LastNetworkID: 536368726F64696E676572205761766573203547`

**[nrf noup] Do not clear Last Network ID and Connection Error after scan**
This bug is already fixed upstream for Matter 1.3. This fixes the issue where `LastNetworkID` attribute is cleared after `ScanNetworks` command is completed.

**[nrf noup] Fix various Wi-Fi issues with error code handling**
This commit handles a few issues with Wi-Fi connection or scanning:
 - Use wifi_status structure instead of incompatible WiFiRequestStatus
 - On connect error value > 2 do not report success*
 - On scan error value > 1 do not report success
 - Provide value of mandatory LastConnectErrorValue attribute
 
*This is especially critical.