### PR TITLE
[nrf noup] Added a proper package name for MAC with ARM CPUs.

### DIFF
--- a/scripts/west/zap_common.py
+++ b/scripts/west/zap_common.py
@@ -142,7 +142,10 @@ class ZapInstaller:
             self.zap_cli_exe = 'zap-cli.exe'
             self.unzip = unzip
         elif self.current_os == 'Darwin':
-            self.package = 'zap-mac-x64'
+            if platform.machine() == 'arm64':
+                self.package = 'zap-mac-arm64'
+            else:
+                self.package = 'zap-mac-x64'
             self.zap_exe = 'zap.app/Contents/MacOS/zap'
             self.zap_cli_exe = 'zap-cli'
             self.unzip = unzip_darwin


### PR DESCRIPTION
Now the script downloads the zap-mac-arm64.zip package if the ARM64 machine is detected for Darwin OS.
