### PR TITLE
[nrf noup] Provide a workaround for Factory Data support on nRF54H

### DIFF
--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -36,7 +36,12 @@
 #else
 #include <zephyr/storage/flash_map.h>
 #define FACTORY_DATA_SIZE DT_REG_SIZE(DT_ALIAS(factory_data))
+#define FACTORY_DATA_LOCATION_ADDRESS DT_REG_ADDR(DT_ALIAS(factory_data_location))
+#if FACTORY_DATA_LOCATION_ADDRESS
+#define FACTORY_DATA_ADDRESS (DT_REG_ADDR(DT_ALIAS(factory_data)) + FACTORY_DATA_LOCATION_ADDRESS)
+#else
 #define FACTORY_DATA_ADDRESS DT_REG_ADDR(DT_ALIAS(factory_data))
+#endif // if FACTORY_DATA_LOCATION_ADDRESS
 #endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
 
 #include <system/SystemError.h>


### PR DESCRIPTION
Until we do not have a proper solution for merging the factory data hex file with the firmware hex file, we need to flash the factory data manually. This commit allows doing that on nRF54H20 DK.

