### PR TITLE
[nrf noup] ci: update the docker image

### DIFF
--- a/.github/workflows/release_tools.yaml
+++ b/.github/workflows/release_tools.yaml
@@ -36,7 +36,7 @@ jobs:
             DEBIAN_FRONTEND: noninteractive
 
         container:
-            image: connectedhomeip/chip-build:0.6.18
+            image: ghcr.io/project-chip/chip-build:41
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
                 - "/tmp/output_binaries:/tmp/output_binaries"


### PR DESCRIPTION
This fixes the chip tools build workflow.

