### PR TITLE
[nrf toup] Increased system workqueue size for LIT

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -51,7 +51,7 @@ config INIT_STACKS
 
 config SYSTEM_WORKQUEUE_STACK_SIZE
     default 2560 if CHIP_WIFI
-    default 1536 if CHIP_ICD_LIT_SUPPORT
+    default 2048 if CHIP_ICD_LIT_SUPPORT
 
 config HEAP_MEM_POOL_SIZE
     default 110720 if CHIP_WIFI


### PR DESCRIPTION
The LIT devices seem to need bigger size of workqueue on 54L.


