### PR TITLE
[config] Fixed gn parser implementation

### DIFF
--- a/config/common/cmake/make_gn_args.py
+++ b/config/common/cmake/make_gn_args.py
@@ -20,6 +20,17 @@
 import argparse
 import sys
 
+
+class _GnArgs(object):
+    """Parsed GN arguments for write_gn_args()."""
+
+    def __init__(self):
+        self.module = None
+        self.arg = []
+        self.arg_string = []
+        self.arg_cflags = []
+
+
 GN_SPECIAL_SEPARATOR = "+|+"
 GN_CFLAG_EXCLUDES = [
     '-fno-asynchronous-unwind-tables',
@@ -73,13 +84,53 @@ def write_gn_args(args):
             key, "{}-".format(GN_SPECIAL_SEPARATOR).join(filtered_value), GN_SPECIAL_SEPARATOR, cflag_excludes))
 
 
+def parse_args_tmp_file(path):
+    """Parse args.tmp (one token per line).
+
+    argparse treats lines starting with '-' as options when using @file, which
+    breaks when a --arg-cflags value is a single compiler flag.
+    """
+    args = _GnArgs()
+    with open(path, encoding='utf-8') as args_file:
+        lines = [line.rstrip('\n\r') for line in args_file]
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line:
+            i += 1
+            continue
+        if line == '--module':
+            i += 1
+            args.module = lines[i]
+            i += 1
+        elif line == '--arg-cflags':
+            i += 1
+            args.arg_cflags.append([lines[i], lines[i + 1]])
+            i += 2
+        elif line == '--arg-string':
+            i += 1
+            args.arg_string.append([lines[i], lines[i + 1]])
+            i += 2
+        elif line == '--arg':
+            i += 1
+            args.arg.append([lines[i], lines[i + 1]])
+            i += 2
+        else:
+            raise ValueError('Unexpected line in {}: {!r}'.format(path, line))
+    return args
+
+
 def main():
-    parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
-    parser.add_argument('--module', action='store')
-    parser.add_argument('--arg', action='append', nargs=2, default=[])
-    parser.add_argument('--arg-string', action='append', nargs=2, default=[])
-    parser.add_argument('--arg-cflags', action='append', nargs=2, default=[])
-    args = parser.parse_args()
+    if len(sys.argv) == 2 and sys.argv[1].startswith('@'):
+        args = parse_args_tmp_file(sys.argv[1][1:])
+    else:
+        parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
+        parser.add_argument('--module', action='store')
+        parser.add_argument('--arg', action='append', nargs=2, default=[])
+        parser.add_argument('--arg-string', action='append', nargs=2, default=[])
+        parser.add_argument('--arg-cflags', action='append', nargs=2, default=[])
+        args = parser.parse_args()
     write_gn_args(args)
 
 


### PR DESCRIPTION
#### Summary
The make_gn_args.py read args.tmp and uses argparse that treats any line starting with - as an option, not as a positional value for --arg-cflags.

When including only a single -D option, for example in TF-M builds that only export -DTF_PSA_CRYPTO_CONFIG_FILE=... on target_cflags, the parser fails with argument --arg-cflags: expected 2 arguments

#### Testing
Automated testing in CI
