### PR TITLE
[nrf noup] Fix the external cluster injection mechanism

### DIFF
--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -69,10 +69,14 @@ endfunction()
 #                   supported by the application.
 #   IDL             .matter IDL file to use for codegen. Inferred from ZAP_FILE
 #                   if not provided
+#   EXTERNAL_CLUSTERS Clusters with external implementations. The default implementations
+#                   will not be used nor required for these clusters.
+#                   Format: MY_CUSTOM_CLUSTER'.
 #
+
 function(chip_configure_data_model APP_TARGET)
     set(SCOPE PRIVATE)
-    cmake_parse_arguments(ARG "INCLUDE_SERVER;BYPASS_IDL" "ZAP_FILE;GEN_DIR;IDL" "" ${ARGN})
+    cmake_parse_arguments(ARG "INCLUDE_SERVER;BYPASS_IDL" "SCOPE;ZAP_FILE;GEN_DIR;IDL" "EXTERNAL_CLUSTERS" ${ARGN})
 
     if(ARG_SCOPE)
         set(SCOPE ${ARG_SCOPE})


### PR DESCRIPTION
The necessary change was reverted during the last upmerge. Without this fix, the external cluster injection does not work.

This patch was already applied on the 2.6.0-branch.

