### PR TITLE
Clear ITS keys on factory reset

### DIFF
--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -433,6 +433,14 @@ config CHIP_FACTORY_RESET_ERASE_NVS
 	  configuration is supposed to be cleared on a factory reset, including
 	  device-specific entries.
 
+config CHIP_FACTORY_RESET_ERASE_PSA_ITS
+	bool "Erase all Matter-related crypto material from PSA ITS storage"
+	depends on CHIP_CRYPTO_PSA
+	help
+	  Erases all crypto materials from PSA ITS (Internal Trusted Storage)
+	  dedicated to Matter purposes. Crypto materials can be defined for example
+	  as Persistent Session keys.
+
 config CHIP_MALLOC_SYS_HEAP
 	bool "Memory allocator based on Zephyr sys_heap"
 	imply SYS_HEAP_RUNTIME_STATS

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -219,6 +219,13 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     for (uint32_t keyID = static_cast<uint32_t>(chip::Crypto::KeyIdBase::Minimum);
          keyID <= static_cast<uint32_t>(chip::Crypto::KeyIdBase::Maximum); keyID++)
     {
+#ifdef CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY
+        // Prevent from removing DAC Private Key
+        if (keyID == static_cast<uint32_t>(chip::Crypto::KeyIdBase::DACPrivKey))
+        {
+            continue;
+        }
+#endif
         psa_destroy_key(static_cast<psa_key_id_t>(keyID));
     }
 #endif

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -42,7 +42,11 @@
 
 #ifdef CONFIG_NET_L2_OPENTHREAD
 #include <platform/ThreadStackManager.h>
-#endif 
+#endif
+
+#ifdef CONFIG_CHIP_FACTORY_RESET_ERASE_PSA_ITS
+#include <crypto/CHIPCryptoPALPSA.h>
+#endif
 
 namespace chip {
 namespace DeviceLayer {
@@ -208,6 +212,15 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     }
 
     ConnectivityMgr().ErasePersistentInfo();
+#endif
+
+#ifdef CONFIG_CHIP_FACTORY_RESET_ERASE_PSA_ITS
+    // Ensure that all persistent PSA crypto materials are removed.
+    for (uint32_t keyID = static_cast<uint32_t>(chip::Crypto::KeyIdBase::Minimum);
+         keyID <= static_cast<uint32_t>(chip::Crypto::KeyIdBase::Maximum); keyID++)
+    {
+        psa_destroy_key(static_cast<psa_key_id_t>(keyID));
+    }
 #endif
 
     PlatformMgr().Shutdown();


### PR DESCRIPTION
Added a kconfig option to enable clearing keys stored in the PSA Internal Trusted Storage. If the kconfig is selected then during the factory reset process all keys stored in the PSA ITS will be destroyed.

This mechanism ensures that all PSA ITS crypto materials that belong to the Matter stack will be removed.

manifest-pr-skip

Commit c6d0842ba7c5b00a958909d16915a2768cbfdd18 will be pushed to Upstream after the first review here, and then this PR will be continued.
