### PR TITLE
[nrf toup] [nrfconnect] Implement IPv6 agnostic L2 network state getters

### DIFF
--- a/src/platform/nrfconnect/ConnectivityManagerImpl.h
+++ b/src/platform/nrfconnect/ConnectivityManagerImpl.h
@@ -81,6 +81,32 @@ class ConnectivityManagerImpl final : public ConnectivityManager,
     // the implementation methods provided by this class.
     friend class ConnectivityManager;
 
+public:
+    // Generic network status checkers
+    bool IsIPv6NetworkEnabled()
+    {
+        return false
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+            || IsThreadEnabled()
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+            || IsWiFiStationEnabled()
+#endif
+            ;
+    };
+
+    bool IsIPv6NetworkProvisioned()
+    {
+        return false
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+            || IsThreadProvisioned()
+#endif
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+            || IsWiFiStationProvisioned()
+#endif
+            ;
+    }
+
 private:
     // ===== Members that implement the ConnectivityManager abstract interface.
 


### PR DESCRIPTION
* Added new API for generic IPv6 connectivity checks
* This patch allows the application layer to limit the amount of pre-processor logic (CONFIG_NET_L2_OPENTHREAD/CONFIG_CHIP_WIFI) needed to configure the


