### PR TITLE
[nrf toup] Enable MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH config

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -420,6 +420,9 @@ config MBEDTLS_SSL_SRV_C
 config MBEDTLS_SSL_COOKIE_C
     default n
 
+config MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
+    default y
+
 # ==============================================================================
 # Logging configuration
 # ==============================================================================


### PR DESCRIPTION
This commit enables MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH for Matter over Wi-Fi to optimize flash usage (~0.4k).

manifest-pr-skip