### PR TITLE
[nrf toup] Fix missing network band in scan response.

### DIFF
--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -49,6 +49,21 @@ namespace DeviceLayer {
 
 namespace {
 
+app::Clusters::NetworkCommissioning::WiFiBandEnum ConvertBandEnum(uint8_t band)
+{
+    switch (band)
+    {
+    case WIFI_FREQ_BAND_2_4_GHZ:
+        return app::Clusters::NetworkCommissioning::WiFiBandEnum::k2g4;
+    case WIFI_FREQ_BAND_5_GHZ:
+        return app::Clusters::NetworkCommissioning::WiFiBandEnum::k5g;
+    case WIFI_FREQ_BAND_6_GHZ:
+        return app::Clusters::NetworkCommissioning::WiFiBandEnum::k6g;
+    default:
+        return app::Clusters::NetworkCommissioning::WiFiBandEnum::kUnknownEnumValue;
+    }
+}
+
 NetworkCommissioning::WiFiScanResponse ToScanResponse(const wifi_scan_result * result)
 {
     NetworkCommissioning::WiFiScanResponse response = {};
@@ -64,6 +79,7 @@ NetworkCommissioning::WiFiScanResponse ToScanResponse(const wifi_scan_result * r
         response.channel = result->channel;
         response.rssi    = result->rssi;
         response.ssidLen = result->ssid_length;
+        response.wiFiBand = ConvertBandEnum(result->band);
         memcpy(response.ssid, result->ssid, result->ssid_length);
         // TODO: MAC/BSSID is not filled by the Wi-Fi driver
         memcpy(response.bssid, result->mac, result->mac_length);


### PR DESCRIPTION
There is a missing network band parameter in the scan response, and due to that the `networkcommissioning scan-networks` command shows 0 as the band field for all found networks.

Fixes: KRKNWK-19105