### PR TITLE
[nrf noup][nrfconnect] Fix DAC migration for MRAM-based devices.

### DIFF
--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -37,11 +37,10 @@
 #include <zephyr/storage/flash_map.h>
 #define FACTORY_DATA_SIZE DT_REG_SIZE(DT_ALIAS(factory_data))
 #define FACTORY_DATA_LOCATION_ADDRESS DT_REG_ADDR(DT_ALIAS(factory_data_location))
-#if FACTORY_DATA_LOCATION_ADDRESS
-#define FACTORY_DATA_ADDRESS (DT_REG_ADDR(DT_ALIAS(factory_data)) + FACTORY_DATA_LOCATION_ADDRESS)
-#else
+#if defined(CONFIG_SOC_FLASH_NRF_MRAM) && !FACTORY_DATA_LOCATION_ADDRESS
+#error factory_data_location alias must be defined while using device with MRAM memory.
+#endif
 #define FACTORY_DATA_ADDRESS DT_REG_ADDR(DT_ALIAS(factory_data))
-#endif // if FACTORY_DATA_LOCATION_ADDRESS
 #endif // if defined(USE_PARTITION_MANAGER) && USE_PARTITION_MANAGER == 1
 
 #include <system/SystemError.h>
@@ -56,7 +55,13 @@ struct InternalFlashFactoryData
 {
     CHIP_ERROR GetFactoryDataPartition(uint8_t *& data, size_t & dataSize)
     {
-        data     = reinterpret_cast<uint8_t *>(FACTORY_DATA_ADDRESS);
+        data = reinterpret_cast<uint8_t *>(FACTORY_DATA_ADDRESS
+#ifdef CONFIG_SOC_FLASH_NRF_MRAM
+                                           // For devices that use MRAM we need to point to the factory data partition as absolute
+                                           // address to get the proper value.
+                                           + FACTORY_DATA_LOCATION_ADDRESS
+#endif
+        );
         dataSize = FACTORY_DATA_SIZE;
         return CHIP_NO_ERROR;
     }


### PR DESCRIPTION
A wrong device type was used for RRAM-based devices and inappropriate factory data addresses.

manifest-pr-skip