### PR TITLE
[nrf toup] nrfconnect: enable detailed logging of Matter messages

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -168,6 +168,7 @@ matter_add_gn_arg_bool  ("chip_enable_factory_data"               CONFIG_CHIP_FA
 matter_add_gn_arg_bool  ("chip_enable_read_client"                CONFIG_CHIP_ENABLE_READ_CLIENT)
 matter_add_gn_arg_bool  ("chip_mdns_minimal"                      CONFIG_WIFI_NRF70)
 matter_add_gn_arg_bool  ("chip_mdns_platform"                     CONFIG_NET_L2_OPENTHREAD)
+matter_add_gn_arg_bool  ("enable_im_pretty_print"                 CONFIG_CHIP_IM_PRETTY_PRINT)
 
 if (CONFIG_CHIP_ENABLE_ICD_SUPPORT)
     matter_add_gn_arg_bool  ("chip_enable_icd_lit"                       CONFIG_CHIP_ICD_LIT_SUPPORT)

--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -458,4 +458,13 @@ config CHIP_SYSTEM_PACKETBUFFER_POOL_SIZE
   help
     Total number of packet buffers allocated by the stack for internal pool.
 
+config CHIP_IM_PRETTY_PRINT
+	bool "Enable detailed logging of Matter messages"
+	help
+	  Enables enhanced verbosity for logging content of Matter messages. This configuration option
+	  facilitates detailed tracking of interactions, including Cluster ID, Endpoint ID, Attribute ID,
+	  or Command ID as well as payload content for all interaction types (like Read Request or Invoke
+	  Request). This option helps in debugging and development of message exchanges within the Matter
+	  protocol.
+
 endif # CHIP


### PR DESCRIPTION
This commit adds an option to enable IM Pretty Print from the KConfig.

(to be upstreamed first -> then I will change commit to nrf fromlist)
