### PR TITLE
Cherry pick build optimizations from upstream

### DIFF
--- a/examples/chef/common/chef-dishwasher-mode-delegate-impl.cpp
+++ b/examples/chef/common/chef-dishwasher-mode-delegate-impl.cpp
@@ -17,6 +17,7 @@
  */
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/util/config.h>
+#include <chef-dishwasher-mode-delegate-impl.h>
 
 using namespace chip;
 using namespace chip::app;

--- a/examples/chef/common/chef-rvc-mode-delegate.cpp
+++ b/examples/chef/common/chef-rvc-mode-delegate.cpp
@@ -17,6 +17,7 @@
  */
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/util/config.h>
+#include <chef-rvc-mode-delegate.h>
 
 using namespace chip;
 using namespace chip::app;

--- a/examples/light-switch-app/cc13x4_26x4/src/AppTask.cpp
+++ b/examples/light-switch-app/cc13x4_26x4/src/AppTask.cpp
@@ -61,7 +61,7 @@
 #include <ti/drivers/apps/LED.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_UAT
-#include "app/icd/server/ICDNotifier.h"
+#include "app/icd/server/ICDNotifier.h" // nogncheck
 #endif
 
 /* syscfg */

--- a/examples/light-switch-app/infineon/cyw30739/src/ZclCallbacks.cpp
+++ b/examples/light-switch-app/infineon/cyw30739/src/ZclCallbacks.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 

--- a/examples/lighting-app/cc13x4_26x4/src/AppTask.cpp
+++ b/examples/lighting-app/cc13x4_26x4/src/AppTask.cpp
@@ -56,7 +56,7 @@
 #include <ti/drivers/apps/LED.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_UAT
-#include "app/icd/server/ICDNotifier.h"
+#include "app/icd/server/ICDNotifier.h" // nogncheck
 #endif
 
 /* syscfg */

--- a/examples/lighting-app/infineon/cyw30739/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/infineon/cyw30739/src/ZclCallbacks.cpp
@@ -19,6 +19,7 @@
 
 #include "LightingManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/DeviceInstanceInfoProvider.h>
 

--- a/examples/lock-app/cc13x4_26x4/src/AppTask.cpp
+++ b/examples/lock-app/cc13x4_26x4/src/AppTask.cpp
@@ -55,7 +55,7 @@
 #include <ti/drivers/apps/LED.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_UAT
-#include "app/icd/server/ICDNotifier.h"
+#include "app/icd/server/ICDNotifier.h" // nogncheck
 #endif
 
 /* syscfg */

--- a/examples/lock-app/infineon/cyw30739/src/ZclCallbacks.cpp
+++ b/examples/lock-app/infineon/cyw30739/src/ZclCallbacks.cpp
@@ -19,6 +19,7 @@
 
 #include "LockManager.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/cluster-objects.h>
 #include <app/data-model/Nullable.h>
 #include <lib/core/DataModelTypes.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/examples/pump-app/cc13x4_26x4/main/AppTask.cpp
+++ b/examples/pump-app/cc13x4_26x4/main/AppTask.cpp
@@ -57,7 +57,7 @@
 #include <ti/drivers/apps/LED.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_UAT
-#include "app/icd/server/ICDNotifier.h"
+#include "app/icd/server/ICDNotifier.h" // nogncheck
 #endif
 
 /* syscfg */

--- a/examples/pump-controller-app/cc13x4_26x4/main/AppTask.cpp
+++ b/examples/pump-controller-app/cc13x4_26x4/main/AppTask.cpp
@@ -52,7 +52,7 @@
 #include <ti/drivers/apps/LED.h>
 
 #if CHIP_CONFIG_ENABLE_ICD_UAT
-#include "app/icd/server/ICDNotifier.h"
+#include "app/icd/server/ICDNotifier.h" // nogncheck
 #endif
 
 /* syscfg */

--- a/examples/thermostat/infineon/cyw30739/src/TemperatureManager.cpp
+++ b/examples/thermostat/infineon/cyw30739/src/TemperatureManager.cpp
@@ -24,6 +24,7 @@
 #include "AppTask.h"
 #include "hdc2010.h"
 #include "platform/CHIPDeviceLayer.h"
