### PR TITLE
[nrf toup] Revert size of Packet Buffer Pool to previous value

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -454,7 +454,7 @@ config CHIP_ENABLE_BDX_LOG_TRANSFER
 
 config CHIP_SYSTEM_PACKETBUFFER_POOL_SIZE
   int "Packet buffer pool size"
-  default 11
+  default 15
   help
     Total number of packet buffers allocated by the stack for internal pool.
 


### PR DESCRIPTION
Set packet buffer pool size to 15.