### PR TITLE
Zephyr upmerge fixes 07.2026

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -140,7 +140,7 @@ config NET_BUF_RX_COUNT
 config NET_BUF_TX_COUNT
     default 16
 
-config NET_SOCKETS_POLL_MAX
+config ZVFS_POLL_MAX
     default 6 if CHIP_WIFI
 
 endif # NETWORKING

--- a/src/platform/nrfconnect/CHIPDevicePlatformConfig.h
+++ b/src/platform/nrfconnect/CHIPDevicePlatformConfig.h
@@ -24,9 +24,9 @@
 #pragma once
 
 #ifndef CONFIG_CHIP_DEVICE_SOFTWARE_VERSION
-#include "app_version.h"
+#include <zephyr/app_version.h>
 #endif
-#include "autoconf.h"
+#include <zephyr/autoconf.h>
 
 // ==================== Platform Adaptations ====================
 


### PR DESCRIPTION
#### Summary

Upmerge fixes

#### Testing

Upmerge CI

NCS PR: nrfconnect/sdk-nrf/pull/30168

manifest-pr-skip
