### PR TITLE
[nrf noup] Enable a depency of MBEDTLS_X509_CREATE_C

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -367,6 +367,9 @@ config MBEDTLS_PKCS5_C
 config MBEDTLS_PK_WRITE_C
     default y
 
+config MBEDTLS_X509_LIBRARY
+    default y
+
 config MBEDTLS_X509_CREATE_C
     default y
 


### PR DESCRIPTION
We are enabling MBEDTLS_X509_CREATE_C, but not it's dependency MBEDTLS_X509_LIBRARY.

Also enable MBEDTLS_X509_LIBRARY in case it's default value changes.

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

