### PR TITLE
[nrf toup] config: nrfconnect: Update name of OPENTHREAD_SECURITY

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -363,7 +363,7 @@ endif # CHIP_WIFI
 # Crypto configuration
 # ==============================================================================
 
-choice OPENTHREAD_SECURITY
+choice OPENTHREAD_SECURITY_CONFIG
     default OPENTHREAD_NRF_SECURITY_PSA_CHOICE if CHIP_CRYPTO_PSA
     default OPENTHREAD_NRF_SECURITY_CHOICE
     


### PR DESCRIPTION
This upstream Zephyr option got recently renamed to OPENTHREAD_SECURITY_CONFIG.

#### Testing
NCS PR: nrfconnect/sdk-nrf/pull/27726

manifest-pr-skip
