### PR TITLE
[nrf toup][nrfconnect] Fixed mcuboot default configuration

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -334,9 +334,9 @@ if PSA_CRYPTO_DRIVER_CC3XX && PSA_CRYPTO_DRIVER_OBERON
 config PSA_USE_CC3XX_HASH_DRIVER
     default n
 
-endif
+endif # PSA_CRYPTO_DRIVER_CC3XX && PSA_CRYPTO_DRIVER_OBERON
 
-endif
+endif # CHIP_CRYPTO_PSA
 
 if !CHIP_CRYPTO_PSA
 
@@ -379,7 +379,7 @@ config MBEDTLS_ECP_C
 config MBEDTLS_ECP_DP_SECP256R1_ENABLED
     default y
 
-endif
+endif # !CHIP_CRYPTO_PSA
 
 config MBEDTLS_PSA_CRYPTO_EXTERNAL_RNG
     default n if CHIP_WIFI
@@ -499,4 +499,4 @@ config OPENTHREAD_SHELL
 
 endif # SHELL
 
-endif
+endif # CHIP

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -42,14 +42,12 @@ config CHIP_WIFI
 
 config CHIP_QSPI_NOR
 	bool "Enable QSPI NOR feature set"
+	imply NORDIC_QSPI_NOR
 	help
 	  Enables QSPI NOR flash with a set of options for configuring pages and
 	  buffer sizes.
 
 if CHIP_QSPI_NOR
-
-config NORDIC_QSPI_NOR
-	default y
 
 config NORDIC_QSPI_NOR_STACK_WRITE_BUFFER_SIZE
 	default 16

--- a/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
@@ -19,16 +19,7 @@
 config MAIN_STACK_SIZE
     default 10240
 
-config BOOT_SWAP_SAVE_ENCTLV
-    default n
-
-config BOOT_ENCRYPT_RSA
-    default n
-
-config BOOT_ENCRYPT_EC256
-    default n
-
-config BOOT_ENCRYPT_X25519
+config BOOT_ENCRYPT_IMAGE
     default n
 
 config BOOT_BOOTSTRAP
@@ -53,9 +44,6 @@ if BOARD_NRF7002DK_NRF5340_CPUAPP || BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP
 config SPI
     default y
 
-config SPI_NOR
-    default y
-
 choice SPI_NOR_SFDP
 	default SPI_NOR_SFDP_DEVICETREE
 endchoice
@@ -73,9 +61,6 @@ endif
 
 # All boards beside nRF7002DK use QSPI NOR external flash
 if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840
-
-config NORDIC_QSPI_NOR
-    default y
 
 config NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE
     default 4096


### PR DESCRIPTION
Removed the defaults from Kconfig.mcuboot.defaults configuration that should not be set there:
* BOOT_ENCRYPT_X - are configs without a prompt, so it should not be modified outside of the mcuboot module
* SPI_NOR and NORDIC_QSPI_NOR - are set based on the device tree configuration, so we should not set it, as it may lead to configuration and dts mismatch.
