### PR TITLE
DNM: Fix Fail-Safe after reboot

### DIFF
--- a/src/app/FailSafeContext.cpp
+++ b/src/app/FailSafeContext.cpp
@@ -34,6 +34,15 @@ using namespace chip::DeviceLayer;
 namespace chip {
 namespace app {
 
+CHIP_ERROR FailSafeContext::Init(const InitParams & initParams)
+{
+    VerifyOrReturnError(initParams.storage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    mStorage = initParams.storage;
+
+    return CHIP_NO_ERROR;
+}
+
 void FailSafeContext::HandleArmFailSafeTimer(System::Layer * layer, void * aAppState)
 {
     FailSafeContext * failSafeContext = reinterpret_cast<FailSafeContext *>(aAppState);

--- a/src/app/FailSafeContext.cpp
+++ b/src/app/FailSafeContext.cpp
@@ -24,6 +24,8 @@
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
 #include <app/icd/server/ICDNotifier.h> // nogncheck
 #endif
+#include <lib/core/TLV.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
 #include <lib/support/SafeInt.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/ConnectivityManager.h>
@@ -33,6 +35,20 @@ using namespace chip::DeviceLayer;
 
 namespace chip {
 namespace app {
+
+namespace {
+
+// Tags for AddNOCStartedMarker storage
+constexpr TLV::Tag kAddNOCStartedMarkerFabricIndexTag = TLV::ContextTag(0);
+
+constexpr size_t AddNOCStartedMarkerContextTLVMaxSize()
+{
+    // Add 2x uncommitted uint64_t to leave space for backwards/forwards
+    // versioning for this critical feature that runs at boot.
+    return TLV::EstimateStructOverhead(sizeof(FabricIndex), sizeof(uint64_t), sizeof(uint64_t));
+}
+
+} // namespace
 
 CHIP_ERROR FailSafeContext::Init(const InitParams & initParams)
 {
@@ -159,6 +175,60 @@ void FailSafeContext::ForceFailSafeTimerExpiry()
     DeviceLayer::SystemLayer().CancelTimer(HandleMaxCumulativeFailSafeTimer, this);
 
     FailSafeTimerExpired();
+}
+
+CHIP_ERROR FailSafeContext::GetAddNOCStartedMarker(AddNOCStartedMarker & outMarker)
+{
+    VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    uint8_t tlvBuf[AddNOCStartedMarkerContextTLVMaxSize()];
+    uint16_t tlvSize = sizeof(tlvBuf);
+
+    ReturnErrorOnFailure(
+        mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FailSafeAddNOCStartedMarkerKey().KeyName(), tlvBuf, tlvSize));
+
+    // If buffer was too small, we won't reach here.
+    TLV::ContiguousBufferTLVReader reader;
+    reader.Init(tlvBuf, tlvSize);
+    ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
+
+    TLV::TLVType containerType;
+    ReturnErrorOnFailure(reader.EnterContainer(containerType));
+
+    ReturnErrorOnFailure(reader.Next(kAddNOCStartedMarkerFabricIndexTag));
+    ReturnErrorOnFailure(reader.Get(outMarker.fabricIndex));
+
+    // Don't try to exit container: we got all we needed. This allows us to
+    // avoid erroring-out on newer versions.
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR FailSafeContext::StoreAddNOCStartedMarker(const AddNOCStartedMarker & marker)
+{
+    VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    uint8_t tlvBuf[AddNOCStartedMarkerContextTLVMaxSize()];
+    TLV::TLVWriter writer;
+    writer.Init(tlvBuf);
+
+    TLV::TLVType outerType;
+    ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, outerType));
+    ReturnErrorOnFailure(writer.Put(kAddNOCStartedMarkerFabricIndexTag, marker.fabricIndex));
+    ReturnErrorOnFailure(writer.EndContainer(outerType));
+
+    const auto markerContextTLVLength = writer.GetLengthWritten();
+    VerifyOrReturnError(CanCastTo<uint16_t>(markerContextTLVLength), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::FailSafeAddNOCStartedMarkerKey().KeyName(), tlvBuf,
+                                     static_cast<uint16_t>(markerContextTLVLength));
+}
+
+void FailSafeContext::ClearAddNOCStartedMarker()
+{
+    VerifyOrDie(mStorage != nullptr);
+
+    mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::FailSafeAddNOCStartedMarkerKey().KeyName());
 }
 
 } // namespace app

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -42,6 +42,8 @@ public:
 
     CHIP_ERROR Init(const InitParams & initParams);
 
+    void CheckAddNOCStartedMarker();
+
     // ===== Members for internal use by other Device Layer components.
 
     /**

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include "lib/core/CHIPPersistentStorageDelegate.h"
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
@@ -34,6 +35,14 @@ namespace app {
 class FailSafeContext
 {
 public:
+    struct InitParams
+    {
+        // PersistentStorageDelegate for marker storage (MANDATORY).
+        PersistentStorageDelegate * storage = nullptr;
+    };
+
+    CHIP_ERROR Init(const InitParams & initParams);
+
     // ===== Members for internal use by other Device Layer components.
 
     /**
@@ -103,6 +112,7 @@ public:
     void ForceFailSafeTimerExpiry();
 
 private:
+    PersistentStorageDelegate * mStorage   = nullptr;
     bool mFailSafeArmed                    = false;
     bool mFailSafeBusy                     = false;
     bool mAddNocCommandHasBeenInvoked      = false;

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -148,7 +148,6 @@ private:
     }
 
     void FailSafeTimerExpired();
-    CHIP_ERROR CommitToStorage();
 };
 
 } // namespace app

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -27,7 +27,6 @@
 #include <lib/core/CHIPError.h>
 #include <lib/core/DataModelTypes.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <system/SystemClock.h>
 
 namespace chip {
 namespace app {
@@ -112,6 +111,15 @@ public:
     void ForceFailSafeTimerExpiry();
 
 private:
+    // Stored to indicate a Fail-Safe is in armed, so that clean-up cana run on next boot
+    // if device is reset e.g. during commissioning.
+    struct AddNOCStartedMarker
+    {
+        AddNOCStartedMarker() = default;
+        AddNOCStartedMarker(FabricIndex fabricIndex_) : fabricIndex{ fabricIndex_ } {}
+        FabricIndex fabricIndex = kUndefinedFabricIndex;
+    };
+
     PersistentStorageDelegate * mStorage   = nullptr;
     bool mFailSafeArmed                    = false;
     bool mFailSafeBusy                     = false;
@@ -158,6 +166,9 @@ private:
     }
 
     void FailSafeTimerExpired();
+    CHIP_ERROR GetAddNOCStartedMarker(AddNOCStartedMarker & outMarker);
+    CHIP_ERROR StoreAddNOCStartedMarker(const AddNOCStartedMarker & marker);
+    void ClearAddNOCStartedMarker();
 };
 
 } // namespace app

--- a/src/app/FailSafeContext.h
+++ b/src/app/FailSafeContext.h
@@ -56,11 +56,21 @@ public:
      * @brief Cleanly disarm failsafe timer, such as on CommissioningComplete
      */
     void DisarmFailSafe();
+
+    bool SetAddNocCommandStarted(FabricIndex nocFabricIndex)
+    {
+        mFabricIndex = nocFabricIndex;
+
+        AddNOCStartedMarker marker{ mFabricIndex };
+        return StoreAddNOCStartedMarker(marker) == CHIP_NO_ERROR;
+    }
+
     void SetAddNocCommandInvoked(FabricIndex nocFabricIndex)
     {
         mAddNocCommandHasBeenInvoked = true;
         mFabricIndex                 = nocFabricIndex;
     }
+
     void SetUpdateNocCommandInvoked() { mUpdateNocCommandHasBeenInvoked = true; }
     void SetAddTrustedRootCertInvoked() { mAddTrustedRootCertHasBeenInvoked = true; }
     void SetCsrRequestForUpdateNoc(bool isForUpdateNoc) { mIsCsrRequestForUpdateNoc = isForUpdateNoc; }
@@ -163,6 +173,8 @@ private:
         mAddTrustedRootCertHasBeenInvoked = false;
         mFailSafeBusy                     = false;
         mIsCsrRequestForUpdateNoc         = false;
+
+        ClearAddNOCStartedMarker();
     }
 
     void FailSafeTimerExpired();

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -650,6 +650,9 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
                                                                  &newFabricIndex);
     VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
