### PR TITLE
[nrf toup] Disable BLE SMP buffer scaling on nRF54L10

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.features
+++ b/config/nrfconnect/chip-module/Kconfig.features
@@ -184,10 +184,10 @@ config MCUMGR_SMP_COMMAND_STATUS_HOOKS
 
 # Increase BT MTU and RX buffer for big size DFU messages
 config BT_L2CAP_TX_MTU
-	default 498
+	default 498 if !SOC_NRF54L10
 
 config BT_BUF_ACL_RX_SIZE
-	default 502
+	default 502 if !SOC_NRF54L10
 
 # Increase MCUMGR_TRANSPORT_NETBUF_SIZE, as it must be big enough to fit MAX MTU + overhead and for single-image DFU default is 384 B
 config MCUMGR_TRANSPORT_NETBUF_SIZE


### PR DESCRIPTION
Disable automatic increase of the Bluetooth SMP MTU and RX buffers on the nRF54L10 SoC.