### PR TITLE
Cherry-pick changes from upstream

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -490,6 +490,25 @@
             "runToEntryPoint": "main",
             "preLaunchTask": "Debug Open IoT SDK unit-tests",
             "showDevDebugOutput": "parsed"
+        },
+        {
+            "name": "Zephyr native tests",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/out/nrf-native-sim-tests/nrfconnect/zephyr/zephyr.exe",
+            "args": ["-testargs"],
+            "stopAtEntry": false,
+            "cwd": "${workspaceFolder}/out/nrf-native-sim-tests/nrfconnect",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                }
+            ]
         }
     ],
     "inputs": [

--- a/examples/platform/infineon/cyw30739/BUILD.gn
+++ b/examples/platform/infineon/cyw30739/BUILD.gn
@@ -29,7 +29,10 @@ static_library("platform") {
 
   public_configs = [ ":${target_name}-config" ]
 
-  deps = [ app_data_model ]
+  deps = [
+    "${chip_root}/src/app:generic-test-event-trigger-handler",
+    app_data_model,
+  ]
 }
 
 config("platform-config") {

--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -187,4 +187,7 @@ ALLOW: Dict[str, Set[str]] = {
     'src/controller/CHIPDeviceController.cpp': {'string'},
     'src/qrcodetool/setup_payload_commands.cpp': {'string'},
     'src/access/AccessRestrictionProvider.h': {'vector', 'map'},
+
+    # nrfconnect test runner
+    'src/test_driver/nrfconnect/main/runner.cpp': {'vector'},
 }

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -426,6 +426,18 @@ source_set("command-handler-impl") {
   ]
 }
 
+source_set("generic-test-event-trigger-handler") {
+  sources = [
+    "GenericEventManagementTestEventTriggerHandler.cpp",
+    "GenericEventManagementTestEventTriggerHandler.h",
+  ]
+
+  public_deps = [
+    ":test-event-trigger",
+    "${chip_root}/src/platform",
+  ]
+}
+
 # Note to developpers, instead of continuously adding files in the app librabry, it is recommand to create smaller source_sets that app can depend on.
 # This way, we can have a better understanding of dependencies and other componenets can depend on the different source_sets without needing to depend on the entire app library.
 static_library("app") {
@@ -447,8 +459,6 @@ static_library("app") {
     "EventManagement.h",
     "FailSafeContext.cpp",
     "FailSafeContext.h",
-    "GenericEventManagementTestEventTriggerHandler.cpp",
-    "GenericEventManagementTestEventTriggerHandler.h",
     "OTAUserConsentCommon.h",
     "ReadHandler.cpp",
     "SafeAttributePersistenceProvider.h",
@@ -470,7 +480,6 @@ static_library("app") {
     ":constants",
     ":global-attributes",
     ":interaction-model",
-    ":test-event-trigger",
     "${chip_root}/src/app/data-model",
     "${chip_root}/src/app/icd/server:icd-server-config",
     "${chip_root}/src/app/util:callbacks",

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -464,6 +464,7 @@ if (chip_device_platform != "none") {
       "../include/platform/ConnectivityManager.h",
       "../include/platform/DeviceControlServer.h",
       "../include/platform/DeviceInstanceInfoProvider.h",
+      "../include/platform/GeneralFaults.h",
       "../include/platform/GeneralUtils.h",
       "../include/platform/KeyValueStoreManager.h",
       "../include/platform/KvsPersistentStorageDelegate.h",

--- a/src/test_driver/nrfconnect/CMakeLists.txt
+++ b/src/test_driver/nrfconnect/CMakeLists.txt
@@ -48,6 +48,8 @@ set(CHIP_CFLAGS
 list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/config/nrfconnect/chip-module)
 find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
+set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
+
 # ==================================================
 # Build 'all tests' runner
 # ==================================================
@@ -56,6 +58,24 @@ project(AllChipTests)
 enable_testing()
 
 target_sources(app PRIVATE main/runner.cpp)
+target_include_directories(app PUBLIC
+  ${PIGWEED_ROOT}/pw_assert/public
+  ${PIGWEED_ROOT}/pw_assert_zephyr/public
+  ${PIGWEED_ROOT}/pw_assert_zephyr/public_overrides
+  ${PIGWEED_ROOT}/pw_bytes/public
+  ${PIGWEED_ROOT}/pw_preprocessor/public
+  ${PIGWEED_ROOT}/pw_polyfill/public
+  ${PIGWEED_ROOT}/pw_polyfill/standard_library_public
+  ${PIGWEED_ROOT}/pw_polyfill/public_overrides
+  ${PIGWEED_ROOT}/pw_result/public
+  ${PIGWEED_ROOT}/pw_span/public
+  ${PIGWEED_ROOT}/pw_span/public_overrides
+  ${PIGWEED_ROOT}/pw_status/public
+  ${PIGWEED_ROOT}/pw_string/public
+  ${PIGWEED_ROOT}/pw_unit_test/public
+  ${PIGWEED_ROOT}/pw_unit_test/light_public_overrides
+  ${PIGWEED_ROOT}/third_party/fuchsia/repo/sdk/lib/stdcompat/include
+)
 target_link_libraries(app PUBLIC chip $<TARGET_FILE:kernel>)
 target_compile_definitions(app PUBLIC CHIP_HAVE_CONFIG_H)
 

--- a/src/test_driver/nrfconnect/main/runner.cpp
+++ b/src/test_driver/nrfconnect/main/runner.cpp
@@ -18,9 +18,12 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/UnitTest.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <pw_unit_test/framework.h>
 
 #include <unistd.h>
+#include <vector>
 
+#include <nsi_cmdline.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/settings/settings.h>
 
@@ -32,6 +35,18 @@ LOG_MODULE_REGISTER(runner, CONFIG_MATTER_LOG_LEVEL);
 extern "C" int main(void)
 {
     VerifyOrDie(settings_subsys_init() == 0);
+
+    int argc;
+    char ** argv;
+    nsi_get_test_cmd_line_args(&argc, &argv);
+
+    std::vector<std::string_view> suites_to_run;
+    for (int i = 0; i < argc; ++i)
+    {
+        suites_to_run.push_back(argv[i]);
+    }
+
+    pw::unit_test::SetTestSuitesToRun(suites_to_run);
 
     LOG_INF("Starting CHIP tests!");
     int status = 0;


### PR DESCRIPTION
* Move GenericEventManagementTestEventTriggerHandler to separate source set.
* [nrfconnect] Allow running only specific test suites.