+    // Inform FailSafeContext about starting adding NOC for specified fabric
+    VerifyOrExit(failSafeContext.SetAddNocCommandStarted(newFabricIndex), nonDefaultStatus = Status::Failure);
+
     // From here if we error-out, we should revert the fabric table pending updates
     needRevert = true;
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -445,6 +445,10 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         }
     }
 
+    // Run fail-safe check for marker. If marker is present, then device was reset while fail-safe was armed
+    // and we need to trigger a cleanup.
+    GetFailSafeContext().CheckAddNOCStartedMarker();
+
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT // support UDC port for commissioner declaration msgs
     mUdcTransportMgr = chip::Platform::New<UdcTransportMgr>();
     ReturnErrorOnFailure(mUdcTransportMgr->Init(Transport::UdpListenParameters(DeviceLayer::UDPEndPointManager())

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -174,6 +174,14 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         SuccessOrExit(err);
     }
 
+    {
+        app::FailSafeContext::InitParams failSafeInitParams;
+        failSafeInitParams.storage = mDeviceStorage;
+
+        err = mFailSafeContext.Init(failSafeInitParams);
+        SuccessOrExit(err);
+    }
+
     SuccessOrExit(err = mAccessControl.Init(initParams.accessDelegate, sDeviceTypeResolver));
     Access::SetAccessControl(mAccessControl);
 

--- a/src/app/tests/TestFailSafeContext.cpp
+++ b/src/app/tests/TestFailSafeContext.cpp
@@ -34,6 +34,7 @@
 #include <lib/core/StringBuilderAdapters.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <platform/CHIPDeviceLayer.h>
 
 using namespace chip;
@@ -66,7 +67,10 @@ public:
 
 TEST_F(TestFailSafeContext, TestFailSafeContext_ArmFailSafe)
 {
+    chip::TestPersistentStorageDelegate testStorage;
     chip::app::FailSafeContext failSafeContext;
+
+    failSafeContext.Init({ &testStorage });
 
     EXPECT_EQ(failSafeContext.ArmFailSafe(kTestAccessingFabricIndex1, System::Clock::Seconds16(1)), CHIP_NO_ERROR);
     EXPECT_TRUE(failSafeContext.IsFailSafeArmed());
@@ -80,7 +84,10 @@ TEST_F(TestFailSafeContext, TestFailSafeContext_ArmFailSafe)
 
 TEST_F(TestFailSafeContext, TestFailSafeContext_NocCommandInvoked)
 {
+    chip::TestPersistentStorageDelegate testStorage;
     chip::app::FailSafeContext failSafeContext;
+
+    failSafeContext.Init({ &testStorage });
 
     EXPECT_EQ(failSafeContext.ArmFailSafe(kTestAccessingFabricIndex1, System::Clock::Seconds16(1)), CHIP_NO_ERROR);
     EXPECT_EQ(failSafeContext.GetFabricIndex(), kTestAccessingFabricIndex1);

--- a/src/app/tests/TestThreadBorderRouterManagementCluster.cpp
+++ b/src/app/tests/TestThreadBorderRouterManagementCluster.cpp
@@ -31,6 +31,7 @@
 #include <lib/support/BitFlags.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/Span.h>
+#include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/ThreadOperationalDataset.h>
 #include <lib/support/tests/ExtraPwTestMacros.h>
 #include <optional>
@@ -154,6 +155,7 @@ public:
 
 constexpr EndpointId kTestEndpointId            = 1;
 constexpr FabricIndex kTestAccessingFabricIndex = 1;
+static chip::TestPersistentStorageDelegate sTestStorage;
 static FailSafeContext sTestFailsafeContext;
 static TestDelegate sTestDelegate;
 static ServerInstance sTestSeverInstance(kTestEndpointId, &sTestDelegate, sTestFailsafeContext);
@@ -211,6 +213,7 @@ public:
     {
         ASSERT_EQ(Platform::MemoryInit(), CHIP_NO_ERROR);
         ASSERT_EQ(DeviceLayer::PlatformMgr().InitChipStack(), CHIP_NO_ERROR);
+        ASSERT_EQ(sTestFailsafeContext.Init({ &sTestStorage }), CHIP_NO_ERROR);
     }
 
     static void TearDownTestSuite()

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1466,7 +1466,7 @@ CHIP_ERROR FabricTable::StoreCommitMarker(const CommitMarker & commitMarker)
     const auto markerContextTLVLength = writer.GetLengthWritten();
     VerifyOrReturnError(CanCastTo<uint16_t>(markerContextTLVLength), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::FailSafeCommitMarkerKey().KeyName(), tlvBuf,
+    return mStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::FabricTableCommitMarkerKey().KeyName(), tlvBuf,
                                      static_cast<uint16_t>(markerContextTLVLength));
 }
 
@@ -1475,7 +1475,7 @@ CHIP_ERROR FabricTable::GetCommitMarker(CommitMarker & outCommitMarker)
     uint8_t tlvBuf[CommitMarkerContextTLVMaxSize()];
     uint16_t tlvSize = sizeof(tlvBuf);
     ReturnErrorOnFailure(
-        mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FailSafeCommitMarkerKey().KeyName(), tlvBuf, tlvSize));
+        mStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::FabricTableCommitMarkerKey().KeyName(), tlvBuf, tlvSize));
 
     // If buffer was too small, we won't reach here.
     TLV::ContiguousBufferTLVReader reader;
