### PR TITLE
[nrf toup] [nrfconnect] Remove redundant multithreding config in mcuboot

### DIFF
--- a/examples/all-clusters-app/nrfconnect/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/examples/all-clusters-app/nrfconnect/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -21,7 +21,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # The following configurations are required to support simultaneous multi image update

--- a/examples/all-clusters-minimal-app/nrfconnect/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/examples/all-clusters-minimal-app/nrfconnect/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -21,7 +21,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # The following configurations are required to support simultaneous multi image update

--- a/examples/light-switch-app/nrfconnect/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/examples/light-switch-app/nrfconnect/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -21,7 +21,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # The following configurations are required to support simultaneous multi image update

--- a/examples/lighting-app/nrfconnect/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/examples/lighting-app/nrfconnect/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -21,7 +21,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # The following configurations are required to support simultaneous multi image update

--- a/examples/lock-app/nrfconnect/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
+++ b/examples/lock-app/nrfconnect/sysbuild/mcuboot/boards/nrf7002dk_nrf5340_cpuapp.conf
@@ -21,7 +21,6 @@ CONFIG_SPI_NOR=y
 CONFIG_SPI_NOR_SFDP_DEVICETREE=y
 CONFIG_SPI_NOR_FLASH_LAYOUT_PAGE_SIZE=4096
 
-CONFIG_MULTITHREADING=y
 CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
 
 # The following configurations are required to support simultaneous multi image update


### PR DESCRIPTION
Remove multithreading configuration from mcuboot where it is not needed. SPI/QSPI drivers do not require multithreading support anymore.

NCS PR: nrfconnect/sdk-nrf/pull/23131
