### PR TITLE
fix: handle paths on different drives in Windows for zap-gui

### DIFF
--- a/scripts/west/zap_common.py
+++ b/scripts/west/zap_common.py
@@ -97,15 +97,22 @@ def update_zcl_in_zap(zap_file: Path, zcl_json: Path, app_templates: Path) -> bo
             if package.get("type") == "zcl-properties":
                 if zcl_json.parent.absolute() == zap_file.parent.absolute() or \
                     not zcl_json.parent.absolute().is_relative_to(zap_file.parent.absolute()):
+                    try:
+                        package.update({"path": str(zcl_json.absolute().relative_to(zap_file.parent.absolute(), walk_up=True))})
+                        updated = True
+                    except ValueError:
+                        package.update({"path": str(zcl_json.absolute())})
+                        updated = True
 
-                    package.update({"path": str(zcl_json.absolute().relative_to(zap_file.parent.absolute(), walk_up=True))})
-                    updated = True
             if package.get("type") == "gen-templates-json":
                 if app_templates.parent.absolute() == zap_file.parent.absolute() or \
                     not app_templates.parent.absolute().is_relative_to(zap_file.parent.absolute()):
-
-                    package.update({"path": str(app_templates.absolute().relative_to(zap_file.parent.absolute(), walk_up=True))})
-                    updated = True
+                    try:
+                        package.update({"path": str(app_templates.absolute().relative_to(zap_file.parent.absolute(), walk_up=True))})
+                        updated = True
+                    except ValueError:
+                        package.update({"path": str(app_templates.absolute())})
+                        updated = True
 
         file.seek(0)
         json.dump(data, file, indent=2)


### PR DESCRIPTION
# Fix zap-gui path handling on Windows systems with different drives

## Issue
When using `west zap-gui` on Windows, if the ZAP file and any of the required files (ZCL or app templates) are located on different drives, the command fails with: `ValueError: 'c:\\ncs\\v3.0.0-rc1\\modules\\lib\\matter\\src\\app\\zap-templates\\zcl\\zcl.json' and 'D:\\Code\\project\\src\\default_zap' have different anchors` 


This occurs because `pathlib.Path.relative_to()` method cannot compute relative paths between different drives in Windows. The issue happens in both scenarios:
1. With default ZCL path from SDK (C: drive) and project on another drive (D: drive)
2. Even when specifying a custom ZCL file with `-j` option, if app-templates.json remains on a different drive

## Root cause
In `update_zcl_in_zap()` function, the code attempts to calculate relative paths using `relative_to()` but doesn't handle the case when paths are on different drives in Windows.

## Solution
This PR fixes the issue by:
1. Adding try/except blocks to properly catch ValueError exceptions where `relative_to()` is called
2. Providing absolute paths as a fallback when relative paths cannot be computed

This ensures that `west zap-gui` works correctly on Windows regardless of drive locations while maintaining the original behavior on Linux and macOS.

## Testing
Tested on Windows 11 with:
- Project on D: drive with SDK on C: drive
- Both with default ZCL path and with custom ZCL file specified via `-j` option

The fix also works correctly on Linux as before, where this issue doesn't occur.
