### PR TITLE
[nrf toup][nrfconnect] remove gone Mbed TLS options

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -411,19 +411,10 @@ endif # CHIP_CRYPTO_PSA
 
 if !CHIP_CRYPTO_PSA
 
-config MBEDTLS_AES_C
-    default y
-
 config MBEDTLS_CTR_DRBG_C
     default y
 
-config MBEDTLS_CIPHER_MODE_CTR
-    default y
-
 config MBEDTLS_MD_C
-    default y
-
-config MBEDTLS_SHA256_C
     default y
 
 config MBEDTLS_PK_C
@@ -439,9 +430,6 @@ config MBEDTLS_X509_CREATE_C
     default y
 
 config MBEDTLS_X509_CSR_WRITE_C
-    default y
-
-config MBEDTLS_ECP_C
     default y
 
 endif # !CHIP_CRYPTO_PSA


### PR DESCRIPTION
Those options have been removed and replaced by PSA_WANT alternatives.

#### Testing

NCS PR: nrfconnect/sdk-nrf/pull/30351

manifest-pr-skip
