### PR TITLE
[nrf toup][nrfconnect] Added support for settings shell in mem profiling

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -499,6 +499,9 @@ config HWINFO_SHELL
 config OPENTHREAD_SHELL
     default n if !CHIP_MEMORY_PROFILING
 
+config SHELL_CMD_BUFF_SIZE
+    default 512 if CHIP_MEMORY_PROFILING
+
 endif # SHELL
 
 endif # CHIP

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -86,6 +86,8 @@ config CHIP_MEMORY_PROFILING
 	select NET_SHELL
 	select NET_BUF_POOL_USAGE
 	select OPENTHREAD_SHELL if !CHIP_WIFI
+	# Settings
+	select SETTINGS_SHELL
 	# Zephyr
 	select KERNEL_SHELL
 	help


### PR DESCRIPTION
Enabled settings shell configuration and increased shell command
buffer size when `CHIP_MEMORY_PROFILING` is enabled to allow
reading and writing settings using shell.

