### PR TITLE
[nrf noup] Bump the Ubuntu version for release tools.

### DIFF
--- a/.github/workflows/release_tools.yaml
+++ b/.github/workflows/release_tools.yaml
@@ -30,13 +30,13 @@ jobs:
         name: Build CHIP Tools
         timeout-minutes: 60
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
 
         env:
             DEBIAN_FRONTEND: noninteractive
 
         container:
-            image: ubuntu:20.04
+            image: ubuntu:22.04
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
                 - "/tmp/output_binaries:/tmp/output_binaries"


### PR DESCRIPTION
Ubuntu 20.04 is deprecated and cannot be used to run build of the release tools. The deprecation took place on 15.04.2025.

Switched to the next stable version: 22.04.

