### PR TITLE
[nrf noup] Add AppFactoryResetHandler

### DIFF
--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -58,6 +58,12 @@
 #include <mpsl/mpsl_lib.h>
 #endif // CONFIG_SOC_FLASH_NRF_RADIO_SYNC_MPSL
 
+// TODO: Remove this workaround after proper API is added
+__weak bool AppFactoryResetHandler()
+{
+    return true;
+}
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -238,7 +244,13 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     {
         ChipLogError(DeviceLayer, "Factory reset failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
+
 #endif // CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
+
+    if (!AppFactoryResetHandler())
+    {
+        ChipLogError(DeviceLayer, "Factory reset failed, AppFactoryReset failed");
+    }
 
     PlatformMgr().Shutdown();
 }


### PR DESCRIPTION
Add weak `AppFactoryResetHandler` to handle application specific cleanup.

NCS PR: nrfconnect/sdk-nrf/pull/20803
