### PR TITLE
[nrf toup][nrfconnect] Fix DAC migration

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -330,9 +330,7 @@ endif # CHIP_FACTORY_DATA_BUILD
 
 # See config/zephyr/Kconfig for full definition
 config CHIP_FACTORY_RESET_ERASE_SETTINGS
-	default y
-	depends on NVS || ZMS
-	depends on !CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY
+	default y if !CHIP_CRYPTO_PSA_DAC_PRIV_KEY_ITS || BUILD_WITH_TFM
 
 config CHIP_LOG_SIZE_OPTIMIZATION
 	bool "Disable some detailed logs to decrease flash usage"
@@ -369,8 +367,11 @@ config CHIP_ENABLE_READ_CLIENT
 
 config CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY
 	bool "Migrate DAC private key from factory data to a secure storage"
+	default y
 	depends on CHIP_CRYPTO_PSA
 	depends on CHIP_FACTORY_DATA
+
+if CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY
 
 choice CHIP_CRYPTO_PSA_DAC_PRIV_KEY_MIGRATION_DEST
 	prompt "Destination for DAC private key migration"
@@ -408,6 +409,8 @@ config CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU_ENCRYPTED
 	depends on CHIP_CRYPTO_PSA_DAC_PRIV_KEY_KMU
 	help
 	  Encrypt the DAC private key in the CRACEN KMU secure storage.
+
+endif # CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY
 
 config CHIP_PERSISTENT_SUBSCRIPTIONS
 	default n

--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -433,9 +433,6 @@ config MBEDTLS_SSL_COOKIE_C
 config MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
     default y
 
-config CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY
-    default y if !CHIP_WIFI
-
 # ==============================================================================
 # Logging configuration
 # ==============================================================================

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -174,15 +174,16 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::MoveDACPrivateKeyToSecureStora
 #else
             psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_VOLATILE);
 #endif // CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY
+            VerifyOrReturnError(psa_import_key(&attributes, reinterpret_cast<uint8_t *>(mFactoryData.dac_priv_key.data),
+                                               mFactoryData.dac_priv_key.len, &mDACPrivKeyId) == PSA_SUCCESS,
+                                CHIP_ERROR_INTERNAL);
         }
-        VerifyOrReturnError(psa_import_key(&attributes, reinterpret_cast<uint8_t *>(mFactoryData.dac_priv_key.data),
-                                           mFactoryData.dac_priv_key.len, &mDACPrivKeyId) == PSA_SUCCESS,
-                            CHIP_ERROR_INTERNAL);
 
 #ifdef CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY
-#ifdef CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+#if defined(CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS) && defined(CONFIG_CHIP_CRYPTO_PSA_DAC_PRIV_KEY_ITS) &&                       \
+    !defined(CONFIG_BUILD_WITH_TFM)
 #error "Do not use both CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS and CONFIG_CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY kconfig options " \
-       "because you will permanently lose the DAC private key from the device."
+       "while saving the DAC private key to ITS because you will permanently lose the DAC private key from the device."
 #endif
         // Check once again if the saved key has attributes set before removing it from the factory data set.
         VerifyOrReturnError(psa_get_key_attributes(mDACPrivKeyId, &attributes) == PSA_SUCCESS, CHIP_ERROR_INTERNAL);


### PR DESCRIPTION
- Fixed wrong dependency in Kconfigs
- Fixed wrong bracket placement that causes overwriting DAC private key.

