### PR TITLE
[nrf noup] Increase default number of packet buffers

### DIFF
--- a/src/platform/nrfconnect/SystemPlatformConfig.h
+++ b/src/platform/nrfconnect/SystemPlatformConfig.h
@@ -47,6 +47,6 @@ struct ChipDeviceEvent;
 #define CHIP_SYSTEM_CONFIG_USE_LWIP 0
 #define CHIP_SYSTEM_CONFIG_USE_SOCKETS 1
 
-#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 8
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 15
 
 // ========== Platform-specific Configuration Overrides =========


### PR DESCRIPTION
This commit reverts the previous optimization of reducing the number of packet buffers in the system.