### PR TITLE
[nrfconnect] Improved generation of factory data

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -147,9 +147,9 @@ config CHIP_FACTORY_DATA_ROTATING_DEVICE_UID_MAX_LEN
 
 config CHIP_FACTORY_DATA_WRITE_PROTECT
 	bool "Enable Factory Data write protection"
-	select FPROTECT
+	imply FPROTECT
 	depends on CHIP_FACTORY_DATA
-	default y if CHIP_FACTORY_DATA
+	default y if SOC_SERIES_NRF53X || SOC_SERIES_NRF52X
 	help
 		Enables the write protection of the Factory Data partition in the flash memory.
 		This is a recommended feature, but it requires the Settings partition size to be

--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -106,7 +106,6 @@ config CHIP_MALLOC_SYS_HEAP
 config CHIP_FACTORY_DATA
 	bool "Factory data provider"
 	select ZCBOR
-	imply FPROTECT
 	help
 	  Enables the default nRF Connect factory data provider implementation that
 	  supports reading the factory data encoded in the CBOR format from the
@@ -147,9 +146,9 @@ config CHIP_FACTORY_DATA_ROTATING_DEVICE_UID_MAX_LEN
 
 config CHIP_FACTORY_DATA_WRITE_PROTECT
 	bool "Enable Factory Data write protection"
-	imply FPROTECT
+	select FPROTECT
 	depends on CHIP_FACTORY_DATA
-	default y if SOC_SERIES_NRF53X || SOC_SERIES_NRF52X
+	default y
 	help
 		Enables the write protection of the Factory Data partition in the flash memory.
 		This is a recommended feature, but it requires the Settings partition size to be

