### PR TITLE
[nrf noup] config: Add support for non-PM factory data generation

### DIFF
--- a/config/nrfconnect/chip-module/generate_factory_data_sysbuild.cmake
+++ b/config/nrfconnect/chip-module/generate_factory_data_sysbuild.cmake
@@ -163,21 +163,16 @@ function(nrfconnect_create_factory_data factory_data_target script_path schema_p
     string(APPEND script_args "--offset $<TARGET_PROPERTY:partition_manager,PM_FACTORY_DATA_ADDRESS>\n")
     string(APPEND script_args "--size $<TARGET_PROPERTY:partition_manager,PM_FACTORY_DATA_OFFSET>\n")
   else()
-    include(${CMAKE_BINARY_DIR}/${DEFAULT_IMAGE}/zephyr/dts.cmake)
+    include(${ZEPHYR_NRF_MODULE_DIR}/cmake/sysbuild/suit_utilities.cmake)
 
-    get_target_property(factory_data_alias devicetree_target "DT_ALIAS|factory-data")
-    get_target_property(factory_data_address devicetree_target "DT_REG|${factory_data_alias}|ADDR")
-    get_target_property(factory_data_size devicetree_target "DT_REG|${factory_data_alias}|SIZE")
-
-    # remove ; from address and size properties
-    string(SUBSTRING ${factory_data_address} 0 -1 factory_data_address)
-    string(SUBSTRING ${factory_data_size} 0 -1 factory_data_size)
-    if(NOT (DEFINED factory_data_alias AND DEFINED factory_data_address AND DEFINED factory_data_size))
-      message(FATAL_ERROR "factory-data alias does not exist in DTS")
-    endif()
-
+    sysbuild_dt_alias(factory_data_alias IMAGE ${DEFAULT_IMAGE} PROPERTY "factory-data")
+    sysbuild_dt_reg_addr(factory_data_address IMAGE ${DEFAULT_IMAGE} PATH "${factory_data_alias}")
+    sysbuild_dt_reg_size(factory_data_size IMAGE ${DEFAULT_IMAGE} PATH "${factory_data_alias}")
     string(APPEND script_args "--offset ${factory_data_address}\n")
     string(APPEND script_args "--size ${factory_data_size}\n")
+    suit_add_merge_hex_file(FILES ${factory_data_output_path}.hex
+                            DEPENDENCIES ${factory_data_target}
+    )
   endif()
 
   # Execute first script to create a JSON file


### PR DESCRIPTION
fixup! [nrf noup] config: Add initial sysbuild files

Adds support for factory data generation using devicetree data from the primary sysbuild image, if partition manager is not enabled for a build

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

