### PR TITLE
[nrf noup] Added measuring factory reset time

### DIFF
--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -508,6 +508,13 @@ config CHIP_FACTORY_RESET_ERASE_SETTINGS
 	  configuration is supposed to be cleared on a factory reset, including
 	  device-specific entries.
 
+config CHIP_FACTORY_RESET_TIME_MEASUREMENT
+	bool "Measure time of factory reset"
+	help
+	  Enables measuring the time it takes to perform a factory reset. The time
+	  is measured from the moment the factory reset is scheduled until the
+	  device is shutdown. The measured time is printed in the log.
+
 config CHIP_MALLOC_SYS_HEAP
 	bool "Memory allocator based on Zephyr sys_heap"
 	imply SYS_HEAP_RUNTIME_STATS

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -43,6 +43,20 @@ public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
 
+#ifdef CONFIG_CHIP_FACTORY_RESET_TIME_MEASUREMENT
+    void CaptureFactoryResetStartTime() { mFactoryResetStartTime = System::SystemClock().GetMonotonicTimestamp(); }
+
+    System::Clock::Milliseconds64 GetFactoryResetDuration()
+    {
+        System::Clock::Timestamp currentTime = System::SystemClock().GetMonotonicTimestamp();
+        if (currentTime >= mFactoryResetStartTime)
+        {
+            return std::chrono::duration_cast<System::Clock::Milliseconds64>(currentTime - mFactoryResetStartTime);
+        }
+        return System::Clock::Milliseconds64(0);
+    }
+#endif // CONFIG_CHIP_FACTORY_RESET_TIME_MEASUREMENT
+
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 
@@ -72,6 +86,10 @@ private:
     // ===== Private members reserved for use by this class only.
 
     static void DoFactoryReset(intptr_t arg);
+
+#ifdef CONFIG_CHIP_FACTORY_RESET_TIME_MEASUREMENT
+    System::Clock::Timestamp mFactoryResetStartTime;
+#endif // CONFIG_CHIP_FACTORY_RESET_TIME_MEASUREMENT
 };
 
 inline bool ConfigurationManagerImpl::CanFactoryReset()


### PR DESCRIPTION
Added functionality that can be enabled using Kconfig option and allows to measure the time between factory reset schedule and factory reset end to know this process duration.

#### Testing
Tested using automated tests
