### PR TITLE
[nrf noup] Use KMU instead of ITS in Matter Crypto

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -192,6 +192,7 @@ endif()
 if (CONFIG_CHIP_CRYPTO_PSA)
     matter_add_gn_arg_string("chip_crypto"             "psa")
     matter_add_gn_arg_bool  ("chip_crypto_psa_spake2p" CONFIG_PSA_WANT_ALG_SPAKE2P_MATTER)
+    matter_add_gn_arg_bool  ("chip_crypto_kmu"         CONFIG_CHIP_CRYPTO_USE_KMU)
 endif()
 
 if (BOARD STREQUAL "native_posix")

--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -289,4 +289,13 @@ config CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY
 	  an action chosen by the CHIP_LAST_FABRIC_REMOVED_ACTION option. This schedule will allow for
 	  avoiding race conditions before the device removes non-volatile data.
 
+config CHIP_CRYPTO_USE_KMU
+	bool "Use CRACEN KMU driver for storing security materials"
+	depends on PSA_NEED_CRACEN_KMU_DRIVER
+	depends on CHIP_CRYPTO_PSA
+	help
+	  Store security materials in the CRACEN KMU space instead of PSA ITS.
+	  KMU slots 100-180 are dedicated for Matter purposes.
+	  The solution is currently limited to maximum 5 Matter fabrics.
+
 endif # CHIP

--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -55,6 +55,7 @@ buildconfig_header("crypto_buildconfig") {
     "CHIP_CRYPTO_OPENSSL=${chip_crypto_openssl}",
     "CHIP_CRYPTO_BORINGSSL=${chip_crypto_boringssl}",
     "CHIP_CRYPTO_PLATFORM=${chip_crypto_platform}",
+    "CHIP_CRYPTO_KMU=${chip_crypto_kmu}",
   ]
 }
 
@@ -124,6 +125,13 @@ if (chip_crypto == "openssl") {
       "CHIPCryptoPALmbedTLS.h",
       "CHIPCryptoPALmbedTLSCert.cpp",
     ]
