### PR TITLE
[nrf toup] Allow for ext flash erasing when using SPI

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -60,6 +60,7 @@ config CHIP_SPI_NOR
 	imply SPI_NOR
 	imply MULTITHREADING
 	imply PM_OVERRIDE_EXTERNAL_DRIVER_CHECK
+	imply MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING
 	help
 	  Enables SPI NOR flash with a set of options for configuring pages and
 	  buffer sizes.


### PR DESCRIPTION
Enable MCUMGR_GRP_IMG_ALLOW_ERASE_PENDING config that allows to overwrite the secondary slot image even
if the pending flag is set on that image.

Fixes KRKNWK-19009.
