### PR TITLE
[nrf toup] examples: align nRF5340 IPC

### DIFF
--- a/examples/all-clusters-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/all-clusters-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,17 +14,10 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/examples/all-clusters-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/examples/all-clusters-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -14,15 +14,8 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };

--- a/examples/light-switch-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/light-switch-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,15 +14,8 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };

--- a/examples/light-switch-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/examples/light-switch-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -14,15 +14,8 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };

--- a/examples/lighting-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/lighting-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,8 +14,6 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
@@ -36,11 +34,6 @@
 			pwms = < &pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 &pwm0 {

--- a/examples/lighting-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/examples/lighting-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -14,8 +14,6 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
@@ -36,11 +34,6 @@
 			pwms = < &pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 &pwm0 {

--- a/examples/lit-icd-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/lit-icd-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,17 +14,10 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/examples/lock-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/lock-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,17 +14,10 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */

--- a/examples/lock-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/examples/lock-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -14,15 +14,8 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };

--- a/examples/pump-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/pump-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,15 +14,8 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };

--- a/examples/pump-controller-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/pump-controller-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,15 +14,8 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };

--- a/examples/window-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/window-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -14,8 +14,6 @@
  *    limitations under the License.
  */
 
-#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
-
 / {
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
@@ -39,11 +37,6 @@
 			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
-};
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
 };
 
 /* Disable unused peripherals to reduce power consumption */


### PR DESCRIPTION
nRF5340 IPC now uses icbmsg, so align all overlays accordingly.

