### PR TITLE
[nrf toup] Disable `chip_build_tools` for Zephyr

### DIFF
--- a/build/chip/tools.gni
+++ b/build/chip/tools.gni
@@ -17,7 +17,7 @@ import("${chip_root}/src/platform/device.gni")
 declare_args() {
   # Build CHIP tools.
   chip_build_tools = current_os != "freertos" && current_os != "android" &&
-                     chip_device_platform != "fake"
+                     current_os != "zephyr" && chip_device_platform != "fake"
   chip_can_build_cert_tool =
       chip_crypto == "openssl" || chip_crypto == "boringssl" ||
       (chip_crypto == "" &&


### PR DESCRIPTION
Disable `chip_build_tools` when building for Zephyr as it enables `chip_with_nlfaultinjection` and increases RAM and FLASH usage.

