### PR TITLE
[nrf toup] [nrfconnect] Disable External FD if QSPI NOR is not available

### DIFF
--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -509,9 +509,10 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetUserKey(const char * userKe
 
 // Fully instantiate the template class in whatever compilation unit includes this file.
 template class FactoryDataProvider<InternalFlashFactoryData>;
-#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
+#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1 && (defined(CONFIG_CHIP_QSPI_NOR) || defined(CONFIG_CHIP_SPI_NOR))
 template class FactoryDataProvider<ExternalFlashFactoryData>;
-#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
+#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1 (defined(CONFIG_CHIP_QSPI_NOR) ||
+       // defined(CONFIG_CHIP_SPI_NOR))
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -99,7 +99,7 @@ struct InternalFlashFactoryData
 #endif
 };
 
-#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
+#if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1 && (defined(CONFIG_CHIP_QSPI_NOR) || defined(CONFIG_CHIP_SPI_NOR))
 struct ExternalFlashFactoryData
 {
     CHIP_ERROR GetFactoryDataPartition(uint8_t *& data, size_t & dataSize)
@@ -122,7 +122,8 @@ struct ExternalFlashFactoryData
     const struct device * mFlashDevice = DEVICE_DT_GET(DT_CHOSEN(nordic_pm_ext_flash));
     uint8_t mFactoryDataBuffer[FACTORY_DATA_SIZE];
 };
-#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
+#endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1 && (defined(CONFIG_CHIP_QSPI_NOR) ||
+       // defined(CONFIG_CHIP_SPI_NOR))
 
 class FactoryDataProviderBase : public chip::Credentials::DeviceAttestationCredentialsProvider,
                                 public CommissionableDataProvider,


### PR DESCRIPTION
We need to have support for factory data when the partition manager is enabled but there is no support for QSPI external flash.
