### PR TITLE
[nrf noup] Export compile commands

### DIFF
--- a/config/common/cmake/chip_gn.cmake
+++ b/config/common/cmake/chip_gn.cmake
@@ -134,6 +134,7 @@ macro(matter_build target)
                                     --dotfile=${GN_ROOT_TARGET}/.gn
                                     --script-executable=${Python3_EXECUTABLE}
                                     gen --check --fail-on-unused-args ${CMAKE_CURRENT_BINARY_DIR}
+                                    --export-compile-commands
         COMMAND                 ninja
         COMMAND                 ${CMAKE_COMMAND} -E echo "Matter library build complete"
         INSTALL_COMMAND         ""


### PR DESCRIPTION
Add `--export-compile-commands` to generate compile_commands.json for Matter library build.