@@ -1499,7 +1499,7 @@ CHIP_ERROR FabricTable::GetCommitMarker(CommitMarker & outCommitMarker)
 
 void FabricTable::ClearCommitMarker()
 {
-    mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::FailSafeCommitMarkerKey().KeyName());
+    mStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::FabricTableCommitMarkerKey().KeyName());
 }
 
 bool FabricTable::HasOperationalKeyForFabric(FabricIndex fabricIndex) const

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1002,39 +1002,35 @@ CHIP_ERROR FabricTable::Delete(FabricIndex fabricIndex)
         }
     }
 
-    if (!fabricIsInitialized)
+    if (fabricIsInitialized)
     {
-        // Make sure to return the error our API promises, not whatever storage
-        // chose to return.
-        return CHIP_ERROR_NOT_FOUND;
-    }
+        // Since fabricIsInitialized was true, fabric is not null.
+        fabricInfo->Reset();
 
-    // Since fabricIsInitialized was true, fabric is not null.
-    fabricInfo->Reset();
+        if (!mNextAvailableFabricIndex.HasValue())
+        {
+            // We must have been in a situation where CHIP_CONFIG_MAX_FABRICS is 254
+            // and our fabric table was full, so there was no valid next index.  We
+            // have a single available index now, though; use it as
+            // mNextAvailableFabricIndex.
+            mNextAvailableFabricIndex.SetValue(fabricIndex);
+        }
+        // If StoreFabricIndexInfo fails here, that's probably OK.  When we try to
+        // read things from storage later we will realize there is nothing for this
+        // index.
+        StoreFabricIndexInfo();
 
