### PR TITLE
[nrf fromtree][OpenThread] Disable IPv6 interface during erasing persistent info. (#33170)

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.hpp
@@ -1224,6 +1224,7 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_ErasePersistentInfo(v
     ChipLogProgress(DeviceLayer, "Erasing Thread persistent info...");
     Impl()->LockThreadStack();
     otThreadSetEnabled(mOTInst, false);
+    otIp6SetEnabled(mOTInst, false);
     otInstanceErasePersistentInfo(mOTInst);
     Impl()->UnlockThreadStack();
 }

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -183,6 +183,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
 {
     ChipLogProgress(DeviceLayer, "Performing factory reset");
 
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+    ThreadStackMgr().ClearAllSrpHostAndServices();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+
 // Lock the Thread stack to avoid unwanted interaction with settings NVS during factory reset.
 #ifdef CONFIG_NET_L2_OPENTHREAD
     ThreadStackMgr().LockThreadStack();


### PR DESCRIPTION
Apart from disabling Thread, and erasing Persistent Info, we should disable the IPv6 interface as well and block receiving further packets.
Otherwise, if we don't reboot the device after erasing Thread persistent data, we can get a packet and as a result, it causes an assert during processing AES_ECB
(because crypto keys have been removed).

cherry-picked from: 416f6a315f286a242e78048039b6525cafaabd74