+#include <app-common/zap-generated/cluster-objects.h>
 
 /**********************************************************
  * Defines and Constants

--- a/examples/thermostat/silabs/src/TemperatureManager.cpp
+++ b/examples/thermostat/silabs/src/TemperatureManager.cpp
@@ -25,6 +25,7 @@
 #include "AppConfig.h"
 #include "AppEvent.h"
 #include "AppTask.h"
+#include <app-common/zap-generated/cluster-objects.h>
 
 /**********************************************************
  * Defines and Constants

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -235,7 +235,6 @@ static_library("interaction-model") {
     "${chip_root}/src/app/codegen-data-model-provider:instance-header",
     "${chip_root}/src/app/data-model-provider",
     "${chip_root}/src/app/icd/server:icd-server-config",
-    "${chip_root}/src/app/icd/server:manager",
     "${chip_root}/src/app/icd/server:observer",
     "${chip_root}/src/app/util:af-types",
     "${chip_root}/src/app/util:callbacks",
@@ -246,6 +245,10 @@ static_library("interaction-model") {
     "${chip_root}/src/protocols/secure_channel",
     "${chip_root}/src/system",
   ]
+
+  if (chip_enable_icd_server) {
+    public_deps += [ "${chip_root}/src/app/icd/server:manager" ]
+  }
 
   public_configs = [ "${chip_root}/src:includes" ]
 
@@ -467,6 +470,7 @@ static_library("app") {
     ":constants",
     ":global-attributes",
     ":interaction-model",
+    ":test-event-trigger",
     "${chip_root}/src/app/data-model",
     "${chip_root}/src/app/icd/server:icd-server-config",
     "${chip_root}/src/app/util:callbacks",

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -25,9 +25,6 @@
 
 #pragma once
 
-// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed
-#include <lib/core/CHIPCore.h>
-
 #include <access/AccessControl.h>
 #include <app/AppConfig.h>
 #include <app/AttributePathParams.h>

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -28,6 +28,16 @@ include("${CHIP_ROOT}/src/app/codegen-data-model-provider/model.cmake")
 function(chip_configure_cluster APP_TARGET CLUSTER)
     file(GLOB CLUSTER_SOURCES "${CHIP_APP_BASE_DIR}/clusters/${CLUSTER}/*.cpp")
     target_sources(${APP_TARGET} PRIVATE ${CLUSTER_SOURCES})
+
+    # Add clusters dependencies
+    if (CLUSTER STREQUAL "icd-management-server")
+      # TODO(#32321): Remove after issue is resolved
+      # Add ICDConfigurationData when ICD management server cluster is included,
+      # but ICD support is disabled, e.g. lock-app on some platforms
+      if(NOT CONFIG_CHIP_ENABLE_ICD_SUPPORT)
+        target_sources(${APP_TARGET} PRIVATE ${CHIP_APP_BASE_DIR}/icd/server/ICDConfigurationData.cpp)
+      endif()
+    endif()
 endfunction()
 
 #

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -141,19 +141,6 @@ function(chip_configure_data_model APP_TARGET)
         )
     endif()
 
-    # These are:
-    #   //src/app/icd/server:notfier
-    #   //src/app/icd/server:monitoring-table
-    #   //src/app/icd/server:configuration-data
-    #
-    # TODO: ideally we would avoid duplication and would link gn-built items. In this case
-    #       it may be slightly harder because these are source_sets rather than libraries.
-    target_sources(${APP_TARGET} ${SCOPE}
-        ${CHIP_APP_BASE_DIR}/icd/server/ICDMonitoringTable.cpp
-        ${CHIP_APP_BASE_DIR}/icd/server/ICDNotifier.cpp
-        ${CHIP_APP_BASE_DIR}/icd/server/ICDConfigurationData.cpp
-    )
-
     # This is:
     #    //src/app/common:cluster-objects
     #

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -151,14 +151,6 @@ function(chip_configure_data_model APP_TARGET)
         )
     endif()
 
-    # This is:
-    #    //src/app/common:cluster-objects
-    #
-    # TODO: ideally we would avoid duplication and would link gn-built items
-    target_sources(${APP_TARGET} ${SCOPE}
-        ${CHIP_APP_BASE_DIR}/../../zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
-    )
-
     target_sources(${APP_TARGET} ${SCOPE}
         ${CHIP_APP_BASE_DIR}/../../zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
         ${CHIP_APP_BASE_DIR}/reporting/reporting.cpp

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/build/chip/chip_codegen.gni")
 import("${chip_root}/src/app/codegen-data-model-provider/model.gni")
 import("${chip_root}/src/app/common_flags.gni")
+import("${chip_root}/src/app/icd/icd.gni")
 import("${chip_root}/src/platform/python.gni")
 
 _app_root = get_path_info(".", "abspath")
@@ -331,9 +332,13 @@ template("chip_data_model") {
         deps += [
           "${chip_root}/src/app/icd/server:configuration-data",
           "${chip_root}/src/app/icd/server:icd-server-config",
-          "${chip_root}/src/app/icd/server:monitoring-table",
-          "${chip_root}/src/app/icd/server:notifier",
         ]
+        if (chip_enable_icd_server) {
+          deps += [ "${chip_root}/src/app/icd/server:notifier" ]
+          if (chip_enable_icd_checkin) {
+            deps += [ "${chip_root}/src/app/icd/server:monitoring-table" ]
+          }
+        }
       } else if (cluster == "resource-monitoring-server") {
         sources += [
           "${_app_root}/clusters/${cluster}/${cluster}.cpp",

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -24,7 +24,9 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/AttributeAccessInterfaceRegistry.h>
-#include <app/icd/server/ICDNotifier.h>
+#if CHIP_CONFIG_ENABLE_ICD_CIP
+#include <app/icd/server/ICDNotifier.h> // nogncheck
+#endif
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
 

--- a/src/app/clusters/icd-management-server/icd-management-server.cpp
+++ b/src/app/clusters/icd-management-server/icd-management-server.cpp
@@ -446,6 +446,7 @@ bool emberAfIcdManagementClusterUnregisterClientCallback(CommandHandler * comman
 bool emberAfIcdManagementClusterStayActiveRequestCallback(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
                                                           const Commands::StayActiveRequest::DecodableType & commandData)
 {
+// TODO(#32321): Remove #if after issue is resolved
 // Note: We only need this #if statement for platform examples that enable the ICD management server without building the sample
 // as an ICD. Since this is not spec compliant, we should remove this #if statement once we stop compiling the ICD management
 // server in those examples.

--- a/src/app/clusters/icd-management-server/icd-management-server.h
+++ b/src/app/clusters/icd-management-server/icd-management-server.h
@@ -30,7 +30,7 @@
 
 #if CHIP_CONFIG_ENABLE_ICD_CIP
 #include <app/ConcreteAttributePath.h>
-#include <app/icd/server/ICDMonitoringTable.h>
+#include <app/icd/server/ICDMonitoringTable.h> // nogncheck
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #endif // CHIP_CONFIG_ENABLE_ICD_CIP
 

--- a/src/app/reporting/ReportScheduler.h
+++ b/src/app/reporting/ReportScheduler.h
@@ -18,9 +18,6 @@
 
 #pragma once
 
-// TODO(#32628): Remove the CHIPCore.h header when the esp32 build is correctly fixed
-#include <lib/core/CHIPCore.h>
-
 #include <app/ReadHandler.h>
 #include <app/icd/server/ICDStateObserver.h>
 #include <lib/core/CHIPError.h>

--- a/src/app/server/BUILD.gn
+++ b/src/app/server/BUILD.gn
@@ -68,12 +68,8 @@ static_library("server") {
   #       be updated if this is not really "testing" even though headers are Test*.h)
   public_deps += [ "${chip_root}/src/lib/support:testing" ]
 
-  if (chip_enable_icd_server) {
-    public_deps += [ "${chip_root}/src/app/icd/server:notifier" ]
-
-    if (chip_enable_icd_checkin) {
-      public_deps +=
-          [ "${chip_root}/src/app/icd/server:default-check-in-back-off" ]
-    }
+  if (chip_enable_icd_checkin) {
+    public_deps +=
+        [ "${chip_root}/src/app/icd/server:default-check-in-back-off" ]
   }
 }

--- a/src/app/util/AttributesChangedListener.h
+++ b/src/app/util/AttributesChangedListener.h
@@ -1,0 +1,35 @@
+/**
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/AttributePathParams.h>
+
+namespace chip {
+namespace app {
+
+/// Notification object of a specific path being changed
+class AttributesChangedListener
+{
+public:
+    virtual ~AttributesChangedListener() = default;
+
+    /// Called when the set of attributes identified by AttributePathParams (which may contain wildcards) is to be considered dirty.
+    virtual void MarkDirty(const AttributePathParams & path) = 0;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/util/BUILD.gn
+++ b/src/app/util/BUILD.gn
@@ -54,7 +54,11 @@ source_set("types") {
 
 # This source set also depends on data-model
 source_set("af-types") {
-  sources = [ "af-types.h" ]
+  sources = [
+    "AttributesChangedListener.h",
+    "MarkAttributeDirty.h",
+    "af-types.h",
+  ]
   deps = [
     ":types",
     "${chip_root}/src/app:paths",

--- a/src/app/util/MarkAttributeDirty.h
+++ b/src/app/util/MarkAttributeDirty.h
@@ -1,0 +1,33 @@
+/**
+ *
+ *    Copyright (c) 2025 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+namespace chip {
+namespace app {
+
+enum class MarkAttributeDirty
+{
+    kIfChanged,
+    kNo,
+    // kYes might need to be used if the attribute value was previously changed
+    // without reporting, and now is being set in a situation where we know
+    // reporting needs to be triggered (e.g. because QuieterReportingAttribute
+    // indicated that).
+    kYes,
+};
+}
+} // namespace chip

--- a/src/app/util/af-types.h
+++ b/src/app/util/af-types.h
@@ -27,6 +27,8 @@
 #include <stdbool.h> // For bool
 #include <stdint.h>  // For various uint*_t types
 
+#include <app/util/AttributesChangedListener.h>
+#include <app/util/MarkAttributeDirty.h>
 #include <app/util/basic-types.h>
 #include <app/util/types_stub.h> // For various types.
 
@@ -300,30 +302,3 @@ typedef chip::Protocols::InteractionModel::Status (*EmberAfClusterPreAttributeCh
 #define MAX_INT16U_VALUE (0xFFFF)
 
 /** @} END addtogroup */
