### PR TITLE
[nrf toup][nrfconnect] Align with Zephyr net_mgmt API changes

### DIFF
--- a/src/platform/nrfconnect/wifi/WiFiManager.cpp
+++ b/src/platform/nrfconnect/wifi/WiFiManager.cpp
@@ -152,7 +152,7 @@ const Map<wifi_iface_state, WiFiManager::StationStatus, 10>
                               { WIFI_STATE_GROUP_HANDSHAKE, WiFiManager::StationStatus::PROVISIONING },
                               { WIFI_STATE_COMPLETED, WiFiManager::StationStatus::FULLY_PROVISIONED } });
 
-const Map<uint32_t, WiFiManager::NetEventHandler, 5> WiFiManager::sEventHandlerMap({
+const Map<uint64_t, WiFiManager::NetEventHandler, 5> WiFiManager::sEventHandlerMap({
     { NET_EVENT_WIFI_SCAN_RESULT, WiFiManager::ScanResultHandler },
     { NET_EVENT_WIFI_SCAN_DONE, WiFiManager::ScanDoneHandler },
     { NET_EVENT_WIFI_CONNECT_RESULT, WiFiManager::ConnectHandler },
@@ -160,7 +160,7 @@ const Map<uint32_t, WiFiManager::NetEventHandler, 5> WiFiManager::sEventHandlerM
     { NET_EVENT_WIFI_DISCONNECT_COMPLETE, WiFiManager::DisconnectHandler },
 });
 
-void WiFiManager::WifiMgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface)
+void WiFiManager::WifiMgmtEventHandler(net_mgmt_event_callback * cb, uint64_t mgmtEvent, net_if * iface)
 {
     if (iface == Instance().mNetIf)
     {
@@ -171,7 +171,7 @@ void WiFiManager::WifiMgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mg
     }
 }
 
-void WiFiManager::IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface)
+void WiFiManager::IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint64_t mgmtEvent, net_if * iface)
 {
     if (((mgmtEvent == NET_EVENT_IPV6_ADDR_ADD) || (mgmtEvent == NET_EVENT_IPV6_ADDR_DEL)) && cb->info)
     {
@@ -179,7 +179,7 @@ void WiFiManager::IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mg
     }
 }
 
-void WiFiManager::SuppEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface)
+void WiFiManager::SuppEventHandler(net_mgmt_event_callback * cb, uint64_t mgmtEvent, net_if * iface)
 {
     if (mgmtEvent == NET_EVENT_SUPPLICANT_NOT_READY)
     {

--- a/src/platform/nrfconnect/wifi/WiFiManager.h
+++ b/src/platform/nrfconnect/wifi/WiFiManager.h
@@ -201,17 +201,17 @@ private:
         int8_t mRssi{ std::numeric_limits<int8_t>::min() };
     };
 
-    constexpr static uint32_t kWifiManagementEvents = NET_EVENT_WIFI_SCAN_RESULT | NET_EVENT_WIFI_SCAN_DONE |
+    constexpr static uint64_t kWifiManagementEvents = NET_EVENT_WIFI_SCAN_RESULT | NET_EVENT_WIFI_SCAN_DONE |
         NET_EVENT_WIFI_CONNECT_RESULT | NET_EVENT_WIFI_DISCONNECT_RESULT | NET_EVENT_WIFI_IFACE_STATUS;
 
-    constexpr static uint32_t kIPv6ManagementEvents = NET_EVENT_IPV6_ADDR_ADD | NET_EVENT_IPV6_ADDR_DEL;
+    constexpr static uint64_t kIPv6ManagementEvents = NET_EVENT_IPV6_ADDR_ADD | NET_EVENT_IPV6_ADDR_DEL;
 
-    constexpr static uint32_t kSupplicantEvents = NET_EVENT_SUPPLICANT_READY | NET_EVENT_SUPPLICANT_NOT_READY;
+    constexpr static uint64_t kSupplicantEvents = NET_EVENT_SUPPLICANT_READY | NET_EVENT_SUPPLICANT_NOT_READY;
 
     // Event handling
-    static void WifiMgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface);
-    static void IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface);
-    static void SuppEventHandler(net_mgmt_event_callback * cb, uint32_t mgmtEvent, net_if * iface);
+    static void WifiMgmtEventHandler(net_mgmt_event_callback * cb, uint64_t mgmtEvent, net_if * iface);
+    static void IPv6MgmtEventHandler(net_mgmt_event_callback * cb, uint64_t mgmtEvent, net_if * iface);
+    static void SuppEventHandler(net_mgmt_event_callback * cb, uint64_t mgmtEvent, net_if * iface);
     static void ScanResultHandler(Platform::UniquePtr<uint8_t> data, size_t length);
     static void ScanDoneHandler(Platform::UniquePtr<uint8_t> data, size_t length);
     static void ConnectHandler(Platform::UniquePtr<uint8_t> data, size_t length);
@@ -259,7 +259,7 @@ private:
     bool mWiFiPsEnabled{ true };
 
     static const Map<wifi_iface_state, StationStatus, 10> sStatusMap;
-    static const Map<uint32_t, NetEventHandler, 5> sEventHandlerMap;
+    static const Map<uint64_t, NetEventHandler, 5> sEventHandlerMap;
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
The net_mgmt event representation changed from 32-bit to 64-bit value, therefore align with this change.

#### Testing

Tested in NCS CI

NCS PR: nrfconnect/sdk-nrf/pull/22993
