### PR TITLE
[nrfconnect] Moved 54L specific configs to defaults

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -60,7 +60,11 @@ config HEAP_MEM_POOL_IGNORE_MIN
     default y if CHIP_WIFI
 
 config CHIP_MALLOC_SYS_HEAP_SIZE
+    default 10240 if SOC_SERIES_NRF54LX # nRF54L requires more memory due to crypto backend
     default 8192 if NET_L2_OPENTHREAD
+
+config MPSL_WORK_STACK_SIZE
+    default 2048 if SOC_SERIES_NRF54LX # nRF54L requires more memory due to crypto backend
 
 # We use sys_heap based allocators, so make sure we don't reserve unused libc heap anyway
 config COMMON_LIBC_MALLOC_ARENA_SIZE


### PR DESCRIPTION
Increased the malloc heap size for 54L and moved MPSL stack size config to defaults, as it was set in all Matter samples.



