### PR TITLE
Fix and re-enable failing tests

### DIFF
--- a/src/messaging/tests/BUILD.gn
+++ b/src/messaging/tests/BUILD.gn
@@ -44,10 +44,10 @@ chip_test_suite("tests") {
   output_name = "libMessagingLayerTests"
 
   test_sources = [
-  #"TestAbortExchangesForFabric.cpp",
+    "TestAbortExchangesForFabric.cpp",
     "TestExchange.cpp",
     "TestExchangeMgr.cpp",
-  #"TestReliableMessageProtocol.cpp",
+    "TestReliableMessageProtocol.cpp",
   ]
 
   if (chip_device_platform != "esp32" && chip_device_platform != "mbed" &&

--- a/src/test_driver/nrfconnect/prj.conf
+++ b/src/test_driver/nrfconnect/prj.conf
@@ -89,3 +89,7 @@ CONFIG_CHIP_PROJECT_CONFIG="main/include/CHIPProjectConfig.h"
 # Don't erase all settings as it deinitializes NVS/ZMS and causes issues with
 # testing Server::ScheduleFactoryReset
 CONFIG_CHIP_FACTORY_RESET_ERASE_SETTINGS=n
+
+# Use default ICD poll intervals to keep compaitbility with tests
+CONFIG_CHIP_ICD_SLOW_POLL_INTERVAL=5000
+CONFIG_CHIP_ICD_FAST_POLLING_INTERVAL=200


### PR DESCRIPTION
* Revert disabling tests
* Use default ICD poll intervals in tests