### PR TITLE
[nrf noup] CODEOWNERS: override codeowners to ncs-matter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -69,3 +69,6 @@ telink/                          @s07641069
 chip-build-telink/               @s07641069
 
 webos/                           @joonhaengHeo
+
+# Global override for sdk-connectedhomeip
+*                                @nrfconnect/ncs-matter


### PR DESCRIPTION
Override codeowners to ncs-matter for whole sdk-connectedhomeip repository.