### PR TITLE
[nrf toup] simplify Key/Value Get function

### DIFF
--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -45,9 +45,9 @@
 #include <zephyr/settings/settings.h>
 #if defined(CONFIG_SETTINGS_NVS)
 #include <zephyr/fs/nvs.h>
-#elif defined(CONFIG_SETTINGS_ZMS)
+#elif defined(CONFIG_SETTINGS_ZMS) || defined(CONFIG_SETTINGS_ZMS_LEGACY)
 #include <zephyr/fs/zms.h>
-#endif // CONFIG_SETTINGS_NVS || CONFIG_SETTINGS_ZMS
+#endif // CONFIG_SETTINGS_NVS || CONFIG_SETTINGS_ZMS || CONFIG_SETTINGS_ZMS_LEGACY
 #endif // CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS
 
 #ifdef CONFIG_NET_L2_OPENTHREAD
@@ -214,9 +214,9 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     {
 #if defined(CONFIG_SETTINGS_NVS)
         status = nvs_clear(static_cast<nvs_fs *>(storage));
-#elif defined(CONFIG_SETTINGS_ZMS)
+#elif defined(CONFIG_SETTINGS_ZMS) || defined(CONFIG_SETTINGS_ZMS_LEGACY)
         status = zms_clear(static_cast<zms_fs *>(storage));
-#endif // CONFIG_SETTINGS_NVS || CONFIG_SETTINGS_ZMS
+#endif // CONFIG_SETTINGS_NVS || CONFIG_SETTINGS_ZMS || CONFIG_SETTINGS_ZMS_LEGACY
     }
     if (status)
     {

--- a/src/platform/Zephyr/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Zephyr/KeyValueStoreManagerImpl.cpp
@@ -34,14 +34,6 @@ namespace DeviceLayer {
 namespace PersistedStorage {
 namespace {
 
-struct ReadEntry
-{
-    void * destination;           // destination address
-    size_t destinationBufferSize; // size of destination buffer
-    size_t readSize;              // [out] size of read entry value
-    CHIP_ERROR result;            // [out] read result
-};
-
 struct DeleteSubtreeEntry
 {
     int result;
@@ -87,43 +79,6 @@ CHIP_ERROR MakeFullKey(char (&fullKey)[SETTINGS_MAX_NAME_LEN + 1], const char * 
     return CHIP_NO_ERROR;
 }
 
-int LoadEntryCallback(const char * name, size_t entrySize, settings_read_cb readCb, void * cbArg, void * param)
-{
-    ReadEntry & entry = *static_cast<ReadEntry *>(param);
-
-    // If requested key X, process just node X and ignore all its descendants: X/*
-    if (name != nullptr && *name != '\0')
-        return 0;
-
-    // Found requested key.
-    uint8_t emptyValue[kEmptyValueSize];
-
-    if (entrySize == kEmptyValueSize && readCb(cbArg, emptyValue, kEmptyValueSize) == kEmptyValueSize &&
-        memcmp(emptyValue, kEmptyValue, kEmptyValueSize) == 0)
-    {
-        // Special case - an empty value represented by known magic bytes.
-        entry.result = CHIP_NO_ERROR;
-
-        // Return 1 to stop processing further keys
-        return 1;
-    }
-
-    const ssize_t bytesRead = readCb(cbArg, entry.destination, entry.destinationBufferSize);
-    entry.readSize          = bytesRead > 0 ? bytesRead : 0;
-
-    if (entrySize > entry.destinationBufferSize)
-    {
-        entry.result = CHIP_ERROR_BUFFER_TOO_SMALL;
-    }
-    else
-    {
-        entry.result = bytesRead > 0 ? CHIP_NO_ERROR : CHIP_ERROR_PERSISTED_STORAGE_FAILED;
-    }
-
-    // Return 1 to stop processing further keys
-    return 1;
-}
-
 int DeleteSubtreeCallback(const char * name, size_t /* entrySize */, settings_read_cb /* readCb */, void * /* cbArg */,
                           void * param)
 {
@@ -143,6 +98,7 @@ int DeleteSubtreeCallback(const char * name, size_t /* entrySize */, settings_re
     return 0;
 }
 
+
 } // namespace
 
 KeyValueStoreManagerImpl KeyValueStoreManagerImpl::sInstance;
@@ -152,9 +108,51 @@ void KeyValueStoreManagerImpl::Init()
     VerifyOrDie(settings_subsys_init() == 0);
 }
 
+void LoadOneAndVerifyResult(const char * fullkey, void * dest_buf, size_t dest_size, size_t * readSize,
+                               CHIP_ERROR * result)
+{
+    ssize_t bytesRead = settings_load_one(fullkey, dest_buf, dest_size);
+
+    // If the return code is -ENOENT the key is not found
+    if ((bytesRead == -ENOENT) || (!bytesRead))
+    {
+        *result = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+        *readSize = 0;
+        return;
+    }
+    if ((bytesRead == kEmptyValueSize) && !memcmp(dest_buf, kEmptyValue, kEmptyValueSize))
+    {
+        *result = CHIP_NO_ERROR;
+        *readSize = 0;
+        return;
+    }
+    if ((size_t)bytesRead > dest_size)
+    {
+        *result = CHIP_ERROR_BUFFER_TOO_SMALL;
+        *readSize = dest_size;
+        return;
+    }
+    else if (bytesRead >= 0)
+    {
+        *result = CHIP_NO_ERROR;
+    }
+    else
+    {
+        *result = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+    }
+
+    *readSize = (bytesRead > 0) ? bytesRead : 0;
+
+    return;
+}
+
 CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t value_size, size_t * read_bytes_size,
                                           size_t offset_bytes) const
 {
+    CHIP_ERROR result;
+    size_t readSize = 0;
+    ssize_t ret = 0;
+    uint8_t emptyValue[kEmptyValueSize];
     // Offset and partial reads are not supported, for now just return NOT_IMPLEMENTED.
     // Support can be added in the future if this is needed.
     VerifyOrReturnError(offset_bytes == 0, CHIP_ERROR_NOT_IMPLEMENTED);
@@ -162,16 +160,55 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     char fullKey[SETTINGS_MAX_NAME_LEN + 1];
     ReturnErrorOnFailure(MakeFullKey(fullKey, key));
 
-    ReadEntry entry{ value, value_size, 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND };
-    settings_load_subtree_direct(fullKey, LoadEntryCallback, &entry);
+    if ((!value) || (value_size == 0))
+    {
+        // we want only to verify that the key exists
+        ret = settings_get_val_len(fullKey);
+        if (ret > 0)
+        {
+            result = CHIP_NO_ERROR;
+        }
+        else if (!ret || (ret == -ENOENT))
+        {
+            result = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+        }
+        else
+        {
+            result = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+        }
+        // check that this pointer is not null as it is an optional argument
+        if (read_bytes_size)
+        {
+            *read_bytes_size = 0;
+        }
+
+        return result;
+    }
+
+    if (value_size < kEmptyValueSize)
+    {
+        LoadOneAndVerifyResult(fullKey, emptyValue, kEmptyValueSize, &readSize, &result);
+        if (readSize)
+        {
+            memcpy(value, emptyValue, value_size);
+        }
+        if (readSize > value_size)
+        {
+            result = CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+    }
+    else
+    {
+        LoadOneAndVerifyResult(fullKey, value, value_size, &readSize, &result);
+    }
 
     // Assign readSize only in case read_bytes_size is not nullptr, as it is optional argument
     if (read_bytes_size)
     {
-        *read_bytes_size = entry.readSize;
+        *read_bytes_size = readSize;
     }
 
-    return entry.result;
+    return result;
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, size_t value_size)
@@ -193,10 +230,10 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
 CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
 {
     char fullKey[SETTINGS_MAX_NAME_LEN + 1];
+
     ReturnErrorOnFailure(MakeFullKey(fullKey, key));
 
-    ReturnErrorCodeIf(Get(key, nullptr, 0) == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND,
-                      CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    ReturnErrorCodeIf(!settings_get_val_len(fullKey), CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     ReturnErrorCodeIf(settings_delete(fullKey) != 0, CHIP_ERROR_PERSISTED_STORAGE_FAILED);
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
use settings_load_one function to load one key/value settings entry instead of settings_load_subtree_direct.
This will avoid loading all the keys for some storage backends. Simplify as well the Delete function by skipping loading the value before deleting it.

NCS PR: nrfconnect/sdk-nrf/pull/20691