### PR TITLE
[nrf toup] config: align the MCUmgr Bluetooth transport Kconfig

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -166,8 +166,9 @@ config CHIP_DFU_OVER_BT_SMP
 if CHIP_DFU_OVER_BT_SMP
 
 # MCU Manager and SMP configuration
-config MCUMGR_TRANSPORT_BT_AUTHEN
-	default n
+choice MCUMGR_TRANSPORT_BT_PERM
+	default MCUMGR_TRANSPORT_BT_PERM_RW
+endchoice
 
 config MCUMGR_TRANSPORT_NETBUF_COUNT
 	default 6

--- a/config/zephyr/chip-module/Kconfig.features
+++ b/config/zephyr/chip-module/Kconfig.features
@@ -36,9 +36,9 @@ config MCUMGR_TRANSPORT_BT
 	bool
 	default y
 
-config MCUMGR_TRANSPORT_BT_AUTHEN
-	bool
-	default n
+choice MCUMGR_TRANSPORT_BT_PERM
+	default MCUMGR_TRANSPORT_BT_PERM_RW
+endchoice
 
 config MCUMGR_TRANSPORT_NETBUF_COUNT
 	int


### PR DESCRIPTION
Aligned the MCUmgr Bluetooth transport Kconfig with the latest changes from Zephyr.

Ref: NCSDK-29061

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

