### PR TITLE
[nrf noup] config: Remove nRF70 Wi-Fi FW patch DFU defaults

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -247,14 +247,7 @@ config BOOT_IMAGE_ACCESS_HOOKS
     default y if SOC_SERIES_NRF53
 
 config UPDATEABLE_IMAGE_NUMBER
-    default 3 if NRF_WIFI_PATCHES_EXT_FLASH_STORE
     default 2 if SOC_SERIES_NRF53
-
-config DFU_MULTI_IMAGE_MAX_IMAGE_COUNT
-    default 3 if NRF_WIFI_PATCHES_EXT_FLASH_STORE
-
-config NRF_WIFI_FW_PATCH_DFU
-    default y if NRF_WIFI_PATCHES_EXT_FLASH_STORE
 
 # ==============================================================================
 # OpenThread L2 configuration


### PR DESCRIPTION

#### Summary

The nRF70 Wi-Fi firmware patch DFU feature has been removed from sdk-nrf, including the NRF_WIFI_FW_PATCH_DFU Kconfig option. Remove the default override for it here, which otherwise triggers a "defined without a type" Kconfig error now that the option no longer exists.

Also drop the UPDATEABLE_IMAGE_NUMBER and DFU_MULTI_IMAGE_MAX_IMAGE_COUNT overrides that accounted for the firmware patch as a separate updatable and DFU image, as the patch is no longer an MCUboot image.


#### Testing
Only build

> Add following line to test this PR against different NCS revision:
> NCS PR: nrfconnect/sdk-nrf/pull/<PR ID>
> Use manifest-pr-skip to skip creting the NCS manifest PR automatically

NCS PR: nrfconnect/sdk-nrf/pull/29780
mainfest-pr-skip

Added DNM, as this is mainly to see the tree-wide impact and then might remove or close the PR.
