### PR TITLE
[nrf noup] Use ZAP CLI for version check

### DIFF
--- a/scripts/west/zap_common.py
+++ b/scripts/west/zap_common.py
@@ -189,13 +189,13 @@ class ZapInstaller:
         """
         Returns ZAP package current version as a tuple of integers.
 
-        Parses the output of `zap --version` to determine the current ZAP
+        Parses the output of `zap-cli --version` to determine the current ZAP
         package version. If the ZAP package has not been installed yet,
         the method returns None.
         """
         try:
             output = subprocess.check_output(
-                [self.get_zap_path(), '--version']).decode('ascii').strip()
+                [self.get_zap_cli_path(), '--version']).decode('ascii').strip()
         except Exception:
             return None
 


### PR DESCRIPTION
Both `zap --version` and `zap-cli --version` do the same thing more or less, but `zap` is heavier to run since it starts Electron just to do `--version`. Since the user may only care about `zap-cli` commands (e.g. `west zap-generate`), requiring that all `west zap-*` commands call `zap` just to get a version check increases the amount of resources and dependencies required.

Instead, just use `zap-cli` to get the version.