### PR TITLE
[nrf noup] Power nRF54H20 workaround.

### DIFF
--- a/src/platform/nrfconnect/Reboot.cpp
+++ b/src/platform/nrfconnect/Reboot.cpp
@@ -21,14 +21,14 @@
 
 #include <zephyr/sys/reboot.h>
 
-#ifndef CONFIG_ARCH_POSIX
+#if !(defined(CONFIG_ARCH_POSIX) || defined(CONFIG_SOC_SERIES_NRF54HX))
 #include <hal/nrf_power.h>
 #endif
 
 namespace chip {
 namespace DeviceLayer {
 
-#ifdef CONFIG_ARCH_POSIX
+#if defined(CONFIG_ARCH_POSIX) || defined(CONFIG_SOC_SERIES_NRF54HX)
 
 void Reboot(SoftwareRebootReason reason)
 {


### PR DESCRIPTION
Provided a workaround for power reason for nrf54h20 since it is not available yet.