### PR TITLE
[nrf toup][nrfconnect] Fixed paths to used in the guides

### DIFF
--- a/docs/guides/nrfconnect_examples_software_update.md
+++ b/docs/guides/nrfconnect_examples_software_update.md
@@ -49,7 +49,7 @@ To test the DFU over Matter, you need to complete the following steps:
 
 4.  Run OTA Provider application with _matter.ota_ replaced with the path to the
     Matter OTA image which you wish to provide to the Matter device. Note that
-    the Matter OTA image is, by default, generated at _zephyr/matter.ota_ in the
+    the Matter OTA image is, by default, generated in the
     example's build directory:
 
     ```
@@ -180,10 +180,10 @@ Complete the following steps to perform DFU using mcumgr:
     that the Bluetooth LE advertising has started. See the user interface
     section in the example documentation to check the LED number.
 4.  Upload the application firmware image to the device by running the following
-    command in your example directory:
+    command in your example directory with the <application_name> replaced by your application name, for example `lock`:
 
     ```
-    sudo mcumgr --conntype ble --hci ble-hci-number --connstring peer_name='ble-device-name' image upload build/zephyr/app_update.bin -n 0 -w 1
+    sudo mcumgr --conntype ble --hci ble-hci-number --connstring peer_name='ble-device-name' image upload build/<application_name>/zephyr/zephyr.signed.bin -n 0 -w 1
     ```
 
     The operation can take a few minutes. Wait until the progress bar reaches
@@ -246,10 +246,10 @@ Complete the following steps to perform DFU using mcumgr:
     go straight to the step 8.
 
     a. Upload the network core firmware image to the device by running the
-    following command in your example directory:
+    following command in your example directory with the <network_image_name> replaced by your network image name, for example `ipc_radio`:
 
     ```
-    sudo mcumgr --conntype ble --hci ble-hci-number --connstring peer_name='ble-device-name' image upload build/zephyr/net_core_app_update.bin -n 1 -w 1
+    sudo mcumgr --conntype ble --hci ble-hci-number --connstring peer_name='ble-device-name' image upload build/signed_by_mcuboot_and_b0_<network_image_name>.bin -n 1 -w 1
     ```
 
     The operation can take a few minutes. Wait until the progress bar reaches

--- a/docs/guides/nrfconnect_factory_data_configuration.md
+++ b/docs/guides/nrfconnect_factory_data_configuration.md
@@ -760,11 +760,11 @@ $ python scripts/tools/nrfconnect/nrfconnect_generate_partition.py -h
 **Example of the command for the nRF52840 DK:**
 
 ```
-$ python scripts/tools/nrfconnect/nrfconnect_generate_partition.py -i build/zephyr/factory_data.json -o build/zephyr/factory_data --offset 0xfb000 --size 0x1000
+$ python scripts/tools/nrfconnect/nrfconnect_generate_partition.py -i build/light_bulb/zephyr/factory_data.json -o build/light_bulb/zephyr/factory_data --offset 0xfb000 --size 0x1000
 ```
 
 As a result, `factory_data.hex` and `factory_data.bin` files are created in the
-`/build/zephyr/` directory. The first file contains the memory offset. For this
+`/build/light_bulb/zephyr/` directory. The first file contains the memory offset. For this
 reason, it can be programmed directly to the device using a programmer (for
 example, `nrfjprog`).
 


### PR DESCRIPTION
Guides contain path examples referring to the older build system version and they have to be updated.



