### PR TITLE
[nrf toup][nrfconnect] Fixed calculation of Wi-Fi unicast counters

### DIFF
--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -299,8 +299,8 @@ CHIP_ERROR WiFiManager::GetNetworkStatistics(NetworkStatistics & stats) const
 
     stats.mPacketMulticastRxCount = data.multicast.rx;
     stats.mPacketMulticastTxCount = data.multicast.tx;
-    stats.mPacketUnicastRxCount   = data.pkts.rx - data.multicast.rx - data.broadcast.rx;
-    stats.mPacketUnicastTxCount   = data.pkts.tx - data.multicast.tx - data.broadcast.tx;
+    stats.mPacketUnicastRxCount   = data.unicast.rx;
+    stats.mPacketUnicastTxCount   = data.unicast.tx;
     stats.mBeaconsSuccessCount    = data.sta_mgmt.beacons_rx;
     stats.mBeaconsLostCount       = data.sta_mgmt.beacons_miss;
 


### PR DESCRIPTION
Wi-Fi unicast tx/rx counters were calculated based on a wrong values, what could lead to getting negative results.

Recent changes allow to use dedicated unicast structure field instead of obtaining the values based on calculation.


