### PR TITLE
[nrf toup] [nrfconnect] disable `FPROTECT` for nRF54L15

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -228,7 +228,7 @@ config CHIP_FACTORY_DATA_ROTATING_DEVICE_UID_MAX_LEN
 config CHIP_FACTORY_DATA_WRITE_PROTECT
 	bool "Enable Factory Data write protection"
 	select FPROTECT
-	depends on CHIP_FACTORY_DATA
+	depends on CHIP_FACTORY_DATA && !SOC_SERIES_NRF54LX
 	default y
 	help
 		Enables the write protection of the Factory Data partition in the flash memory.


### PR DESCRIPTION
`FPROTECT` should be disabled for nRF54L15 in app to allow correctly protecting whole region of mcuboot

