### PR TITLE
[nrf noup] Add SUIT to the Matter configuration

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -55,15 +55,58 @@ config CHIP_NFC_COMMISSIONING
 	help
 	  Enables sharing the onboarding payload in the NFC tag.
 
+choice CHIP_BOOTLOADER
+	prompt "Bootloader implementation for Matter purposes"
+	default CHIP_BOOTLOADER_SUIT if SOC_SERIES_NRF54HX
+	default CHIP_BOOTLOADER_MCUBOOT if !BOARD_NRF21540DK
+	default CHIP_BOOTLOADER_NONE
+
+config CHIP_BOOTLOADER_SUIT
+	bool "SUIT for Matter purposes"
+	imply SUIT
+	imply SSF_SUIT_SERVICE_ENABLED
+	
+config CHIP_BOOTLOADER_MCUBOOT
+	bool "MCUBOOT for Matter Bootloader purpose"
+	imply BOOTLOADER_MCUBOOT
+	select IMG_MANAGER
+
+config CHIP_BOOTLOADER_NONE
+	bool "No bootloader selected for Matter purposes"
+
+endchoice
+
+config CHIP_DFU_LIBRARY_MCUMGR
+	bool "Use mcumgr library for Matter DFU purposes"
+	# MCUBOOT
+	select MCUMGR_GRP_IMG if CHIP_BOOTLOADER_MCUBOOT
+	select MCUMGR_GRP_OS if CHIP_BOOTLOADER_MCUBOOT
+	# SUIT
+	select MGMT_SUITFU if CHIP_BOOTLOADER_SUIT
+	select MGMT_SUITFU_GRP_SUIT if CHIP_BOOTLOADER_SUIT
+	select MCUMGR_SMP_LEGACY_RC_BEHAVIOUR if CHIP_BOOTLOADER_SUIT
+	# COMMON
+	select MCUMGR
+	imply STREAM_FLASH
+	imply STREAM_FLASH_ERASE
+
+config CHIP_DFU_LIBRARY_DFU_TARGET
+	bool "Use dfu target library for Matter DFU purposes"
+	# MCUBOOT
+	imply DFU_MULTI_IMAGE if CHIP_BOOTLOADER_MCUBOOT
+	# SUIT
+	imply DFU_TARGET_SUIT if CHIP_BOOTLOADER_SUIT
+	# COMMON
+	imply DFU_TARGET
+	imply STREAM_FLASH
+	imply STREAM_FLASH_ERASE
+	select ZCBOR
+	select ZCBOR_CANONICAL
+
 # See config/zephyr/Kconfig for full definition
 config CHIP_OTA_REQUESTOR
 	bool
-	imply DFU_MULTI_IMAGE
-	imply DFU_TARGET
-	imply BOOTLOADER_MCUBOOT
-	imply IMG_MANAGER
-	imply STREAM_FLASH
-	imply STREAM_FLASH_ERASE
+	select CHIP_DFU_LIBRARY_DFU_TARGET
 
 config CHIP_OTA_REQUESTOR_BUFFER_SIZE
 	int "OTA Requestor image buffer size"

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -146,19 +146,13 @@ config CHIP_NUS_MAX_COMMANDS
 
 endif
 
-
 config CHIP_DFU_OVER_BT_SMP
 	bool "Enable DFU over Bluetooth LE SMP feature set"
+	depends on !CHIP_BOOTLOADER_NONE
 	imply CHIP_QSPI_NOR if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF52840DK_NRF52840
 	imply CHIP_SPI_NOR if BOARD_NRF7002DK_NRF5340_CPUAPP || BOARD_NRF7002DK_NRF7001_NRF5340_CPUAPP || BOARD_NRF54L15PDK_NRF54L15_CPUAPP
-	imply BOOTLOADER_MCUBOOT
-	select MCUMGR
+	select CHIP_DFU_LIBRARY_MCUMGR
 	select MCUMGR_TRANSPORT_BT
-	select IMG_MANAGER
-	select STREAM_FLASH
-	select ZCBOR
-	select MCUMGR_GRP_IMG
-	select MCUMGR_GRP_OS
 	# Enable custom SMP request to erase settings partition.
 	select MCUMGR_GRP_ZBASIC
 	select MCUMGR_GRP_ZBASIC_STORAGE_ERASE
@@ -176,15 +170,12 @@ config MCUMGR_TRANSPORT_NETBUF_COUNT
 	default 6
 
 config MCUMGR_MGMT_NOTIFICATION_HOOKS
-	bool
 	default y
 
 config MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK
-	bool
 	default y
 
 config MCUMGR_SMP_COMMAND_STATUS_HOOKS
-	bool
 	default y
 
 # Increase BT MTU and RX buffer for big size DFU messages


### PR DESCRIPTION
Added the new CHIP_SUIT config to enable all required dependencies for SUIT. Added SUIT for CHIP_DFU_OVER_BT_SMP to automatically enable SUIT module and BT SMP for nRF54H20.


