### PR TITLE
[nrfconnect] Reconfigure memory pool sizes

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -53,8 +53,17 @@ config SYSTEM_WORKQUEUE_STACK_SIZE
     default 2560 if CHIP_WIFI
     default 2048 if CHIP_ICD_LIT_SUPPORT
 
+if CHIP_WIFI
+
 config HEAP_MEM_POOL_SIZE
-    default 110720 if CHIP_WIFI
+    default 48336 if BUILD_WITH_TFM
+    default 40144
+
+config NRF_WIFI_DATA_HEAP_SIZE
+    default 42384 if BUILD_WITH_TFM
+    default 50576
+
+endif # CHIP_WIFI
 
 config HEAP_MEM_POOL_IGNORE_MIN
     default y if CHIP_WIFI


### PR DESCRIPTION
With introduction of dedicated memory pools for nRF70 Wi-Fi driver, redistribute current heap size among the
driver heap and kernel heap.


> Add following line to test this PR against different NCS revision:
> NCS PR: nrfconnect/sdk-nrf/pull/<PR ID>
