### PR TITLE
[nrf toup] [Groups] Do not add group if there is no listener

### DIFF
--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -480,20 +480,24 @@ private:
             return CHIP_NO_ERROR;
         };
 
-        void OnGroupAdded(chip::FabricIndex fabric_index, const Credentials::GroupDataProvider::GroupInfo & new_group) override
+        CHIP_ERROR OnGroupAdded(chip::FabricIndex fabric_index,
+                                const Credentials::GroupDataProvider::GroupInfo & new_group) override
         {
             const FabricInfo * fabric = mServer->GetFabricTable().FindFabricWithIndex(fabric_index);
             if (fabric == nullptr)
             {
                 ChipLogError(AppServer, "Group added to nonexistent fabric?");
-                return;
+                return CHIP_ERROR_INVALID_FABRIC_INDEX;
             }
 
             if (mServer->GetTransportManager().MulticastGroupJoinLeave(
                     Transport::PeerAddress::Multicast(fabric->GetFabricId(), new_group.group_id), true) != CHIP_NO_ERROR)
             {
                 ChipLogError(AppServer, "Unable to listen to group");
+                return CHIP_ERROR_NO_MEMORY;
             }
+
+            return CHIP_NO_ERROR;
         };
 
         void OnGroupRemoved(chip::FabricIndex fabric_index, const Credentials::GroupDataProvider::GroupInfo & old_group) override

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -177,8 +177,11 @@ public:
          *  Callback invoked when a new group is added.
          *
          *  @param[in] new_group  GroupInfo structure of the new group.
+         *  @retval #CHIP_NO_ERROR on success
+         *  @retval #CHIP_ERROR_INVALID_FABRIC_INDEX if the fabric index is invalid
+         *  @retval #CHIP_ERROR_NO_MEMORY if there is no group listener available
          */
-        virtual void OnGroupAdded(FabricIndex fabric_index, const GroupInfo & new_group) = 0;
+        virtual CHIP_ERROR OnGroupAdded(FabricIndex fabric_index, const GroupInfo & new_group) = 0;
         /**
          *  Callback invoked when an existing group is removed.
          *
@@ -317,12 +320,13 @@ public:
     void RemoveListener() { mListener = nullptr; };
 
 protected:
-    void GroupAdded(FabricIndex fabric_index, const GroupInfo & new_group)
+    CHIP_ERROR GroupAdded(FabricIndex fabric_index, const GroupInfo & new_group)
     {
         if (mListener)
         {
-            mListener->OnGroupAdded(fabric_index, new_group);
+            return mListener->OnGroupAdded(fabric_index, new_group);
         }
+        return CHIP_NO_ERROR;
     }
     void GroupRemoved(FabricIndex fabric_index, const GroupInfo & old_group)
     {

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -954,7 +954,14 @@ CHIP_ERROR GroupDataProviderImpl::SetGroupInfoAt(chip::FabricIndex fabric_index,
     }
     // Update fabric
     ReturnErrorOnFailure(fabric.Save(mStorage));
-    GroupAdded(fabric_index, group);
+
+    err = GroupAdded(fabric_index, group);
+    if (err != CHIP_NO_ERROR)
+    {
+        // We failed to add listener to the group,
+        RemoveGroupInfoAt(fabric_index, index);
+        return err;
+    }
     return CHIP_NO_ERROR;
 }
 
@@ -1062,7 +1069,13 @@ CHIP_ERROR GroupDataProviderImpl::AddEndpoint(chip::FabricIndex fabric_index, ch
         fabric.first_group = group.group_id;
         fabric.group_count++;
         ReturnErrorOnFailure(fabric.Save(mStorage));
-        GroupAdded(fabric_index, group);
+        err = GroupAdded(fabric_index, group);
+        if (err != CHIP_NO_ERROR)
+        {
+            // We failed to add listener to the group, remove the endpoint and return error
+            RemoveEndpoint(fabric_index, group_id, endpoint_id);
+            return err;
+        }
         return CHIP_NO_ERROR;
     }
 

--- a/src/credentials/tests/TestGroupDataProvider.cpp
+++ b/src/credentials/tests/TestGroupDataProvider.cpp
@@ -147,11 +147,12 @@ public:
         removed_count = 0;
     }
 
-    void OnGroupAdded(chip::FabricIndex fabric, const GroupInfo & new_group) override
+    CHIP_ERROR OnGroupAdded(chip::FabricIndex fabric, const GroupInfo & new_group) override
     {
         fabric_index = fabric;
         latest       = new_group;
         added_count++;
+        return CHIP_NO_ERROR;
     }
     void OnGroupRemoved(chip::FabricIndex fabric, const GroupInfo & old_group) override
     {


### PR DESCRIPTION
Check if the listener has been assigned to the multicast group; if not, remove the group and return `ResourceExhausted` status in the AddGroupResponse message.

