### PR TITLE
[nrf toup][nrfconnect] Enabled DAC migration by default for Thread

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -433,6 +433,9 @@ config MBEDTLS_SSL_COOKIE_C
 config MBEDTLS_AES_ONLY_128_BIT_KEY_LENGTH
     default y
 
+config CHIP_CRYPTO_PSA_MIGRATE_DAC_PRIV_KEY
+    default y if !CHIP_WIFI
+
 # ==============================================================================
 # Logging configuration
 # ==============================================================================


### PR DESCRIPTION
Enabled DAC migration for all targets using Thread protocol, as Wi-Fi does not support PSA yet.

