### PR TITLE
[nrf fromtree] Fix TestInetEndPoint to pass even when computer is offline

### DIFF
--- a/src/inet/tests/TestInetEndPoint.cpp
+++ b/src/inet/tests/TestInetEndPoint.cpp
@@ -277,8 +277,13 @@ TEST_F(TestInetEndPoint, TestInetEndPointInternal)
 
     err = InterfaceId::Null().GetLinkLocalAddr(&addr);
 
-    // We should skip the following checks if the interface does not have the Link local address
-    ASSERT_NE(err, INET_ERROR_ADDRESS_NOT_FOUND);
+    // We should skip the following checks if the interface does not have the Link local address.
+    // This can happen if you don't have network interfaces connected to any link (like happened
+    // to the author of this comment at YYZ before CSA 2025 Chicago Member Meeting).
+    if (err == INET_ERROR_ADDRESS_NOT_FOUND)
+    {
+        return;
+    }
 
     EXPECT_EQ(err, CHIP_NO_ERROR);
     intId = InterfaceId::FromIPAddress(addr);


### PR DESCRIPTION
Description:

- TestInetEndPoint was not hermetic, it required at least one network interface connected to a link and up.
- There was a comment before to skip tests if the link was not up, but it was not actually skipping the test. This made it fail for me when working offline and trying to run unit tests.

Testing done:
- Test passes with and without link up.

(cherry picked from commit b2a86bddd3c2b34e33e0defbef61b37f76267e1d)