+
+    if (chip_crypto_kmu) {
+      sources += [
+        "KMUKeystoreAdaptation.h"
+      ]
+    }
+
     public_deps = [ ":public_headers" ]
 
     if (!chip_external_mbedtls) {

--- a/src/crypto/CHIPCryptoPALPSA.cpp
+++ b/src/crypto/CHIPCryptoPALPSA.cpp
@@ -22,6 +22,9 @@
 
 #include "CHIPCryptoPALPSA.h"
 #include "CHIPCryptoPALmbedTLS.h"
+#if CHIP_CRYPTO_KMU
+#include "KMUKeystoreAdaptation.h"
+#endif
 
 #include <lib/core/CHIPEncoding.h>
 #include <lib/core/CHIPSafeCasts.h>
@@ -272,6 +275,10 @@ CHIP_ERROR FindFreeKeySlotInRange(psa_key_id_t & keyId, psa_key_id_t start, uint
 
     for (keyId = start; keyId < end; keyId++)
     {
+#if CHIP_CRYPTO_KMU
+        CHIP_ERROR error = KMU::GetSlot(&keyId, &attributes);
+        VerifyOrReturnError(error == CHIP_NO_ERROR, error);
+#endif
         psa_status_t status = psa_get_key_attributes(keyId, &attributes);
         if (status == PSA_ERROR_INVALID_HANDLE)
         {

--- a/src/crypto/KMUKeystoreAdaptation.h
+++ b/src/crypto/KMUKeystoreAdaptation.h
@@ -1,0 +1,104 @@
+/*
+ *    Copyright (c) 2024 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include "CHIPCryptoPALPSA.h"
+
+#include <cinttypes>
+#include <cracen_psa_kmu.h>
+
+/* KMU Slots for Matter purpose:
+ *
+ * DAC private key                  176-180 (1 key)
+ * NOC private keys (Operational)   155-175 (5 fabrics max)
+ * ICD keys                         113-153 (5 fabrics max)
+ *
+ * DAC private key needs 4 KMU slots (Encrypted)
+ * NOC private key needs 4 KMU slots (Encrypted)
+ * ICD key needs 3 KMU slots (Not encrypted)
+ */
+#define KMU_ADAPTATION_USE_ENCRYPTION 0
+
+namespace chip {
+namespace Crypto {
+namespace KMU {
+
+inline constexpr static uint8_t NOC_Offset         = 155;
+inline constexpr static uint8_t ICD_Offset         = 113;
+inline constexpr static uint8_t NOC_KeyMax         = 5;
+inline constexpr static uint8_t ICD_KeyMax         = 5;
+inline constexpr static uint8_t NOC_SingleKeySlots = 2;
+inline constexpr static uint8_t ICD_SingleKeySlots = 1;
+inline constexpr static uint8_t EncryptionOverhead = 2;
+
+inline CHIP_ERROR GetSlot(psa_key_id_t * keyID, psa_key_attributes_t * attributes)
+{
+    if (!keyID)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (static_cast<uint8_t>(*keyID) >= static_cast<uint8_t>(KeyIdBase::Operational) &&
+        static_cast<uint8_t>(*keyID) < static_cast<uint8_t>(KeyIdBase::DACPrivKey))
+    {
+        if (static_cast<uint8_t>(*keyID) > static_cast<uint8_t>(NOC_KeyMax))
+        {
+            return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+        }
+
+        psa_key_id_t newId = NOC_Offset + ((NOC_SingleKeySlots + EncryptionOverhead) * (*keyID - 1));
+        *keyID = static_cast<psa_key_id_t>(PSA_KEY_HANDLE_FROM_CRACEN_KMU_SLOT(CRACEN_KMU_KEY_USAGE_SCHEME_ENCRYPTED, newId));
+        if (attributes)
+        {
+            psa_set_key_lifetime(
+                attributes,
+                PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(PSA_KEY_PERSISTENCE_DEFAULT, PSA_KEY_LOCATION_CRACEN_KMU));
+        }
+
+        return CHIP_NO_ERROR;
+    }
+    else if (static_cast<uint8_t>(*keyID) >= static_cast<uint8_t>(KeyIdBase::ICDKeyRangeStart) &&
+             static_cast<uint8_t>(*keyID) < static_cast<uint8_t>(KeyIdBase::Maximum))
+    {
+        if (static_cast<uint8_t>(*keyID) > static_cast<uint8_t>(NOC_KeyMax))
+        {
+            return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+        }
+
+        psa_key_id_t newId = ICD_Offset + (ICD_SingleKeySlots * (*keyID - 1));
+        *keyID = static_cast<psa_key_id_t>(PSA_KEY_HANDLE_FROM_CRACEN_KMU_SLOT(CRACEN_KMU_KEY_USAGE_SCHEME_RAW, newId));
+
+        if (attributes)
+        {
+            // Cracen KMU supports only PSA_ALG_CCM algorithm, so convert it.
+            if (psa_get_key_algorithm(attributes) == PSA_ALG_AEAD_WITH_AT_LEAST_THIS_LENGTH_TAG(PSA_ALG_CCM, 8))
+            {
+                psa_set_key_algorithm(attributes, PSA_ALG_CCM);
+            }
+
+            psa_set_key_lifetime(
+                attributes,
+                PSA_KEY_LIFETIME_FROM_PERSISTENCE_AND_LOCATION(PSA_KEY_PERSISTENCE_DEFAULT, PSA_KEY_LOCATION_CRACEN_KMU));
+        }
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_ERROR_INVALID_ARGUMENT;
+}
+} // namespace KMU
+} // namespace Crypto
+} // namespace chip

--- a/src/crypto/PSASessionKeystore.cpp
+++ b/src/crypto/PSASessionKeystore.cpp
@@ -202,8 +202,10 @@ CHIP_ERROR PSASessionKeystore::PersistICDKey(Symmetric128BitsKeyHandle & key)
         return CHIP_NO_ERROR;
     }
 
-    SuccessOrExit(err = Crypto::FindFreeKeySlotInRange(newKeyId, to_underlying(KeyIdBase::ICDKeyRangeStart), kMaxICDClientKeys));
-    psa_set_key_lifetime(&attrs, PSA_KEY_LIFETIME_PERSISTENT);
+SuccessOrExit(err = Crypto::FindFreeKeySlotInRange(newKeyId, to_underlying(KeyIdBase::ICDKeyRangeStart), kMaxICDClientKeys));
+#if !CHIP_CRYPTO_KMU 
+    psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_PERSISTENT);
+#endif
     psa_set_key_id(&attrs, newKeyId);
     VerifyOrExit(psa_copy_key(key.As<psa_key_id_t>(), &attrs, &newKeyId) == PSA_SUCCESS, err = CHIP_ERROR_INTERNAL);
 

--- a/src/crypto/crypto.gni
+++ b/src/crypto/crypto.gni
@@ -22,6 +22,9 @@ declare_args() {
 
   # Use PSA Spake2+ implementation. Only used if chip_crypto == "psa"
   chip_crypto_psa_spake2p = false
+
+  # Provide KMU support for nRF54L15 devices. Only used if chip_crypto == "psa"
+  chip_crypto_kmu = false
 }
 
 assert(


### PR DESCRIPTION
Use KMU to store crypto materials instead of ITS when it is possible.
Added translation between ITS key IDs and KMU slots and adapted existing API.
The new feature can be enabled by setting the CHIP_CRYPTO_USE_KMU kconfig option to ``y``.