-    if (!mNextAvailableFabricIndex.HasValue())
-    {
-        // We must have been in a situation where CHIP_CONFIG_MAX_FABRICS is 254
-        // and our fabric table was full, so there was no valid next index.  We
-        // have a single available index now, though; use it as
-        // mNextAvailableFabricIndex.
-        mNextAvailableFabricIndex.SetValue(fabricIndex);
-    }
-    // If StoreFabricIndexInfo fails here, that's probably OK.  When we try to
-    // read things from storage later we will realize there is nothing for this
-    // index.
-    StoreFabricIndexInfo();
-
-    // If we ever start moving the FabricInfo entries around in the array on
-    // delete, we should update DeleteAllFabrics to handle that.
-    if (mFabricCount == 0)
-    {
-        ChipLogError(FabricProvisioning, "Trying to delete a fabric, but the current fabric count is already 0");
-    }
-    else
-    {
-        mFabricCount--;
-        ChipLogProgress(FabricProvisioning, "Fabric (0x%x) deleted.", static_cast<unsigned>(fabricIndex));
+        // If we ever start moving the FabricInfo entries around in the array on
+        // delete, we should update DeleteAllFabrics to handle that.
+        if (mFabricCount == 0)
+        {
+            ChipLogError(FabricProvisioning, "Trying to delete a fabric, but the current fabric count is already 0");
+        }
+        else
+        {
+            mFabricCount--;
+            ChipLogProgress(FabricProvisioning, "Fabric (0x%x) deleted.", static_cast<unsigned>(fabricIndex));
+        }
     }
 
     if (mDelegateListRoot != nullptr)
