### PR TITLE
[nrf noup] Use proper ZAP package for Linux/Windows with ARM CPUs

### DIFF
--- a/scripts/west/zap_common.py
+++ b/scripts/west/zap_common.py
@@ -132,12 +132,18 @@ class ZapInstaller:
             f.close()
 
         if self.current_os == 'Linux':
-            self.package = 'zap-linux-x64'
+            if platform.machine() == 'aarch64':
+                self.package = 'zap-linux-arm64'
+            else:
+                self.package = 'zap-linux-x64'
             self.zap_exe = 'zap'
             self.zap_cli_exe = 'zap-cli'
             self.unzip = unzip
         elif self.current_os == 'Windows':
-            self.package = 'zap-win-x64'
+            if platform.machine() == 'ARM64':
+                self.package = 'zap-win-arm64'
+            else:
+                self.package = 'zap-win-x64'
             self.zap_exe = 'zap.exe'
             self.zap_cli_exe = 'zap-cli.exe'
             self.unzip = unzip


### PR DESCRIPTION
Currently x86 ZAP is always downloaded on Linux & Windows. This change looks at the architecture of the system to download either x86_64 or arm64 binaries as provided by ZAP releases

This is the Linux / Windows equivalent to #574 which similarly downloads ARM64 binaries for Darwin systems on Apple Silicon.