-
-namespace chip {
-namespace app {
-
-enum class MarkAttributeDirty
-{
-    kIfChanged,
-    kNo,
-    // kYes might need to be used if the attribute value was previously changed
-    // without reporting, and now is being set in a situation where we know
-    // reporting needs to be triggered (e.g. because QuieterReportingAttribute
-    // indicated that).
-    kYes,
-};
-
-/// Notification object of a specific path being changed
-class AttributesChangedListener
-{
-public:
-    virtual ~AttributesChangedListener() = default;
-
-    /// Called when the set of attributes identified by AttributePathParams (which may contain wildcards) is to be considered dirty.
-    virtual void MarkDirty(const AttributePathParams & path) = 0;
-};
-
-} // namespace app
-} // namespace chip

--- a/src/app/util/attribute-table.h
+++ b/src/app/util/attribute-table.h
@@ -18,7 +18,8 @@
 #pragma once
 
 #include <app/ConcreteAttributePath.h>
-#include <app/util/af-types.h>
+#include <app/util/AttributesChangedListener.h>
+#include <app/util/MarkAttributeDirty.h>
 #include <app/util/attribute-metadata.h>
 #include <lib/core/DataModelTypes.h>
 #include <protocols/interaction_model/StatusCode.h>

--- a/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors-src.zapt
@@ -12,6 +12,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/attribute-storage-null-handling.h>
 #include <app/util/attribute-table.h>
