### PR TITLE
[nrf toup][nrfconnect] Added config to enable report on active mode

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -168,6 +168,7 @@ if (CONFIG_CHIP_ENABLE_ICD_SUPPORT)
     matter_add_gn_arg_bool  ("chip_enable_icd_checkin"                   CONFIG_CHIP_ICD_CHECK_IN_SUPPORT)
     matter_add_gn_arg_bool  ("chip_enable_icd_user_active_mode_trigger"  CONFIG_CHIP_ICD_UAT_SUPPORT)
     matter_add_gn_arg_bool  ("chip_enable_icd_dsls"                      CONFIG_CHIP_ICD_DSLS_SUPPORT)
+    matter_add_gn_arg_bool  ("chip_icd_report_on_active_mode"            CONFIG_CHIP_ICD_REPORT_ON_ACTIVE_MODE)
 endif()
 
 if (CONFIG_CHIP_FACTORY_DATA OR CONFIG_CHIP_FACTORY_DATA_CUSTOM_BACKEND)

--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -427,7 +427,7 @@ config CHIP_ICD_UAT_SUPPORT
 	  means (e.g. button press) to trigger an ICD device to enter the active mode and become responsive.
 
 config CHIP_ICD_DSLS_SUPPORT
-	bool "Intermittenttly Connected Device Dynamic SIT LIT support"
+	bool "Intermittently Connected Device Dynamic SIT LIT support"
 	depends on CHIP_ICD_LIT_SUPPORT
 	help
 	  Enables the Dynamic SIT LIT support in Matter. It allows the application to dynamically switch between
@@ -440,6 +440,11 @@ config CHIP_ICD_CLIENTS_PER_FABRIC
 	help
 	  Provides the Intermittently Connected Device number of clients per fabric. It determines the maximum number
 	  of clients per fabric that can be registered to receive notification from a device if their subscription is lost.
+
+config CHIP_ICD_REPORT_ON_ACTIVE_MODE
+	bool "Intermittently Connected Device report on active mode"
+	help
+	  Enables an ICD to send data report to the subscribers on entering the active mode.
 
 endif # CHIP_ENABLE_ICD_SUPPORT
 


### PR DESCRIPTION
Introduced Kconfig option that allows to enable an ICD to send data report on entering the active mode.

