### PR TITLE
[nrf fromlist] [nrfconnect] Optimize packet buffer size

### DIFF
--- a/src/platform/nrfconnect/SystemPlatformConfig.h
+++ b/src/platform/nrfconnect/SystemPlatformConfig.h
@@ -51,6 +51,20 @@ struct ChipDeviceEvent;
 #define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 15
 #endif
 
+#ifndef CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX
+#ifdef CONFIG_WIFI_NRF700X
+// Minimal mDNS uses Matter packet buffers, so as long as minimal mDNS is used
+// in Nordic's Wi-Fi solution, the packet buffers must be a bit bigger than what
+// is required by Matter.
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX CONFIG_NRF_WIFI_IFACE_MTU
+#else
+// Matter specification requires that Matter messages fit in IPV6 MTU of 1280B
+// unless for large messages that can be sent over BTP or TCP. But those will
+// likely require a separate buffer pool or employ chained buffers.
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX 1280
+#endif // CONFIG_WIFI_NRF700X
+#endif // CHIP_SYSTEM_CONFIG_PACKETBUFFER_CAPACITY_MAX
+
 // ========== Platform-specific Configuration Overrides =========
 
 // Disable Zephyr Socket extensions module, as the Zephyr RTOS now implements recvmsg()


### PR DESCRIPTION
Matter requires that regular Matter messages fit in IPv6 MTU of 1280 bytes so the default packet buffer size of 1583 bytes seems excessively large for some configurations. Especially that the buffers only hold the UDP payload in the case of non-LWIP transports.

There are two exceptions to the above though:
1. Minimal mDNS uses the same packet buffer pool and mDNS message size is not limited to 1280 bytes, so shrinking the buffer size below MTU might have a negative impact on the mDNS behavior.
2. Matter allows definining so called large messages that can be bigger than 1280 bytes and sent over TCP, but that is not implemented yet and will likely require a different allocation mechanism.

manifest-pr-skip
