### PR TITLE
[nrf noup] Build chip-tool with logs

### DIFF
--- a/.github/workflows/release_tools.yaml
+++ b/.github/workflows/release_tools.yaml
@@ -76,7 +76,7 @@ jobs:
             - name: Build x64 CHIP Tool with debug logs enabled
               timeout-minutes: 10
               run: |
-                  scripts/run_in_build_env.sh "gn gen out/chiptool_x64_debug --args='chip_mdns=\"platform\" chip_crypto=\"mbedtls\" symbol_level=0 is_debug=false'"
+                  scripts/run_in_build_env.sh "gn gen out/chiptool_x64_debug --args='chip_mdns=\"platform\" chip_crypto=\"mbedtls\" symbol_level=0 is_debug=false enable_im_pretty_print=true'"
                   scripts/run_in_build_env.sh "ninja -C out/chiptool_x64_debug chip-tool"
                   strip out/chiptool_x64_debug/chip-tool -o /tmp/output_binaries/chip-tool_x64
             - name: Build x64 OTA Provider
@@ -111,6 +111,7 @@ jobs:
                       target_cpu=\"arm64\"
                       symbol_level=0
                       is_debug=false
+                      enable_im_pretty_print=true
                       chip_crypto=\"mbedtls\"'"
                   scripts/run_in_build_env.sh "ninja -C out/chiptool_arm64_debug chip-tool"
                   aarch64-linux-gnu-strip out/chiptool_arm64_debug/chip-tool -o /tmp/output_binaries/chip-tool_arm64


### PR DESCRIPTION
Add `enable_im_pretty_print=true` to enable detailed debug logs.

manifest-pr-skip