### PR TITLE
[nrf toup] Disable `CONFIG_FPU` by default to align with OT libraries

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -40,9 +40,6 @@ config ASSERT_NO_MSG_INFO
 config HW_STACK_PROTECTION
     default y
 
-config FPU
-    default y
-
 config POSIX_MAX_FDS
     default 16
 


### PR DESCRIPTION
Remove setting `CONFIG_FPU` to `y` by default as OpenThread libraries are now build without FPU support.