### PR TITLE
[nrf toup][nrfconnect] Add `--full` flag to zap-generate and parametrize app-common zap-generated path

### DIFF
--- a/config/common/cmake/chip_gn.cmake
+++ b/config/common/cmake/chip_gn.cmake
@@ -36,6 +36,10 @@ if (NOT CHIP_ROOT)
     get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_LIST_DIR}/../../.. REALPATH)
 endif()
 
+if (NOT CHIP_APP_ZAP_DIR)
+    get_filename_component(CHIP_APP_ZAP_DIR ${CHIP_ROOT}/zzz_generated/app-common REALPATH)
+endif()
+
 # ==============================================================================
 # Find required programs
 # ==============================================================================
@@ -165,7 +169,7 @@ macro(matter_build target)
         ${CHIP_ROOT}/third_party/nlassert/repo/include
         ${CHIP_ROOT}/third_party/nlio/repo/include
         ${CHIP_ROOT}/third_party/nlfaultinjection/include
-        ${CHIP_ROOT}/zzz_generated/app-common
+        ${CHIP_APP_ZAP_DIR}
         ${CMAKE_CURRENT_BINARY_DIR}/gen/include
     )
 

--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -41,6 +41,11 @@ include(generate_factory_data.cmake)
 if (NOT CHIP_ROOT)
     get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../../.. REALPATH)
 endif()
+
+if (NOT CHIP_APP_ZAP_DIR)
+    get_filename_component(CHIP_APP_ZAP_DIR ${CHIP_ROOT}/zzz_generated/app-common REALPATH)
+endif()
+
 get_filename_component(GN_ROOT_TARGET ${CHIP_ROOT}/config/nrfconnect/chip-gn REALPATH)
 get_filename_component(COMMON_CMAKE_SOURCE_DIR ${CHIP_ROOT}/config/common/cmake REALPATH)
 
@@ -140,6 +145,7 @@ matter_common_gn_args(
 matter_add_gn_arg_string("zephyr_ar"                              ${CMAKE_AR})
 matter_add_gn_arg_string("zephyr_cc"                              ${CMAKE_C_COMPILER})
 matter_add_gn_arg_string("zephyr_cxx"                             ${CMAKE_CXX_COMPILER})
+matter_add_gn_arg_string("chip_app_zap_dir"                       ${CHIP_APP_ZAP_DIR})
 matter_add_gn_arg_bool  ("chip_logging"                           CONFIG_LOG)
 matter_add_gn_arg_bool  ("chip_enable_openthread"                 CONFIG_NET_L2_OPENTHREAD)
 matter_add_gn_arg_bool  ("chip_openthread_ftd"                    CONFIG_OPENTHREAD_FTD)

--- a/scripts/west/zap_common.py
+++ b/scripts/west/zap_common.py
@@ -95,11 +95,15 @@ def update_zcl_in_zap(zap_file: Path, zcl_json: Path, app_templates: Path) -> bo
 
         for package in packages:
             if package.get("type") == "zcl-properties":
-                if not zcl_json.parent.absolute().is_relative_to(zap_file.parent.absolute()):
+                if zcl_json.parent.absolute() == zap_file.parent.absolute() or \
+                    not zcl_json.parent.absolute().is_relative_to(zap_file.parent.absolute()):
+
                     package.update({"path": str(zcl_json.absolute().relative_to(zap_file.parent.absolute(), walk_up=True))})
                     updated = True
             if package.get("type") == "gen-templates-json":
-                if not app_templates.parent.absolute().is_relative_to(zap_file.parent.absolute()):
+                if app_templates.parent.absolute() == zap_file.parent.absolute() or \
+                    not app_templates.parent.absolute().is_relative_to(zap_file.parent.absolute()):
+
                     package.update({"path": str(app_templates.absolute().relative_to(zap_file.parent.absolute(), walk_up=True))})
                     updated = True
 

--- a/src/app/chip_data_model.cmake
+++ b/src/app/chip_data_model.cmake
@@ -20,6 +20,10 @@ if (NOT CHIP_ROOT)
     get_filename_component(CHIP_ROOT ${CHIP_APP_BASE_DIR}/../.. REALPATH)
 endif()
 
+if (NOT CHIP_APP_ZAP_DIR)
+    get_filename_component(CHIP_APP_ZAP_DIR ${CHIP_ROOT}/zzz_generated/app-common REALPATH)
+endif()
+
 include("${CHIP_ROOT}/build/chip/chip_codegen.cmake")
 include("${CHIP_ROOT}/src/app/codegen-data-model-provider/model.cmake")
 
@@ -152,7 +156,7 @@ function(chip_configure_data_model APP_TARGET)
     endif()
 
     target_sources(${APP_TARGET} ${SCOPE}
-        ${CHIP_APP_BASE_DIR}/../../zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.cpp
+        ${CHIP_APP_ZAP_DIR}/app-common/zap-generated/attributes/Accessors.cpp
         ${CHIP_APP_BASE_DIR}/reporting/reporting.cpp
         ${CHIP_APP_BASE_DIR}/util/attribute-storage.cpp
         ${CHIP_APP_BASE_DIR}/util/attribute-table.cpp

--- a/src/app/common/BUILD.gn
+++ b/src/app/common/BUILD.gn
@@ -13,23 +13,24 @@
 # limitations under the License.
 
 import("//build_overrides/chip.gni")
+import("${chip_root}/src/app/common_flags.gni")
 
 config("includes") {
-  include_dirs = [ "${chip_root}/zzz_generated/app-common" ]
+  include_dirs = [ "${chip_app_zap_dir}" ]
 }
 
 source_set("attribute-type") {
-  sources = [ "${chip_root}/zzz_generated/app-common/app-common/zap-generated/attribute-type.h" ]
+  sources = [ "${chip_app_zap_dir}/app-common/zap-generated/attribute-type.h" ]
 
   public_configs = [ ":includes" ]
 }
 
 source_set("ids") {
   sources = [
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/ids/Attributes.h",
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/ids/Clusters.h",
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/ids/Commands.h",
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/ids/Events.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/ids/Attributes.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/ids/Clusters.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/ids/Commands.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/ids/Events.h",
   ]
 
   public_deps = [ "${chip_root}/src/app/util:types" ]
@@ -41,8 +42,8 @@ static_library("cluster-objects") {
   output_name = "libClusterObjects"
 
   sources = [
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp",
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/cluster-objects.cpp",
+    "${chip_app_zap_dir}/app-common/zap-generated/cluster-objects.h",
   ]
 
   public_deps = [
@@ -61,8 +62,8 @@ static_library("cluster-objects") {
 
 source_set("enums") {
   sources = [
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h",
-    "${chip_root}/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/cluster-enums-check.h",
+    "${chip_app_zap_dir}/app-common/zap-generated/cluster-enums.h",
     "CompatEnumNames.h",
   ]
 

--- a/src/app/common_flags.gni
+++ b/src/app/common_flags.gni
@@ -35,6 +35,9 @@ declare_args() {
     chip_use_data_model_interface = "disabled"
   }
 
+  # Flag that sets path to zap-generated app-common directory
+  chip_app_zap_dir = chip_root + "/zzz_generated/app-common"
+
   # Whether we call `chipDie` on DM `check` errors
   #
   # If/once the chip_use_data_model_interface flag is removed or does not support


### PR DESCRIPTION
Add a `--full` flag that generates full data model and puts it it `app-common/zap-generated` subdirectory.

Additionaly fix minor bug when equal paths have been shown as non- relative and zap file is not properly updated with zcl.json file

Also pull commit [nrf fromtree] Parametrize app-common zap-generated path from upstream