### PR TITLE
[nrf toup] Increased packet buffer pool size

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -456,7 +456,7 @@ config CHIP_USE_OPENTHREAD_ENDPOINT
 
 config CHIP_SYSTEM_PACKETBUFFER_POOL_SIZE
   int "Packet buffer pool size"
-  default 11
+  default 15
   help
     Total number of packet buffers allocated by the stack for internal pool.
 


### PR DESCRIPTION
Increased default packet buffer pool size, as it was decreased some time ago and we can observe lack of available buffers in the load tests.

#### Testing
Tested in CI