--- a/docs/guides/nrfconnect_factory_data_configuration.md
+++ b/docs/guides/nrfconnect_factory_data_configuration.md
@@ -37,7 +37,7 @@ data secure by applying hardware write protection.
       - [Appearance field description](#appearance-field-description)
   - [Enabling factory data support](#enabling-factory-data-support)
   - [Generating factory data](#generating-factory-data)
-    - [Creating the factory data JSON file with the first script](#creating-the-factory-data-json-file-with-the-first-script)
+    - [Creating the factory data JSON and HEX files with the first script](#creating-the-factory-data-json-and-hex-files-with-the-first-script)
     - [How to set user data](#how-to-set-user-data)
       - [How to handle user data](#how-to-handle-user-data)
     - [Verifying using the JSON Schema tool](#verifying-using-the-json-schema-tool)
@@ -597,7 +597,7 @@ To generate a manual pairing code and a QR code, complete the following steps:
     ```
 
 2. Complete steps 1, 2, and 3 from the
-   [Creating the factory data JSON file with the first script](#creating-the-factory-data-json-file-with-the-first-script)
+   [Creating the factory data JSON and HEX files with the first script](#creating-the-factory-data-json-and-hex-files-with-the-first-script)
    section to prepare the final invocation of the Python script.
 
 3. Add the `--generate_onboarding` argument to the Python script final

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -509,7 +509,9 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetUserKey(const char * userKe
 
 // Fully instantiate the template class in whatever compilation unit includes this file.
 template class FactoryDataProvider<InternalFlashFactoryData>;
+#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
 template class FactoryDataProvider<ExternalFlashFactoryData>;
+#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -66,8 +66,8 @@ struct InternalFlashFactoryData
     // the application code at runtime anyway.
     constexpr size_t FactoryDataBlockBegin()
     {
-        // calculate the nearest multiple of CONFIG_FPROTECT_BLOCK_SIZE smaller than PM_FACTORY_DATA_ADDRESS
-        return PM_FACTORY_DATA_ADDRESS & (-CONFIG_FPROTECT_BLOCK_SIZE);
+        // calculate the nearest multiple of CONFIG_FPROTECT_BLOCK_SIZE smaller than FACTORY_DATA_ADDRESS
+        return FACTORY_DATA_ADDRESS & (-CONFIG_FPROTECT_BLOCK_SIZE);
     }
 
     constexpr size_t FactoryDataBlockSize()
@@ -75,7 +75,7 @@ struct InternalFlashFactoryData
         // calculate the factory data end address rounded up to the nearest multiple of CONFIG_FPROTECT_BLOCK_SIZE
         // and make sure we do not overlap with settings partition
         constexpr size_t kFactoryDataBlockEnd =
-            (PM_FACTORY_DATA_ADDRESS + PM_FACTORY_DATA_SIZE + CONFIG_FPROTECT_BLOCK_SIZE - 1) & (-CONFIG_FPROTECT_BLOCK_SIZE);
+            (FACTORY_DATA_ADDRESS + FACTORY_DATA_SIZE + CONFIG_FPROTECT_BLOCK_SIZE - 1) & (-CONFIG_FPROTECT_BLOCK_SIZE);
         static_assert(kFactoryDataBlockEnd <= PM_SETTINGS_STORAGE_ADDRESS,
                       "FPROTECT memory block, which contains factory data"
                       "partition overlaps with the settings partition."
@@ -88,7 +88,7 @@ struct InternalFlashFactoryData
     CHIP_ERROR ProtectFactoryDataPartitionAgainstWrite()
     {
 #ifdef CONFIG_FPROTECT
-        int ret = fprotect_area(FACTORY_DATA_ADDRESS, FACTORY_DATA_SIZE);
+        int ret = fprotect_area(FactoryDataBlockBegin(), FactoryDataBlockSize());
         return System::MapErrorZephyr(ret);
 #else
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -25,8 +25,20 @@
 #include <crypto/CHIPCryptoPALPSA.h>
 #endif
 
+#ifdef CONFIG_FPROTECT
 #include <fprotect.h>
+#endif // if CONFIG_FPROTECT
+
+#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
 #include <pm_config.h>
+#define FACTORY_DATA_ADDRESS PM_FACTORY_DATA_ADDRESS
+#define FACTORY_DATA_SIZE PM_FACTORY_DATA_SIZE
+#else
+#include <zephyr/storage/flash_map.h>
+#define FACTORY_DATA_SIZE DT_REG_SIZE(DT_ALIAS(factory_data))
+#define FACTORY_DATA_ADDRESS DT_REG_ADDR(DT_ALIAS(factory_data))
+#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
+
 #include <system/SystemError.h>
 #include <zephyr/drivers/flash.h>
 
@@ -39,8 +51,8 @@ struct InternalFlashFactoryData
 {
     CHIP_ERROR GetFactoryDataPartition(uint8_t *& data, size_t & dataSize)
     {
-        data     = reinterpret_cast<uint8_t *>(PM_FACTORY_DATA_ADDRESS);
-        dataSize = PM_FACTORY_DATA_SIZE;
+        data     = reinterpret_cast<uint8_t *>(FACTORY_DATA_ADDRESS);
+        dataSize = FACTORY_DATA_SIZE;
         return CHIP_NO_ERROR;
     }
 
@@ -75,19 +87,24 @@ struct InternalFlashFactoryData
 #undef TO_STR_IMPL
     CHIP_ERROR ProtectFactoryDataPartitionAgainstWrite()
     {
-        int ret = fprotect_area(FactoryDataBlockBegin(), FactoryDataBlockSize());
+#ifdef CONFIG_FPROTECT
+        int ret = fprotect_area(FACTORY_DATA_ADDRESS, FACTORY_DATA_SIZE);
         return System::MapErrorZephyr(ret);
+#else
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif // if CONFIG_FPROTECT
     }
 #else
     CHIP_ERROR ProtectFactoryDataPartitionAgainstWrite() { return CHIP_ERROR_NOT_IMPLEMENTED; }
 #endif
 };
 
+#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
 struct ExternalFlashFactoryData
 {
     CHIP_ERROR GetFactoryDataPartition(uint8_t *& data, size_t & dataSize)
     {
-        int ret = flash_read(mFlashDevice, PM_FACTORY_DATA_ADDRESS, mFactoryDataBuffer, PM_FACTORY_DATA_SIZE);
+        int ret = flash_read(mFlashDevice, FACTORY_DATA_ADDRESS, mFactoryDataBuffer, FACTORY_DATA_SIZE);
 
         if (ret != 0)
         {
@@ -95,16 +112,17 @@ struct ExternalFlashFactoryData
         }
 
         data     = mFactoryDataBuffer;
-        dataSize = PM_FACTORY_DATA_SIZE;
+        dataSize = FACTORY_DATA_SIZE;
 
         return CHIP_NO_ERROR;
     }
 
     CHIP_ERROR ProtectFactoryDataPartitionAgainstWrite() { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
-    const struct device * mFlashDevice = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
-    uint8_t mFactoryDataBuffer[PM_FACTORY_DATA_SIZE];
+    const struct device * mFlashDevice = DEVICE_DT_GET(DT_CHOSEN(nordic_pm_ext_flash));
+    uint8_t mFactoryDataBuffer[FACTORY_DATA_SIZE];
 };
+#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
 
 class FactoryDataProviderBase : public chip::Credentials::DeviceAttestationCredentialsProvider,
                                 public CommissionableDataProvider,
@@ -198,8 +216,8 @@ public:
     CHIP_ERROR GetUserKey(const char * userKey, void * buf, size_t & len) override;
 
 private:
-    static constexpr uint16_t kFactoryDataPartitionSize    = PM_FACTORY_DATA_SIZE;
-    static constexpr uint32_t kFactoryDataPartitionAddress = PM_FACTORY_DATA_ADDRESS;
+    static constexpr uint16_t kFactoryDataPartitionSize    = FACTORY_DATA_SIZE;
+    static constexpr uint32_t kFactoryDataPartitionAddress = FACTORY_DATA_ADDRESS;
     static constexpr uint8_t kDACPrivateKeyLength          = 32;
     static constexpr uint8_t kDACPublicKeyLength           = 65;
 


### PR DESCRIPTION
Added support for platforms not built using PM. This commit includes fixes only firmware implementation and does not include cmake changes for factory data generation.

- Allow to merge the factory data .hex file with the firmware's .hex file when the partition manager is not available.