@@ -1050,12 +1046,17 @@ CHIP_ERROR FabricTable::Delete(FabricIndex fabricIndex)
         }
     }
 
-    // Only return error after trying really hard to remove everything we could
-    ReturnErrorOnFailure(metadataErr);
-    ReturnErrorOnFailure(opKeyErr);
-    ReturnErrorOnFailure(opCertsErr);
+    if (fabricIsInitialized)
+    {
+        // Only return error after trying really hard to remove everything we could
+        ReturnErrorOnFailure(metadataErr);
+        ReturnErrorOnFailure(opKeyErr);
+        ReturnErrorOnFailure(opCertsErr);
 
-    return CHIP_NO_ERROR;
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_ERROR_NOT_FOUND;
 }
 
 void FabricTable::DeleteAllFabrics()

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -412,7 +412,15 @@ public:
         No
     };
 
-    // Returns CHIP_ERROR_NOT_FOUND if there is no fabric for that index.
+    /**
+     * @brief Delete the fabric with given `fabricIndex`.
+     *
+     * @param fabricIndex - Index of fabric for deletion
+     * @retval CHIP_NO_ERROR on success
+     * @retval CHIP_ERROR_NOT_FOUND if there is no fabric for that index
+     * @retval CHIP_ERROR_INVALID_ARGUMENT if any of the arguments are invalid such as too large or out of bounds
+     * @retval other CHIP_ERROR on internal errors
+     */
     CHIP_ERROR Delete(FabricIndex fabricIndex);
     void DeleteAllFabrics();
 

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -103,7 +103,7 @@ public:
     static StorageKeyName FabricOpKey(FabricIndex fabric) { return StorageKeyName::Formatted("f/%x/o", fabric); }
 
     // Fail-safe handling
-    static StorageKeyName FailSafeCommitMarkerKey() { return StorageKeyName::FromConst("g/fs/c"); }
+    static StorageKeyName FabricTableCommitMarkerKey() { return StorageKeyName::FromConst("g/fs/c"); }
     static StorageKeyName FailSafeNetworkConfig() { return StorageKeyName::FromConst("g/fs/n"); }
 
     // LastKnownGoodTime

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -104,6 +104,7 @@ public:
 
     // Fail-safe handling
     static StorageKeyName FabricTableCommitMarkerKey() { return StorageKeyName::FromConst("g/fs/c"); }
+    static StorageKeyName FailSafeAddNOCStartedMarkerKey() { return StorageKeyName::FromConst("g/fs/m"); }
     static StorageKeyName FailSafeNetworkConfig() { return StorageKeyName::FromConst("g/fs/n"); }
 
     // LastKnownGoodTime


### PR DESCRIPTION
* Add Fail-Safe marker and store it before adding/updating NOC.
* Check if marker is present in settings during boot.
* Delete all Fabric data, even if they are not complete.

TODO: replace with commit fromtree