### PR TITLE
[nrf toup] getting boot reason on nRF54h20

### DIFF
--- a/src/platform/SaveBootReasonDFUSuit.h
+++ b/src/platform/SaveBootReasonDFUSuit.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef NRF_SAVE_BOOT_REASON_H__
+#define NRF_SAVE_BOOT_REASON_H__
+
+inline int SoftwareBootReasonSUIT __attribute__((section(".noinit")));
+
+inline int getSoftwareRebootReasonSUIT()
+{
+    return SoftwareBootReasonSUIT;
+}
+
+inline void setSoftwareRebootReasonSUIT(int reason)
+{
+    SoftwareBootReasonSUIT = reason;
+}
+
+#endif

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -46,6 +46,10 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
 
+#ifdef CONFIG_SOC_SERIES_NRF54HX
+#include <platform/SaveBootReasonDFUSuit.h>
+#endif
+
 namespace chip {
 namespace {
 #ifdef CONFIG_CHIP_CERTIFICATION_DECLARATION_STORAGE
@@ -182,6 +186,7 @@ CHIP_ERROR OTAImageProcessorImpl::Apply()
                 PlatformMgr().HandleServerShuttingDown();
                 k_msleep(CHIP_DEVICE_CONFIG_SERVER_SHUTDOWN_ACTIONS_SLEEP_MS);
 #ifdef CONFIG_DFU_TARGET_SUIT
+                SetSoftwareRebootReason(SoftwareRebootReason::kSoftwareUpdate);
                 dfu_target_suit_reboot();
 #else
                 Reboot(SoftwareRebootReason::kSoftwareUpdate);

--- a/src/platform/nrfconnect/Reboot.h
+++ b/src/platform/nrfconnect/Reboot.h
@@ -30,6 +30,7 @@ enum class SoftwareRebootReason : uint8_t
 
 [[noreturn]] void Reboot(SoftwareRebootReason reason);
 SoftwareRebootReason GetSoftwareRebootReason();
+void SetSoftwareRebootReason(SoftwareRebootReason reason);
 
 } // namespace DeviceLayer
 } // namespace chip


### PR DESCRIPTION
- Use NRF_RESETINFO register to get boot reason