+#include <app/util/ember-strings.h>
 #include <app/util/odd-sized-integers.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/src/app/zap-templates/templates/app/attributes/Accessors.zapt
+++ b/src/app/zap-templates/templates/app/attributes/Accessors.zapt
@@ -7,11 +7,10 @@
 
 #pragma once
 
+#include <app-common/zap-generated/cluster-enums.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/af-types.h>
-#include <app/util/ember-strings.h>
-#include <app-common/zap-generated/cluster-objects.h>
-#include <lib/support/Span.h>
+#include <app/util/basic-types.h>
+#include <app/util/MarkAttributeDirty.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
@@ -29,6 +29,7 @@
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/util/attribute-storage-null-handling.h>
 #include <app/util/attribute-table.h>
+#include <app/util/ember-strings.h>
 #include <app/util/odd-sized-integers.h>
 #include <lib/core/CHIPEncoding.h>
 #include <lib/support/logging/CHIPLogging.h>

--- a/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+++ b/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
@@ -24,11 +24,10 @@
 
 #pragma once
 
-#include <app-common/zap-generated/cluster-objects.h>
+#include <app-common/zap-generated/cluster-enums.h>
 #include <app/data-model/Nullable.h>
-#include <app/util/af-types.h>
-#include <app/util/ember-strings.h>
-#include <lib/support/Span.h>
+#include <app/util/MarkAttributeDirty.h>
+#include <app/util/basic-types.h>
 #include <protocols/interaction_model/StatusCode.h>
 
 namespace chip {


### PR DESCRIPTION
* Remove ICD server sources from chip_data_model.cmake
* Fix ICD dependencies
* Fix gn include warnings
* iOS TVCasting app: Add missing chip_project_config_include
* Fix ICD management server cluster dependecies
* Remove workaround for upstream issue 32628
