### PR TITLE
[nrf toup] Increased CHIP stack size for cracen based targets

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -177,6 +177,7 @@ config CHIP_MALLOC_SYS_HEAP
 config CHIP_TASK_STACK_SIZE
 	int "The CHIP (Matter) thread stack size"
 	default 10240 if (LTO || PSA_CRYPTO_DRIVER_CC3XX)
+	default 9216 if PSA_CRYPTO_DRIVER_CRACEN
 	default 6144
 	help
 	  Configures the stack size available for the CHIP (Matter) thread.


### PR DESCRIPTION
Targets using cracen crypto backend requires bigger CHIP stack size.
