### PR TITLE
Zephyr native tests improvements

### DIFF
--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -57,19 +57,6 @@ jobs:
               uses: ./.github/actions/checkout-submodules-and-bootstrap
               with:
                 platform: nrfconnect
-            - name: Detect changed paths
-              uses: dorny/paths-filter@v3
-              id: changed_paths
-              with:
-                  filters: |
-                      nrfconnect:
-                        - '**/nrfconnect/**'
-                        - '**/Zephyr/**'
-                        - '**/zephyr/**'
-                      tests:
-                        - '**/tests/**'
-                      shell:
-                        - 'examples/shell/nrfconnect/**'
             - name: Update NCS recommended version (workflow_dispatch)
               if: github.event_name == 'workflow_dispatch'
               run: |
@@ -98,7 +85,6 @@ jobs:
                   scripts/run_in_build_env.sh 'pip3 install -r scripts/setup/requirements.nrfconnect.txt'
                   scripts/run_in_build_env.sh "./scripts/tools/nrfconnect/tests/test_generate_factory_data.py"
             - name: Run unit tests for Zephyr native_posix_64 platform
-              if: github.event_name == 'push' || steps.changed_paths.outputs.tests == 'true' || steps.changed_paths.outputs.nrfconnect == 'true'
               run: |
                   scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target nrf-native-sim-tests build"
             - name: Uploading Failed Test Logs

--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -222,7 +222,7 @@ class NrfConnectBuilder(Builder):
             # Note: running zephyr/zephyr.elf has the same result except it creates
             # a flash.bin in the current directory. ctest has more options and does not
             # pollute the source directory
-            self._Execute(['ctest', '--build-nocmake', '-V', '--output-on-failure', '--test-dir', os.path.join(self.output_dir, 'nrfconnect')],
+            self._Execute(['ctest', '--build-nocmake', '-V', '--output-on-failure', '--test-dir', os.path.join(self.output_dir, 'nrfconnect'), '--no-tests=error'],
                           title='Run Tests ' + self.identifier)
 
     def _bundle(self):


### PR DESCRIPTION
* Return error when ctest finds no tests.
* Always run Zephyr native tests.