### PR TITLE
[nrf toup] Don't advertise when waiting for last fabric removed action

### DIFF
--- a/examples/platform/nrfconnect/util/include/FabricTableDelegate.h
+++ b/examples/platform/nrfconnect/util/include/FabricTableDelegate.h
@@ -47,7 +47,19 @@ public:
 private:
     void OnFabricRemoved(const chip::FabricTable & fabricTable, chip::FabricIndex fabricIndex)
     {
-        k_timer_start(&sFabricRemovedTimer, K_MSEC(CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY), K_NO_WAIT);
+#ifndef CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
+        auto & server = chip::Server::GetInstance();
+
+        if (server.GetFabricTable().FabricCount() == 0)
+        {
+            if (chip::DeviceLayer::ConnectivityMgr().IsBLEAdvertisingEnabled())
+            {
+                server.GetCommissioningWindowManager().CloseCommissioningWindow();
+            }
+
+            k_timer_start(&sFabricRemovedTimer, K_MSEC(CONFIG_CHIP_LAST_FABRIC_REMOVED_ACTION_DELAY), K_NO_WAIT);
+        }
+#endif // CONFIG_CHIP_LAST_FABRIC_REMOVED_NONE
     }
 
     static void OnFabricRemovedTimerCallback(k_timer * timer)
@@ -59,6 +71,9 @@ private:
 #ifdef CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_REBOOT
                 chip::Server::GetInstance().ScheduleFactoryReset();
 #elif defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_ONLY) || defined(CONFIG_CHIP_LAST_FABRIC_REMOVED_ERASE_AND_PAIRING_START)
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
+                chip::DeviceLayer::ThreadStackMgr().ClearAllSrpHostAndServices();
+#endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT
                 // Erase Matter data
                 chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().DoFactoryReset();
                 // Erase Network credentials and disconnect


### PR DESCRIPTION
* Close commissioning window on last fabric removal. It will be reopened depending on `CHIP_LAST_FABRIC_REMOVED_ACTION`.
* Update handler to match implementation in NCS.