### PR TITLE
[DNM] [nrf toup] Network Commissioning: Add hysteresis to status reporting

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -126,10 +126,24 @@ private:
     Optional<uint64_t> mCurrentOperationBreadcrumb;
     bool mScanningWasDirected = false;
 
+#if !CHIP_CONFIG_NETWORK_COMMISSIONING_IMMEDIATE_STATUS_REPORTING
+    System::Clock::Timestamp mLastSuccessTimestamp{};
+    bool mDeferredErrorPending = false;
+    DeviceLayer::NetworkCommissioning::Status mDeferredLastStatus;
+    Optional<int32_t> mDeferredConnectError;
+#endif
+
     void SetLastNetworkingStatusValue(Attributes::LastNetworkingStatus::TypeInfo::Type networkingStatusValue);
     void SetLastConnectErrorValue(Attributes::LastConnectErrorValue::TypeInfo::Type connectErrorValue);
     void SetLastNetworkId(ByteSpan lastNetworkId);
     void ReportNetworksListChanged() const;
+
+#if !CHIP_CONFIG_NETWORK_COMMISSIONING_IMMEDIATE_STATUS_REPORTING
+    void ResetSuccessTimestamp();
+    static void DeferredErrorTimerFiredStatic(System::Layer *, void * context);
+    void DeferredErrorTimerFired();
+    void CancelPendingError();
+#endif
 
 #if CHIP_DEVICE_CONFIG_SUPPORTS_CONCURRENT_CONNECTION
     // Disconnect if the current connection is not in the Networks list

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1467,6 +1467,24 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #define CHIP_CONFIG_NETWORK_COMMISSIONING_DEBUG_TEXT_BUFFER_SIZE 64
 #endif // CHIP_CONFIG_NETWORK_COMMISSIONING_DEBUG_TEXT_BUFFER_SIZE
 
+/*
+ * @def CHIP_CONFIG_NETWORK_COMMISSIONING_IMMEDIATE_STATUS_REPORTING
+ *
+ * @brief If enabled, networking status and connection error values (LastNetworkingStatus / LastConnectErrorValue)
+ * are updated immediately upon receiving the result from the driver.
+ *
+ * If disabled, errors will be reported only after the driver-defined connect timeout (e.g. 30s),
+ * to avoid reflecting transient failures too early.
+ *
+ * This allows delaying status reporting to reduce the impact of temporary network instabilities.
+ *
+ * Default: 1 (enabled)
+ */
+#ifndef CHIP_CONFIG_NETWORK_COMMISSIONING_IMMEDIATE_STATUS_REPORTING
+#define CHIP_CONFIG_NETWORK_COMMISSIONING_IMMEDIATE_STATUS_REPORTING 0
+#endif // CHIP_CONFIG_NETWORK_COMMISSIONING_IMMEDIATE_STATUS_REPORTING
+
+
 /**
  *  @def CHIP_CONFIG_IM_STATUS_CODE_VERBOSE_FORMAT
  *


### PR DESCRIPTION
This is just a PoC for delaying reporting the error status - for review.

This patch delays error reporting in NetworkCommissioning cluster if a success was recently observed, premature notifications to mislead clients. Functionality is controlled by
CHIP_CONFIG_NETWORK_COMMISSIONING_IMMEDIATE_STATUS_REPORTING
