### PR TITLE
[nrf noup] Shedule factory reset in Server using Matter Shell command

### DIFF
--- a/src/lib/shell/commands/Device.cpp
+++ b/src/lib/shell/commands/Device.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include <app/server/Server.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/shell/Commands.h>
 #if CONFIG_DEVICE_LAYER
@@ -42,7 +43,11 @@ int DeviceHelpHandler(int argc, char ** argv)
 static CHIP_ERROR FactoryResetHandler(int argc, char ** argv)
 {
     streamer_printf(streamer_get(), "Performing factory reset ... \r\n");
+#if CHIP_CONFIG_TEST
     DeviceLayer::ConfigurationMgr().InitiateFactoryReset();
+#else
+    chip::Server::GetInstance().ScheduleFactoryReset();
+#endif // CHIP_TEST
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
It is better to call the ScheduleFactoryReset method from the Server because it also removes all fabrics and emits the Leave event whereas calling InitiateFactoryReset() removes only the persistent storage entries.

In this way, the Matter Shell command works in the same way as other factory reset sources.

We cannot upmerge it in an easy way because many vendors do not use chip server and there are multiple building issues.


