### PR TITLE
[nrf toup][nrfconnect] remove `zephyr,priority` phandle

### DIFF
--- a/examples/all-clusters-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/all-clusters-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -22,11 +22,6 @@
 	};
 };
 
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};
-
 /* Disable unused peripherals to reduce power consumption */
 &adc {
 	status = "disabled";

--- a/examples/all-clusters-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/examples/all-clusters-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -21,8 +21,3 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};

--- a/examples/light-switch-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/light-switch-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -21,8 +21,3 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};

--- a/examples/light-switch-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/examples/light-switch-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -21,8 +21,3 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};

--- a/examples/lighting-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/lighting-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -38,11 +38,6 @@
 	};
 };
 
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};
-
 &pwm0 {
 	pinctrl-0 = <&pwm0_default_alt>;
 	pinctrl-1 = <&pwm0_sleep_alt>;

--- a/examples/lighting-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/examples/lighting-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -38,11 +38,6 @@
 	};
 };
 
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};
-
 &pwm0 {
 	pinctrl-0 = <&pwm0_default_alt>;
 	pinctrl-1 = <&pwm0_sleep_alt>;

--- a/examples/lit-icd-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/lit-icd-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -22,11 +22,6 @@
 	};
 };
 
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};
-
 /* Disable unused peripherals to reduce power consumption */
 &adc {
 	status = "disabled";

--- a/examples/lock-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/lock-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -22,11 +22,6 @@
 	};
 };
 
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};
-
 /* Disable unused peripherals to reduce power consumption */
 &adc {
 	status = "disabled";

--- a/examples/lock-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
+++ b/examples/lock-app/nrfconnect/boards/nrf7002dk_nrf5340_cpuapp.overlay
@@ -21,8 +21,3 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};

--- a/examples/pump-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/pump-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -21,8 +21,3 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};

--- a/examples/pump-controller-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/pump-controller-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -21,8 +21,3 @@
 		nordic,pm-ext-flash = &mx25r64;
 	};
 };
-
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};

--- a/examples/window-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/window-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -41,11 +41,6 @@
 	};
 };
 
-/* Set IPC thread priority to the highest value to not collide with other threads. */
-&ipc0 {
-    zephyr,priority = <0 PRIO_COOP>;
-};
-
 /* Disable unused peripherals to reduce power consumption */
 &adc {
 	status = "disabled";


### PR DESCRIPTION
Remove `zephyr,priority` as it is not needed after switching to ipc,icbmsg.

